### PR TITLE
[2.5] add the annotation for setting the range of supported rancher version 

### DIFF
--- a/charts/rancher-webhook/Chart.yaml
+++ b/charts/rancher-webhook/Chart.yaml
@@ -9,3 +9,4 @@ annotations:
   catalog.cattle.io/namespace: cattle-system
   catalog.cattle.io/release-name: rancher-webhook
   catalog.cattle.io/os: linux
+  catalog.cattle.io/rancher-version: '>= 2.5.10-0 <2.5.99-0'


### PR DESCRIPTION
`>= 2.5.10-0` since the post-delete-hook needs rancher 2.5.10 and above