### PR TITLE
Validate provisioning cluster names on create

### DIFF
--- a/pkg/resources/validation/cluster/provisioningcluster_test.go
+++ b/pkg/resources/validation/cluster/provisioningcluster_test.go
@@ -1,0 +1,84 @@
+package cluster
+
+import (
+	"testing"
+)
+
+func Test_isValidName(t *testing.T) {
+	tests := []struct {
+		name, clusterName, clusterNamespace string
+		clusterExists                       bool
+		want                                bool
+	}{
+		{
+			name:             "local cluster in fleet-local",
+			clusterName:      "local",
+			clusterNamespace: "fleet-local",
+			clusterExists:    true,
+			want:             true,
+		},
+		{
+			name:             "local cluster in fleet-local, cluster does not exist",
+			clusterName:      "local",
+			clusterNamespace: "fleet-local",
+			clusterExists:    false,
+			want:             true,
+		},
+		{
+			name:             "local cluster not in fleet-local",
+			clusterName:      "local",
+			clusterNamespace: "fleet-default",
+			clusterExists:    true,
+			want:             false,
+		},
+		{
+			name:             "c-xxxxx cluster exists",
+			clusterName:      "c-12345",
+			clusterNamespace: "default",
+			clusterExists:    true,
+			want:             true,
+		},
+		{
+			name:             "c-xxxxx cluster does not exist",
+			clusterName:      "c-xxxxx",
+			clusterNamespace: "fleet-default",
+			clusterExists:    false,
+			want:             false,
+		},
+		{
+			name:             "suffix matches c-xxxxx and cluster exists",
+			clusterName:      "logic-xxxxx",
+			clusterNamespace: "fleet-local",
+			clusterExists:    true,
+			want:             true,
+		},
+		{
+			name:             "prefix matches c-xxxxx and cluster exists",
+			clusterName:      "c-aaaaab",
+			clusterNamespace: "fleet-default",
+			clusterExists:    true,
+			want:             true,
+		},
+		{
+			name:             "substring matches c-xxxxx and cluster exists",
+			clusterName:      "logic-1a3c5bool",
+			clusterNamespace: "cattle-system",
+			clusterExists:    true,
+			want:             true,
+		},
+		{
+			name:             "substring matches c-xxxxx and cluster does not exist",
+			clusterName:      "logic-1a3c5bool",
+			clusterNamespace: "cattle-system",
+			clusterExists:    false,
+			want:             true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isValidName(tt.clusterName, tt.clusterNamespace, tt.clusterExists); got != tt.want {
+				t.Errorf("isValidName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/server/validation.go
+++ b/pkg/server/validation.go
@@ -23,7 +23,7 @@ func Validation(clients *clients.Clients) (http.Handler, error) {
 
 	features := feature.NewValidator()
 	clusters := cluster.NewValidator(clients.K8s.AuthorizationV1().SubjectAccessReviews())
-	provisioningCluster := cluster.NewProvisioningClusterValidator(clients.K8s.AuthorizationV1().SubjectAccessReviews())
+	provisioningCluster := cluster.NewProvisioningClusterValidator(clients)
 
 	router.Kind("Feature").Group(management.GroupName).Type(&v3.Feature{}).Handle(features)
 	router.Kind("Cluster").Group(management.GroupName).Type(&v3.Cluster{}).Handle(clusters)


### PR DESCRIPTION
Users should not be able to create a cluster with name 'local' or of the
form 'c-xxxxx' because this conflicts with logic related to v3.Clusters.
The webhook now checks for such names and denies creates.

Issue:
https://github.com/rancher/rancher/issues/33694