### PR TITLE
Add ACE validation for v1.Clusters

### DIFF
--- a/pkg/resources/validation/cluster/cluster.go
+++ b/pkg/resources/validation/cluster/cluster.go
@@ -3,9 +3,8 @@ package cluster
 import (
 	"net/http"
 
-	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	objectsv3 "github.com/rancher/webhook/pkg/generated/objects/management.cattle.io/v3"
 	"github.com/rancher/wrangler/pkg/webhook"
-	admissionv1 "k8s.io/api/admission/v1"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	v1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,7 +22,7 @@ type clusterValidator struct {
 }
 
 func (c *clusterValidator) Admit(response *webhook.Response, request *webhook.Request) error {
-	oldCluster, newCluster, err := clusterObjects(request)
+	oldCluster, newCluster, err := objectsv3.ClusterOldAndNewFromRequest(request)
 	if err != nil {
 		return err
 	}
@@ -73,22 +72,4 @@ func toExtra(extra map[string]authenticationv1.ExtraValue) map[string]v1.ExtraVa
 		result[k] = v1.ExtraValue(v)
 	}
 	return result
-}
-
-func clusterObjects(request *webhook.Request) (*v3.Cluster, *v3.Cluster, error) {
-	object, err := request.DecodeObject()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if request.Operation == admissionv1.Create {
-		return &v3.Cluster{}, object.(*v3.Cluster), nil
-	}
-
-	oldObject, err := request.DecodeOldObject()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return oldObject.(*v3.Cluster), object.(*v3.Cluster), nil
 }

--- a/pkg/resources/validation/cluster/provisioningcluster.go
+++ b/pkg/resources/validation/cluster/provisioningcluster.go
@@ -6,10 +6,10 @@ import (
 
 	v1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	"github.com/rancher/webhook/pkg/auth"
+	objectsv1 "github.com/rancher/webhook/pkg/generated/objects/provisioning.cattle.io/v1"
 	"github.com/rancher/wrangler/pkg/webhook"
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/trace"
 )
 
@@ -22,49 +22,16 @@ type provisioningClusterValidator struct{}
 func (p *provisioningClusterValidator) Admit(response *webhook.Response, request *webhook.Request) error {
 	listTrace := trace.New("provisioningClusterValidator Admit", trace.Field{Key: "user", Value: request.UserInfo.Username})
 	defer listTrace.LogIfLong(2 * time.Second)
-	cluster, err := clusterObject(request)
+	oldCluster, cluster, err := objectsv1.ClusterOldAndNewFromRequest(request)
 	if err != nil {
 		return err
 	}
 
-	if request.Operation == admissionv1.Create {
-		// When creating the cluster the annotation must match the user creating it
-		if cluster.Annotations[auth.CreatorIDAnn] != request.UserInfo.Username {
-			response.Result = &metav1.Status{
-				Status:  "Failure",
-				Message: "creatorID annotation does not match user",
-				Reason:  metav1.StatusReasonInvalid,
-				Code:    http.StatusUnprocessableEntity,
-			}
-			return nil
-		}
-		response.Allowed = true
+	if response.Result = validateCreatorID(request, oldCluster, cluster); response.Result != nil {
 		return nil
 	}
 
-	// Check that the anno doesn't exist on the update object, the only allowed
-	// update to this field is deleting it.
-	if _, ok := cluster.Annotations[auth.CreatorIDAnn]; !ok {
-		response.Allowed = true
-		return nil
-	}
-
-	c, err := request.DecodeOldObject()
-	if err != nil {
-		return err
-	}
-
-	oldCluster := c.(*v1.Cluster)
-
-	// Compare old vs new because they need to be the same, no updates are allowed for
-	// the CreatorIDAnn
-	if oldCluster.GetAnnotations()[auth.CreatorIDAnn] != cluster.GetAnnotations()[auth.CreatorIDAnn] {
-		response.Result = &metav1.Status{
-			Status:  "Failure",
-			Message: "creatorID annotation cannot be changed",
-			Reason:  metav1.StatusReasonInvalid,
-			Code:    http.StatusUnprocessableEntity,
-		}
+	if response.Result = validateACEConfig(cluster); response.Result != nil {
 		return nil
 	}
 
@@ -72,13 +39,47 @@ func (p *provisioningClusterValidator) Admit(response *webhook.Response, request
 	return nil
 }
 
-func clusterObject(request *webhook.Request) (*v1.Cluster, error) {
-	var cluster runtime.Object
-	var err error
-	if request.Operation == admissionv1.Delete {
-		cluster, err = request.DecodeOldObject()
-	} else {
-		cluster, err = request.DecodeObject()
+func validateCreatorID(request *webhook.Request, oldCluster, cluster *v1.Cluster) *metav1.Status {
+	status := &metav1.Status{
+		Status: "Failure",
+		Reason: metav1.StatusReasonInvalid,
+		Code:   http.StatusUnprocessableEntity,
 	}
-	return cluster.(*v1.Cluster), err
+
+	if request.Operation == admissionv1.Create {
+		// When creating the cluster the annotation must match the user creating it
+		if cluster.Annotations[auth.CreatorIDAnn] != request.UserInfo.Username {
+			status.Message = "creatorID annotation does not match user"
+			return status
+		}
+		return nil
+	}
+
+	// Check that the anno doesn't exist on the update object, the only allowed
+	// update to this field is deleting it.
+	if _, ok := cluster.Annotations[auth.CreatorIDAnn]; !ok {
+		return nil
+	}
+
+	// Compare old vs new because they need to be the same, no updates are allowed for
+	// the CreatorIDAnn
+	if oldCluster.GetAnnotations()[auth.CreatorIDAnn] != cluster.GetAnnotations()[auth.CreatorIDAnn] {
+		status.Message = "creatorID annotation cannot be changed"
+		return status
+	}
+
+	return nil
+}
+
+func validateACEConfig(cluster *v1.Cluster) *metav1.Status {
+	if cluster.Spec.RKEConfig.LocalClusterAuthEndpoint.Enabled && cluster.Spec.RKEConfig.LocalClusterAuthEndpoint.CACerts != "" && cluster.Spec.RKEConfig.LocalClusterAuthEndpoint.FQDN == "" {
+		return &metav1.Status{
+			Status:  "Failure",
+			Message: "CACerts defined but FQDN is not defined",
+			Reason:  metav1.StatusReasonInvalid,
+			Code:    http.StatusUnprocessableEntity,
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
When a v1.Cluster is created/updated, the ACE configuration should be
validated. The webhook will respond with an error if a cert is provided
without a FQDN.

Issue:
https://github.com/rancher/rancher/issues/32388