### PR TITLE
Disallow disabling RKE2 feature if RKE2 clusters exist

### DIFF
--- a/pkg/resources/validation/feature/feature.go
+++ b/pkg/resources/validation/feature/feature.go
@@ -5,10 +5,16 @@ import (
 	"net/http"
 	"time"
 
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	objectsv3 "github.com/rancher/webhook/pkg/generated/objects/management.cattle.io/v3"
 	"github.com/rancher/wrangler/pkg/webhook"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/trace"
+)
+
+const (
+	RKE2ClustersExistAnn = "provisioning.cattle.io/rke2-clusters-exist"
+	RKE2FeatureName      = "rke2"
 )
 
 func NewValidator() webhook.Handler {
@@ -30,6 +36,17 @@ func (fv *featureValidator) Admit(response *webhook.Response, request *webhook.R
 		response.Result = &metav1.Status{
 			Status:  "Failure",
 			Message: fmt.Sprintf("feature flag cannot be changed from current value: %v", *newFeature.Status.LockedValue),
+			Reason:  metav1.StatusReasonInvalid,
+			Code:    http.StatusBadRequest,
+		}
+		response.Allowed = false
+		return nil
+	}
+
+	if !validateRKE2FeatureFlag(newFeature, oldFeature) {
+		response.Result = &metav1.Status{
+			Status:  "Failure",
+			Message: "RKE2 flag cannot be disabled until all RKE2 provisioned clusters are deleted",
 			Reason:  metav1.StatusReasonInvalid,
 			Code:    http.StatusBadRequest,
 		}
@@ -61,4 +78,11 @@ func isValidFeatureValue(lockedValue *bool, oldSpecValue *bool, desiredSpecValue
 	}
 
 	return false
+}
+
+func validateRKE2FeatureFlag(newFeature, oldFeature *v3.Feature) bool {
+	if oldFeature.Spec.Value == nil && newFeature.Spec.Value == nil || *newFeature.Spec.Value == *oldFeature.Spec.Value {
+		return true
+	}
+	return newFeature.Name != RKE2FeatureName || oldFeature.Annotations[RKE2ClustersExistAnn] != "true" || newFeature.Spec.Value == nil || *newFeature.Spec.Value
 }


### PR DESCRIPTION
Users should not be allowed to disable RKE2 feature flag if RKE2
provisioned clusters exist. When Rancher provisions an RKE2 cluster, an
annotation will be put on the RKE2 feature. If this annotation exists,
then changing the value of the RKE2 feature flag will not be allowed.

Issue:
https://github.com/rancher/rancher/issues/35179