### PR TITLE
Omit rules from webhook configs if mcm is disabled

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/rancher/lasso v0.0.0-20210616224652-fc3ebd901c08
 	github.com/rancher/lasso/controller-runtime v0.0.0-20210616224652-fc3ebd901c08
 	github.com/rancher/rancher/pkg/apis v0.0.0-20210628154046-7a2fc74f9598
-	github.com/rancher/wrangler v0.8.3
+	github.com/rancher/wrangler v0.8.6
 	github.com/sirupsen/logrus v1.8.1
 	golang.org/x/tools v0.1.0
 	k8s.io/api v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -732,8 +732,8 @@ github.com/rancher/wrangler v0.6.2-0.20200820173016-2068de651106/go.mod h1:iKqQc
 github.com/rancher/wrangler v0.6.2-0.20200829053106-7e1dd4260224/go.mod h1:I7qe4DZNMOLKVa9ax7DJdBZ0XtKOppLF/dalhPX3vaE=
 github.com/rancher/wrangler v0.7.3-0.20201020003736-e86bc912dfac/go.mod h1:goezjesEKwMxHLfltdjg9DW0xWV7txQee6vOuSDqXAI=
 github.com/rancher/wrangler v0.8.1-0.20210618171953-ab479ee75244/go.mod h1:aj/stIidTzU6UEKKRB8JyrrqNMJAfDMziL1+zhG8lc0=
-github.com/rancher/wrangler v0.8.3 h1:m3d5ChOQj2Pdozy6nkGiSzAgQxlQlXRis2zSRwaO83k=
-github.com/rancher/wrangler v0.8.3/go.mod h1:dKEaHNB4izxmPUtpq1Hvr3z3Oh+9k5pCZyFO9sUhlaY=
+github.com/rancher/wrangler v0.8.6 h1:z0PYRySnwEEPtybjSdcUbHlgznIuxQpseVP7OEsKOb0=
+github.com/rancher/wrangler v0.8.6/go.mod h1:dKEaHNB4izxmPUtpq1Hvr3z3Oh+9k5pCZyFO9sUhlaY=
 github.com/rancher/wrangler-api v0.6.1-0.20200427172631-a7c2f09b783e/go.mod h1:2lcWR98q8HU3U4mVETnXc8quNG0uXxrt8vKd6cAa/30=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=

--- a/pkg/server/rules.go
+++ b/pkg/server/rules.go
@@ -1,0 +1,162 @@
+package server
+
+import v1 "k8s.io/api/admissionregistration/v1"
+
+var rancherRules = []v1.RuleWithOperations{
+	{
+		Operations: []v1.OperationType{
+			v1.Create,
+			v1.Update,
+		},
+		Rule: v1.Rule{
+			APIGroups:   []string{"management.cattle.io"},
+			APIVersions: []string{"v3"},
+			Resources:   []string{"clusters"},
+			Scope:       &clusterScope,
+		},
+	},
+	{
+		Operations: []v1.OperationType{
+			v1.Update,
+		},
+		Rule: v1.Rule{
+			APIGroups:   []string{"management.cattle.io"},
+			APIVersions: []string{"v3"},
+			Resources:   []string{"features"},
+			Scope:       &clusterScope,
+		},
+	},
+}
+
+var rancherAuthBaseRules = []v1.RuleWithOperations{
+	{
+		Operations: []v1.OperationType{
+			v1.Create,
+			v1.Update,
+		},
+		Rule: v1.Rule{
+			APIGroups:   []string{"provisioning.cattle.io"},
+			APIVersions: []string{"v1"},
+			Resources:   []string{"clusters"},
+			Scope:       &namespaceScope,
+		},
+	},
+}
+
+var rancherAuthMCMRules = []v1.RuleWithOperations{
+	{
+		Operations: []v1.OperationType{
+			v1.Create,
+			v1.Update,
+			v1.Delete,
+		},
+		Rule: v1.Rule{
+			APIGroups:   []string{"management.cattle.io"},
+			APIVersions: []string{"v3"},
+			Resources:   []string{"globalrolebindings"},
+			Scope:       &clusterScope,
+		},
+	},
+	{
+		Operations: []v1.OperationType{
+			v1.Create,
+			v1.Update,
+		},
+		Rule: v1.Rule{
+			APIGroups:   []string{"management.cattle.io"},
+			APIVersions: []string{"v3"},
+			Resources:   []string{"roletemplates"},
+			Scope:       &clusterScope,
+		},
+	},
+	{
+		Operations: []v1.OperationType{
+			v1.Create,
+			v1.Update,
+		},
+		Rule: v1.Rule{
+			APIGroups:   []string{"management.cattle.io"},
+			APIVersions: []string{"v3"},
+			Resources:   []string{"projectroletemplatebindings"},
+			Scope:       &namespaceScope,
+		},
+	},
+	{
+		Operations: []v1.OperationType{
+			v1.Create,
+			v1.Update,
+		},
+		Rule: v1.Rule{
+			APIGroups:   []string{"management.cattle.io"},
+			APIVersions: []string{"v3"},
+			Resources:   []string{"clusterroletemplatebindings"},
+			Scope:       &namespaceScope,
+		},
+	},
+	{
+		Operations: []v1.OperationType{
+			v1.Create,
+			v1.Update,
+		},
+		Rule: v1.Rule{
+			APIGroups:   []string{"management.cattle.io"},
+			APIVersions: []string{"v3"},
+			Resources:   []string{"globalroles"},
+			Scope:       &clusterScope,
+		},
+	},
+}
+
+var fleetMutationRules = []v1.RuleWithOperations{
+	{
+		Operations: []v1.OperationType{
+			v1.Create,
+		},
+		Rule: v1.Rule{
+			APIGroups:   []string{"management.cattle.io"},
+			APIVersions: []string{"v3"},
+			Resources:   []string{"fleetworkspaces"},
+			Scope:       &clusterScope,
+		},
+	},
+}
+
+var rancherMutationRules = []v1.RuleWithOperations{
+	{
+		Operations: []v1.OperationType{
+			v1.Create,
+		},
+		Rule: v1.Rule{
+			APIGroups:   []string{"provisioning.cattle.io"},
+			APIVersions: []string{"v1"},
+			Resources:   []string{"clusters"},
+			Scope:       &namespaceScope,
+		},
+	},
+	{
+		Operations: []v1.OperationType{
+			v1.Create,
+		},
+		Rule: v1.Rule{
+			APIGroups:   []string{""},
+			APIVersions: []string{"v1"},
+			Resources:   []string{"secrets"},
+			Scope:       &namespaceScope,
+		},
+	},
+}
+
+var rancherAuthMutationRules = []v1.RuleWithOperations{
+	{
+		Operations: []v1.OperationType{
+			v1.Create,
+			v1.Update,
+		},
+		Rule: v1.Rule{
+			APIGroups:   []string{"management.cattle.io"},
+			APIVersions: []string{"v3"},
+			Resources:   []string{"globalrolebindings"},
+			Scope:       &clusterScope,
+		},
+	},
+}

