### PR TITLE
Add generation for getting objects from requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 /dist
 *.swp
 .idea
+.vscode
 /webhook

--- a/.golangci.json
+++ b/.golangci.json
@@ -11,6 +11,9 @@
 		]
 	},
 	"run": {
+		"skip-dirs": [
+			"pkg/generated"
+		],
 		"skip-files": [
 			"/zz_generated_"
 		],

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/rancher/rancher/pkg/apis v0.0.0-20210628154046-7a2fc74f9598
 	github.com/rancher/wrangler v0.8.3
 	github.com/sirupsen/logrus v1.8.1
+	golang.org/x/tools v0.1.0
 	k8s.io/api v0.21.0
 	k8s.io/apiextensions-apiserver v0.21.0
 	k8s.io/apimachinery v0.21.0

--- a/main.go
+++ b/main.go
@@ -1,5 +1,5 @@
 //go:generate go run pkg/codegen/cleanup/main.go
-//go:generate go run pkg/codegen/main.go
+//go:generate go run pkg/codegen/main.go pkg/codegen/template.go
 package main
 
 import (

--- a/pkg/codegen/main.go
+++ b/pkg/codegen/main.go
@@ -1,12 +1,24 @@
 package main
 
 import (
+	"bytes"
+	"fmt"
 	"os"
+	"path"
+	"reflect"
+	"strings"
+	"text/template"
 
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	v1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	controllergen "github.com/rancher/wrangler/pkg/controller-gen"
 	"github.com/rancher/wrangler/pkg/controller-gen/args"
+	"golang.org/x/tools/imports"
 )
+
+type typeInfo struct {
+	Name, Type, Package string
+}
 
 func main() {
 	os.Unsetenv("GOPATH")
@@ -23,4 +35,88 @@ func main() {
 			},
 		},
 	})
