### PR TITLE
Remove mutation webhook config for global role bindings

### DIFF
--- a/pkg/server/rules.go
+++ b/pkg/server/rules.go
@@ -145,18 +145,3 @@ var rancherMutationRules = []v1.RuleWithOperations{
 		},
 	},
 }
-
-var rancherAuthMutationRules = []v1.RuleWithOperations{
-	{
-		Operations: []v1.OperationType{
-			v1.Create,
-			v1.Update,
-		},
-		Rule: v1.Rule{
-			APIGroups:   []string{"management.cattle.io"},
-			APIVersions: []string{"v3"},
-			Resources:   []string{"globalrolebindings"},
-			Scope:       &clusterScope,
-		},
-	},
-}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -164,14 +164,6 @@ func listenAndServe(ctx context.Context, clients *clients.Clients, handler http.
 					SideEffects:             &sideEffectClassNoneOnDryRun,
 					AdmissionReviewVersions: []string{"v1", "v1beta1"},
 				},
-				{
-					Name:                    "rancherauth.cattle.io",
-					ClientConfig:            mutationClientConfig,
-					Rules:                   rancherAuthMutationRules,
-					FailurePolicy:           &failPolicyFail,
-					SideEffects:             &sideEffectClassNoneOnDryRun,
-					AdmissionReviewVersions: []string{"v1", "v1beta1"},
-				},
 			},
 		})
 	})


### PR DESCRIPTION
A previous change mistakenly added a mutation webhook configuration for
global role bindings. This change removes this configuration because
there are no such webhooks.