### PR TITLE
Use mutationPath for mutation service config

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -110,7 +110,7 @@ func listenAndServe(ctx context.Context, clients *clients.Clients, handler http.
 			Service: &v1.ServiceReference{
 				Namespace: namespace,
 				Name:      serviceName,
-				Path:      &validationPath,
+				Path:      &mutationPath,
 				Port:      &port,
 			},
 			CABundle: secret.Data[corev1.TLSCertKey],


### PR DESCRIPTION
The validationPath was accidentally used for the mutation service
config. This change alters this to use the mutationPath.