### PR TITLE
add the missing check in  one of the template

### DIFF
--- a/charts/rancher-webhook/templates/pre-delete-hook-psp.yaml
+++ b/charts/rancher-webhook/templates/pre-delete-hook-psp.yaml
@@ -1,4 +1,4 @@
-
+{{- if .Values.preDelete.enabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -30,3 +30,4 @@ spec:
   readOnlyRootFilesystem: false
   volumes:
     - 'secret'
+{{- end }}


### PR DESCRIPTION
Issue https://github.com/rancher/rancher/issues/34508

add the missing check in one of the templates to match the behavior of other templates for pre-delete-hook
The fix should not affect any functionality of the chart. 


The chart is not used by users directly, and the default setting is to `preDelete.enabled: true`, So no behavior will be changed. 

Update: this fix will be merged for rancher 2.6.1 

TODO:

- [ ] cut a new tag 