### PR TITLE
add a pre-delete-hook to clean up mutatingwebhookconfigurations

### DIFF
--- a/charts/rancher-webhook/templates/_helpers.tpl
+++ b/charts/rancher-webhook/templates/_helpers.tpl
@@ -5,3 +5,7 @@
 {{- "" -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "rancher-webhook.labels" -}}
+app: rancher-webhook
+{{- end }}

--- a/charts/rancher-webhook/templates/pre-delete-hook-cluster-role-binding.yaml
+++ b/charts/rancher-webhook/templates/pre-delete-hook-cluster-role-binding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.preDelete.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rancher-webhook-pre-delete
+  labels: {{ include "rancher-webhook.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rancher-webhook-pre-delete
+subjects:
+  - kind: ServiceAccount
+    name: rancher-webhook-pre-delete
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/rancher-webhook/templates/pre-delete-hook-cluster-role.yaml
+++ b/charts/rancher-webhook/templates/pre-delete-hook-cluster-role.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.preDelete.enabled }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rancher-webhook-pre-delete
+  labels: {{ include "rancher-webhook.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+rules:
+  - apiGroups: [ "admissionregistration.k8s.io" ]
+    resources: [ "mutatingwebhookconfigurations" ]
+    verbs: [ "delete" ]
+    resourceNames: [ "rancher.cattle.io"]
+{{- end }}

--- a/charts/rancher-webhook/templates/pre-delete-hook-job.yaml
+++ b/charts/rancher-webhook/templates/pre-delete-hook-job.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.preDelete.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rancher-webhook-pre-delete
+  namespace: {{ .Release.Namespace }}
+  labels: {{ include "rancher-webhook.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "3"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      name: rancher-webhook-pre-delete
+      labels: {{ include "rancher-webhook.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: rancher-webhook-pre-delete
+      restartPolicy: OnFailure
+      containers:
+        - name:  rancher-webhook-pre-delete
+          image: "{{ include "system_default_registry" . }}{{ .Values.preDelete.image.repository }}:{{ .Values.preDelete.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          command: ["kubectl", "delete", "mutatingwebhookconfigurations.admissionregistration.k8s.io", "rancher.cattle.io" ]
+{{- end }}

--- a/charts/rancher-webhook/templates/pre-delete-hook-service-account.yaml
+++ b/charts/rancher-webhook/templates/pre-delete-hook-service-account.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.preDelete.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rancher-webhook-pre-delete
+  namespace: {{ .Release.Namespace }}
+  labels: {{ include "rancher-webhook.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+{{- end }}

--- a/charts/rancher-webhook/values.yaml
+++ b/charts/rancher-webhook/values.yaml
@@ -13,3 +13,9 @@ capi:
 
 mcm:
   enabled: true
+
+preDelete:
+  enabled: true
+  image:
+    repository: rancher/kubectl
+    tag: v1.20.2


### PR DESCRIPTION
Issue https://github.com/rancher/rancher/issues/33988

Cause:
When rancher-webhook is uninstalled, it will leave the resource `MutatingWebhookConfiguration` named `rancher.cattle.io`, which prevents us from re-installing Rancher into the cluster. 

Fixes:
We need to fix the rancher-webhook chart such that it will delete the MutatingWebhookConfiguration when the app is uninstalled. 

`Pre-delete-hook` is used here because 
- we can run a `Job` successfully only when either both the `MutatingWebhookConfiguration`  and `Validatingwebhookconfigurations` exist or not
- and because the `MutatingWebhookConfiguration` is not part of the helm chart, so Helm cleans only the 
`Validatingwebhookconfigurations` by itself
- therefore, we have to use the pre-delete-hook to remove both of them before Helm starts deleting other managed resources

Note:
We have another PR in rancher/rancher for adding missing permissions for rancher's post-delete-hook to run the `helm uninstall rancher-webhook` command 


TODO after merging:

- [ ] cut a new tag 
- [ ] update the chart in rancher/charts
- [ ] need [the rancher/rancher PR](https://github.com/rancher/rancher/pull/34144) to be merged 