+
+	// Generate the <TYPE>FromRequest and <TYPE>OldAndNewFromRequest functions to get the new and old objects from the webhook request.
+	if err := generateObjectsFromRequest("pkg/generated/objects", map[string]args.Group{
+		"management.cattle.io": {
+			Types: []interface{}{
+				&v3.Cluster{},
+				&v3.ClusterRoleTemplateBinding{},
+				&v3.FleetWorkspace{},
+				&v3.GlobalRole{},
+				&v3.GlobalRoleBinding{},
+				&v3.RoleTemplate{},
+				&v3.ProjectRoleTemplateBinding{},
+			},
+		},
+		"provisioning.cattle.io": {
+			Types: []interface{}{
+				&v1.Cluster{},
+			},
+		}}); err != nil {
+		fmt.Printf("ERROR: %v\n", err)
+	}
+}
+
+func generateObjectsFromRequest(outputDir string, groups map[string]args.Group) error {
+	temp := template.Must(template.New("objectsFromRequest").Funcs(template.FuncMap{
+		"replace": strings.ReplaceAll,
+	}).Parse(objectsFromRequestTemplate))
+
+	for groupName, group := range groups {
+		var packageName string
+		types := make([]typeInfo, 0, len(group.Types))
+
+		for _, t := range group.Types {
+			rt := reflect.TypeOf(t)
+			ti := typeInfo{
+				Type: rt.String(),
+			}
+			if rt.Kind() == reflect.Ptr {
+				// PkgPath returns an empty string for pointers
+				// Elem returns a Type associated to the dereferenced type.
+				rt = rt.Elem()
+			}
+			ti.Package = rt.PkgPath()
+			ti.Name = rt.Name()
+			packageName = path.Base(ti.Package)
+			types = append(types, ti)
+		}
+
+		groupDir := path.Join(outputDir, groupName, packageName)
+		if err := os.MkdirAll(groupDir, 0755); err != nil {
+			return err
+		}
+
+		data := map[string]interface{}{
+			"types":   types,
+			"package": packageName,
+		}
+
+		var content bytes.Buffer
+		if err := temp.Execute(&content, data); err != nil {
+			return err
+		}
+
+		if err := gofmtAndWriteToFile(path.Join(groupDir, "objects.go"), content.Bytes()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func gofmtAndWriteToFile(path string, content []byte) error {
+	formatted, err := imports.Process(path, content, &imports.Options{FormatOnly: true, Comments: true})
+	if err != nil {
+		return err
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = f.Write(formatted)
+	return err
 }

--- a/pkg/codegen/template.go
+++ b/pkg/codegen/template.go
@@ -1,0 +1,61 @@
+package main
+
+const objectsFromRequestTemplate = `
+package {{ .package }}
+
+import (
+	{{ range .types }}
+	"{{ .Package }}"{{ end }}
+	"github.com/rancher/wrangler/pkg/webhook"
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+{{ range .types }}
+
+// {{ .Name }}OldAndNewFromRequest gets the old and new {{ .Name }} objects, respectively, from the webhook request.
+// If the request is a Delete operation, then the new object is the zero value for {{ .Name }}.
+// Similarly, if the request is a Create operation, then the old object is the zero value for {{ .Name }}.
+func {{ .Name }}OldAndNewFromRequest(request *webhook.Request) ({{ .Type }}, {{ .Type }}, error) {
+	var object runtime.Object
+	var err error
+	if request.Operation != admissionv1.Delete {
+		object, err = request.DecodeObject()
+		if err != nil {
+			return nil, nil, err
+		}
+	} else {
+		object = {{ replace .Type "*" "&" }}{}
+	}
+
+	if request.Operation == admissionv1.Create {
+		return {{ replace .Type "*" "&" }}{}, object.({{ .Type }}), nil
+	}
+
+	oldObject, err := request.DecodeOldObject()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return oldObject.({{ .Type }}), object.({{ .Type }}), nil
+}
+
+// {{ .Name }}FromRequest returns a {{ .Name }} object from the webhook request.
+// If the operation is a Delete operation, then the old object is returned.
+// Otherwise, the new object is returned.
+func {{ .Name }}FromRequest(request *webhook.Request) ({{ .Type }}, error) {
+	var object runtime.Object
+	var err error
+	if request.Operation == admissionv1.Delete {
+		object, err = request.DecodeOldObject()
+	} else {
+		object, err = request.DecodeObject()
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return object.({{ .Type }}), nil
+}
+{{ end }}
+`

--- a/pkg/generated/objects/management.cattle.io/v3/objects.go
+++ b/pkg/generated/objects/management.cattle.io/v3/objects.go
@@ -1,0 +1,330 @@
+package v3
+
+import (
+	"github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/wrangler/pkg/webhook"
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// ClusterOldAndNewFromRequest gets the old and new Cluster objects, respectively, from the webhook request.
+// If the request is a Delete operation, then the new object is the zero value for Cluster.
+// Similarly, if the request is a Create operation, then the old object is the zero value for Cluster.
+func ClusterOldAndNewFromRequest(request *webhook.Request) (*v3.Cluster, *v3.Cluster, error) {
+	var object runtime.Object
+	var err error
+	if request.Operation != admissionv1.Delete {
+		object, err = request.DecodeObject()
+		if err != nil {
+			return nil, nil, err
+		}
+	} else {
+		object = &v3.Cluster{}
+	}
+
+	if request.Operation == admissionv1.Create {
+		return &v3.Cluster{}, object.(*v3.Cluster), nil
+	}
+
+	oldObject, err := request.DecodeOldObject()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return oldObject.(*v3.Cluster), object.(*v3.Cluster), nil
+}
+
+// ClusterFromRequest returns a Cluster object from the webhook request.
+// If the operation is a Delete operation, then the old object is returned.
+// Otherwise, the new object is returned.
+func ClusterFromRequest(request *webhook.Request) (*v3.Cluster, error) {
+	var object runtime.Object
+	var err error
+	if request.Operation == admissionv1.Delete {
+		object, err = request.DecodeOldObject()
+	} else {
+		object, err = request.DecodeObject()
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return object.(*v3.Cluster), nil
+}
+
+// ClusterRoleTemplateBindingOldAndNewFromRequest gets the old and new ClusterRoleTemplateBinding objects, respectively, from the webhook request.
+// If the request is a Delete operation, then the new object is the zero value for ClusterRoleTemplateBinding.
+// Similarly, if the request is a Create operation, then the old object is the zero value for ClusterRoleTemplateBinding.
+func ClusterRoleTemplateBindingOldAndNewFromRequest(request *webhook.Request) (*v3.ClusterRoleTemplateBinding, *v3.ClusterRoleTemplateBinding, error) {
+	var object runtime.Object
+	var err error
+	if request.Operation != admissionv1.Delete {
+		object, err = request.DecodeObject()
+		if err != nil {
+			return nil, nil, err
+		}
+	} else {
+		object = &v3.ClusterRoleTemplateBinding{}
+	}
+
+	if request.Operation == admissionv1.Create {
+		return &v3.ClusterRoleTemplateBinding{}, object.(*v3.ClusterRoleTemplateBinding), nil
+	}
+
+	oldObject, err := request.DecodeOldObject()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return oldObject.(*v3.ClusterRoleTemplateBinding), object.(*v3.ClusterRoleTemplateBinding), nil
+}
+
+// ClusterRoleTemplateBindingFromRequest returns a ClusterRoleTemplateBinding object from the webhook request.
+// If the operation is a Delete operation, then the old object is returned.
+// Otherwise, the new object is returned.
+func ClusterRoleTemplateBindingFromRequest(request *webhook.Request) (*v3.ClusterRoleTemplateBinding, error) {
+	var object runtime.Object
+	var err error
+	if request.Operation == admissionv1.Delete {
+		object, err = request.DecodeOldObject()
+	} else {
+		object, err = request.DecodeObject()
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return object.(*v3.ClusterRoleTemplateBinding), nil
+}
+
+// FleetWorkspaceOldAndNewFromRequest gets the old and new FleetWorkspace objects, respectively, from the webhook request.
+// If the request is a Delete operation, then the new object is the zero value for FleetWorkspace.
+// Similarly, if the request is a Create operation, then the old object is the zero value for FleetWorkspace.
+func FleetWorkspaceOldAndNewFromRequest(request *webhook.Request) (*v3.FleetWorkspace, *v3.FleetWorkspace, error) {
+	var object runtime.Object
+	var err error
+	if request.Operation != admissionv1.Delete {
+		object, err = request.DecodeObject()
+		if err != nil {
+			return nil, nil, err
+		}
+	} else {
+		object = &v3.FleetWorkspace{}
+	}
+
+	if request.Operation == admissionv1.Create {
+		return &v3.FleetWorkspace{}, object.(*v3.FleetWorkspace), nil
+	}
+
+	oldObject, err := request.DecodeOldObject()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return oldObject.(*v3.FleetWorkspace), object.(*v3.FleetWorkspace), nil
+}
+
+// FleetWorkspaceFromRequest returns a FleetWorkspace object from the webhook request.
+// If the operation is a Delete operation, then the old object is returned.
+// Otherwise, the new object is returned.
+func FleetWorkspaceFromRequest(request *webhook.Request) (*v3.FleetWorkspace, error) {
+	var object runtime.Object
+	var err error
+	if request.Operation == admissionv1.Delete {
+		object, err = request.DecodeOldObject()
+	} else {
+		object, err = request.DecodeObject()
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return object.(*v3.FleetWorkspace), nil
+}
+
+// GlobalRoleOldAndNewFromRequest gets the old and new GlobalRole objects, respectively, from the webhook request.
+// If the request is a Delete operation, then the new object is the zero value for GlobalRole.
+// Similarly, if the request is a Create operation, then the old object is the zero value for GlobalRole.
+func GlobalRoleOldAndNewFromRequest(request *webhook.Request) (*v3.GlobalRole, *v3.GlobalRole, error) {
+	var object runtime.Object
+	var err error
+	if request.Operation != admissionv1.Delete {
+		object, err = request.DecodeObject()
+		if err != nil {
+			return nil, nil, err
+		}
+	} else {
+		object = &v3.GlobalRole{}
+	}
+
+	if request.Operation == admissionv1.Create {
+		return &v3.GlobalRole{}, object.(*v3.GlobalRole), nil
+	}
+
+	oldObject, err := request.DecodeOldObject()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return oldObject.(*v3.GlobalRole), object.(*v3.GlobalRole), nil
+}
+
+// GlobalRoleFromRequest returns a GlobalRole object from the webhook request.
+// If the operation is a Delete operation, then the old object is returned.
+// Otherwise, the new object is returned.
+func GlobalRoleFromRequest(request *webhook.Request) (*v3.GlobalRole, error) {
+	var object runtime.Object
+	var err error
+	if request.Operation == admissionv1.Delete {
+		object, err = request.DecodeOldObject()
+	} else {
+		object, err = request.DecodeObject()
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return object.(*v3.GlobalRole), nil
+}
+
+// GlobalRoleBindingOldAndNewFromRequest gets the old and new GlobalRoleBinding objects, respectively, from the webhook request.
+// If the request is a Delete operation, then the new object is the zero value for GlobalRoleBinding.
+// Similarly, if the request is a Create operation, then the old object is the zero value for GlobalRoleBinding.
+func GlobalRoleBindingOldAndNewFromRequest(request *webhook.Request) (*v3.GlobalRoleBinding, *v3.GlobalRoleBinding, error) {
+	var object runtime.Object
+	var err error
+	if request.Operation != admissionv1.Delete {
+		object, err = request.DecodeObject()
+		if err != nil {
+			return nil, nil, err
+		}
+	} else {
+		object = &v3.GlobalRoleBinding{}
+	}
+
+	if request.Operation == admissionv1.Create {
+		return &v3.GlobalRoleBinding{}, object.(*v3.GlobalRoleBinding), nil
+	}
+
+	oldObject, err := request.DecodeOldObject()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return oldObject.(*v3.GlobalRoleBinding), object.(*v3.GlobalRoleBinding), nil
+}
+
+// GlobalRoleBindingFromRequest returns a GlobalRoleBinding object from the webhook request.
+// If the operation is a Delete operation, then the old object is returned.
+// Otherwise, the new object is returned.
+func GlobalRoleBindingFromRequest(request *webhook.Request) (*v3.GlobalRoleBinding, error) {
+	var object runtime.Object
+	var err error
+	if request.Operation == admissionv1.Delete {
+		object, err = request.DecodeOldObject()
+	} else {
+		object, err = request.DecodeObject()
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return object.(*v3.GlobalRoleBinding), nil
+}
+
+// RoleTemplateOldAndNewFromRequest gets the old and new RoleTemplate objects, respectively, from the webhook request.
+// If the request is a Delete operation, then the new object is the zero value for RoleTemplate.
+// Similarly, if the request is a Create operation, then the old object is the zero value for RoleTemplate.
+func RoleTemplateOldAndNewFromRequest(request *webhook.Request) (*v3.RoleTemplate, *v3.RoleTemplate, error) {
+	var object runtime.Object
+	var err error
+	if request.Operation != admissionv1.Delete {
+		object, err = request.DecodeObject()
+		if err != nil {
+			return nil, nil, err
+		}
+	} else {
+		object = &v3.RoleTemplate{}
+	}
+
+	if request.Operation == admissionv1.Create {
+		return &v3.RoleTemplate{}, object.(*v3.RoleTemplate), nil
+	}
+
+	oldObject, err := request.DecodeOldObject()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return oldObject.(*v3.RoleTemplate), object.(*v3.RoleTemplate), nil
+}
+
+// RoleTemplateFromRequest returns a RoleTemplate object from the webhook request.
+// If the operation is a Delete operation, then the old object is returned.
+// Otherwise, the new object is returned.
+func RoleTemplateFromRequest(request *webhook.Request) (*v3.RoleTemplate, error) {
+	var object runtime.Object
+	var err error
+	if request.Operation == admissionv1.Delete {
+		object, err = request.DecodeOldObject()
+	} else {
+		object, err = request.DecodeObject()
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return object.(*v3.RoleTemplate), nil
+}
+
+// ProjectRoleTemplateBindingOldAndNewFromRequest gets the old and new ProjectRoleTemplateBinding objects, respectively, from the webhook request.
+// If the request is a Delete operation, then the new object is the zero value for ProjectRoleTemplateBinding.
+// Similarly, if the request is a Create operation, then the old object is the zero value for ProjectRoleTemplateBinding.
+func ProjectRoleTemplateBindingOldAndNewFromRequest(request *webhook.Request) (*v3.ProjectRoleTemplateBinding, *v3.ProjectRoleTemplateBinding, error) {
+	var object runtime.Object
+	var err error
+	if request.Operation != admissionv1.Delete {
+		object, err = request.DecodeObject()
+		if err != nil {
+			return nil, nil, err
+		}
+	} else {
+		object = &v3.ProjectRoleTemplateBinding{}
+	}
+
+	if request.Operation == admissionv1.Create {
+		return &v3.ProjectRoleTemplateBinding{}, object.(*v3.ProjectRoleTemplateBinding), nil
+	}
+
+	oldObject, err := request.DecodeOldObject()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return oldObject.(*v3.ProjectRoleTemplateBinding), object.(*v3.ProjectRoleTemplateBinding), nil
+}
+
+// ProjectRoleTemplateBindingFromRequest returns a ProjectRoleTemplateBinding object from the webhook request.
+// If the operation is a Delete operation, then the old object is returned.
+// Otherwise, the new object is returned.
+func ProjectRoleTemplateBindingFromRequest(request *webhook.Request) (*v3.ProjectRoleTemplateBinding, error) {
+	var object runtime.Object
+	var err error
+	if request.Operation == admissionv1.Delete {
+		object, err = request.DecodeOldObject()
+	} else {
+		object, err = request.DecodeObject()
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return object.(*v3.ProjectRoleTemplateBinding), nil
+}

--- a/pkg/generated/objects/provisioning.cattle.io/v1/objects.go
+++ b/pkg/generated/objects/provisioning.cattle.io/v1/objects.go
@@ -1,0 +1,54 @@
+package v1
+
+import (
+	"github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	"github.com/rancher/wrangler/pkg/webhook"
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// ClusterOldAndNewFromRequest gets the old and new Cluster objects, respectively, from the webhook request.
+// If the request is a Delete operation, then the new object is the zero value for Cluster.
+// Similarly, if the request is a Create operation, then the old object is the zero value for Cluster.
+func ClusterOldAndNewFromRequest(request *webhook.Request) (*v1.Cluster, *v1.Cluster, error) {
+	var object runtime.Object
+	var err error
+	if request.Operation != admissionv1.Delete {
+		object, err = request.DecodeObject()
+		if err != nil {
+			return nil, nil, err
+		}
+	} else {
+		object = &v1.Cluster{}
+	}
+
+	if request.Operation == admissionv1.Create {
+		return &v1.Cluster{}, object.(*v1.Cluster), nil
+	}
+
+	oldObject, err := request.DecodeOldObject()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return oldObject.(*v1.Cluster), object.(*v1.Cluster), nil
+}
+
+// ClusterFromRequest returns a Cluster object from the webhook request.
+// If the operation is a Delete operation, then the old object is returned.
+// Otherwise, the new object is returned.
+func ClusterFromRequest(request *webhook.Request) (*v1.Cluster, error) {
+	var object runtime.Object
+	var err error
+	if request.Operation == admissionv1.Delete {
+		object, err = request.DecodeOldObject()
+	} else {
+		object, err = request.DecodeObject()
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return object.(*v1.Cluster), nil
+}

--- a/pkg/resources/mutation/cluster/provisioningcluster.go
+++ b/pkg/resources/mutation/cluster/provisioningcluster.go
@@ -3,13 +3,11 @@ package cluster
 import (
 	"time"
 
-	v1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	"github.com/rancher/webhook/pkg/auth"
 	"github.com/rancher/webhook/pkg/clients"
+	objectsv1 "github.com/rancher/webhook/pkg/generated/objects/provisioning.cattle.io/v1"
 	"github.com/rancher/webhook/pkg/patch"
 	"github.com/rancher/wrangler/pkg/webhook"
-	admissionv1 "k8s.io/api/admission/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/trace"
 )
 
@@ -29,7 +27,7 @@ func (m *mutator) Admit(response *webhook.Response, request *webhook.Request) er
 	listTrace := trace.New("provisioningCluster Admit", trace.Field{Key: "user", Value: request.UserInfo.Username})
 	defer listTrace.LogIfLong(2 * time.Second)
 
-	cluster, err := clusterObject(request)
+	cluster, err := objectsv1.ClusterFromRequest(request)
 	if err != nil {
 		return err
 	}
@@ -43,15 +41,4 @@ func (m *mutator) Admit(response *webhook.Response, request *webhook.Request) er
 	newCluster.Annotations[auth.CreatorIDAnn] = request.UserInfo.Username
 
 	return patch.CreatePatch(cluster, newCluster, response)
-}
-
-func clusterObject(request *webhook.Request) (*v1.Cluster, error) {
-	var cluster runtime.Object
-	var err error
-	if request.Operation == admissionv1.Delete {
-		cluster, err = request.DecodeOldObject()
-	} else {
-		cluster, err = request.DecodeObject()
-	}
-	return cluster.(*v1.Cluster), err
 }

--- a/pkg/resources/validation/clusterroletemplatebinding/clusterrtb.go
+++ b/pkg/resources/validation/clusterroletemplatebinding/clusterrtb.go
@@ -3,13 +3,11 @@ package clusterroletemplatebinding
 import (
 	"time"
 
-	rancherv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/webhook/pkg/auth"
 	v3 "github.com/rancher/webhook/pkg/generated/controllers/management.cattle.io/v3"
+	objectsv3 "github.com/rancher/webhook/pkg/generated/objects/management.cattle.io/v3"
 	"github.com/rancher/wrangler/pkg/webhook"
-	admissionv1 "k8s.io/api/admission/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/trace"
 )
 
@@ -29,7 +27,7 @@ func (c *clusterRoleTemplateBindingValidator) Admit(response *webhook.Response, 
 	listTrace := trace.New("clusterRoleTemplateBindingValidator Admit", trace.Field{Key: "user", Value: request.UserInfo.Username})
 	defer listTrace.LogIfLong(2 * time.Second)
 
-	crtb, err := crtbObject(request)
+	crtb, err := objectsv3.ClusterRoleTemplateBindingFromRequest(request)
 	if err != nil {
 		return err
 	}
@@ -54,15 +52,4 @@ func (c *clusterRoleTemplateBindingValidator) Admit(response *webhook.Response, 
 	}
 
 	return c.escalationChecker.ConfirmNoEscalation(response, request, rules, "local")
-}
-
-func crtbObject(request *webhook.Request) (*rancherv3.ClusterRoleTemplateBinding, error) {
-	var crtb runtime.Object
-	var err error
-	if request.Operation == admissionv1.Delete {
-		crtb, err = request.DecodeOldObject()
-	} else {
-		crtb, err = request.DecodeObject()
-	}
-	return crtb.(*rancherv3.ClusterRoleTemplateBinding), err
 }

--- a/pkg/resources/validation/globalrole/globalrole.go
+++ b/pkg/resources/validation/globalrole/globalrole.go
@@ -4,11 +4,9 @@ import (
 	"net/http"
 	"time"
 
-	rancherv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	objectsv3 "github.com/rancher/webhook/pkg/generated/objects/management.cattle.io/v3"
 	"github.com/rancher/wrangler/pkg/webhook"
-	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/trace"
 )
 
@@ -22,7 +20,7 @@ func (grv *globalRoleValidator) Admit(response *webhook.Response, request *webho
 	listTrace := trace.New("globalRoleValidator Admit", trace.Field{Key: "user", Value: request.UserInfo.Username})
 	defer listTrace.LogIfLong(2 * time.Second)
 
-	newGR, err := grObject(request)
+	newGR, err := objectsv3.GlobalRoleFromRequest(request)
 	if err != nil {
 		return err
 	}
@@ -50,15 +48,4 @@ func (grv *globalRoleValidator) Admit(response *webhook.Response, request *webho
 
 	response.Allowed = true
 	return nil
-}
-
-func grObject(request *webhook.Request) (*rancherv3.GlobalRole, error) {
-	var gr runtime.Object
-	var err error
-	if request.Operation == admissionv1.Delete {
-		gr, err = request.DecodeOldObject()
-	} else {
-		gr, err = request.DecodeObject()
-	}
-	return gr.(*rancherv3.GlobalRole), err
 }

--- a/pkg/resources/validation/globalrolebinding/globarolebinding.go
+++ b/pkg/resources/validation/globalrolebinding/globarolebinding.go
@@ -8,12 +8,11 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	rancherv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/webhook/pkg/auth"
 	v3 "github.com/rancher/webhook/pkg/generated/controllers/management.cattle.io/v3"
+	objectsv3 "github.com/rancher/webhook/pkg/generated/objects/management.cattle.io/v3"
 	"github.com/rancher/wrangler/pkg/webhook"
 	admissionv1 "k8s.io/api/admission/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/trace"
 )
 
@@ -33,7 +32,7 @@ func (grbv *globalRoleBindingValidator) Admit(response *webhook.Response, reques
 	listTrace := trace.New("globalRoleBindingValidator Admit", trace.Field{Key: "user", Value: request.UserInfo.Username})
 	defer listTrace.LogIfLong(2 * time.Second)
 
-	newGRB, err := grbObject(request)
+	newGRB, err := objectsv3.GlobalRoleBindingFromRequest(request)
 	if err != nil {
 		return err
 	}
@@ -65,15 +64,4 @@ func (grbv *globalRoleBindingValidator) Admit(response *webhook.Response, reques
 	}
 
 	return grbv.escalationChecker.ConfirmNoEscalation(response, request, globalRole.Rules, "")
-}
-
-func grbObject(request *webhook.Request) (*rancherv3.GlobalRoleBinding, error) {
-	var grb runtime.Object
-	var err error
-	if request.Operation == admissionv1.Delete {
-		grb, err = request.DecodeOldObject()
-	} else {
-		grb, err = request.DecodeObject()
-	}
-	return grb.(*rancherv3.GlobalRoleBinding), err
 }


### PR DESCRIPTION
In order to validate objects, the new and old objects, if they exist,
should be pull from the webhook request. This process is identical for
all objects except that the return types would be different. This is a
candidate for code generation, and this generation is added.