--- a/pkg/server/validation.go
+++ b/pkg/server/validation.go
@@ -19,11 +19,15 @@ import (
 )
 
 func Validation(clients *clients.Clients) (http.Handler, error) {
-	clusters := cluster.NewValidator(clients.K8s.AuthorizationV1().SubjectAccessReviews())
-	features := feature.NewValidator()
 	router := webhook.NewRouter()
-	router.Kind("Cluster").Group(management.GroupName).Type(&v3.Cluster{}).Handle(clusters)
+
+	features := feature.NewValidator()
+	clusters := cluster.NewValidator(clients.K8s.AuthorizationV1().SubjectAccessReviews())
+	provisioningCluster := cluster.NewProvisioningClusterValidator(clients.K8s.AuthorizationV1().SubjectAccessReviews())
+
 	router.Kind("Feature").Group(management.GroupName).Type(&v3.Feature{}).Handle(features)
+	router.Kind("Cluster").Group(management.GroupName).Type(&v3.Cluster{}).Handle(clusters)
+	router.Kind("Cluster").Group(provisioning.GroupName).Type(&v1.Cluster{}).Handle(provisioningCluster)
 
 	if clients.MultiClusterManagement {
 		globalRoleBindings := globalrolebinding.NewValidator(clients.Management.GlobalRole().Cache(), clients.EscalationChecker)
@@ -31,14 +35,12 @@ func Validation(clients *clients.Clients) (http.Handler, error) {
 		prtbs := projectroletemplatebinding.NewValidator(clients.Management.RoleTemplate().Cache(), clients.EscalationChecker)
 		crtbs := clusterroletemplatebinding.NewValidator(clients.Management.RoleTemplate().Cache(), clients.EscalationChecker)
 		roleTemplates := roletemplate.NewValidator(clients.EscalationChecker)
-		provisioningCluster := cluster.NewProvisioningClusterValidator(clients.K8s.AuthorizationV1().SubjectAccessReviews())
 
 		router.Kind("RoleTemplate").Group(management.GroupName).Type(&v3.RoleTemplate{}).Handle(roleTemplates)
 		router.Kind("GlobalRoleBinding").Group(management.GroupName).Type(&v3.GlobalRoleBinding{}).Handle(globalRoleBindings)
 		router.Kind("GlobalRole").Group(management.GroupName).Type(&v3.GlobalRole{}).Handle(globalRoles)
 		router.Kind("ClusterRoleTemplateBinding").Group(management.GroupName).Type(&v3.ClusterRoleTemplateBinding{}).Handle(crtbs)
 		router.Kind("ProjectRoleTemplateBinding").Group(management.GroupName).Type(&v3.ProjectRoleTemplateBinding{}).Handle(prtbs)
-		router.Kind("Cluster").Group(provisioning.GroupName).Type(&v1.Cluster{}).Handle(provisioningCluster)
 	}
 
 	return router, nil


### PR DESCRIPTION
Issue: 
- https://github.com/rancher/rancher/issues/34691

When MCM is disabled we are not mounting RBAC resource validation routes in the webhook. This needs to also be reflected in the webhook configurations. As part of this I moved the rules out of the server.go file