### PR TITLE
Set certificate expiration to 10 years by default

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ replace (
 
 require (
 	github.com/gorilla/mux v1.8.0
-	github.com/rancher/dynamiclistener v0.2.1-0.20201110045217-9b1b7d3132e8
+	github.com/rancher/dynamiclistener v0.3.1-0.20211119182849-962b63526960
 	github.com/rancher/lasso v0.0.0-20210709145333-6c6cd7fd6607
 	github.com/rancher/lasso/controller-runtime v0.0.0-20210608205930-775fcaf2f523
 	github.com/rancher/rancher/pkg/apis v0.0.0-20210628154046-7a2fc74f9598

--- a/go.sum
+++ b/go.sum
@@ -774,8 +774,8 @@ github.com/rancher/aks-operator v1.0.1-rc11 h1:OGxwaQ+MmqTNl/45wfS0PuI78mvo/FXfB
 github.com/rancher/aks-operator v1.0.1-rc11/go.mod h1:V43rw+oKpjQ2tlIITgejlatpNBGi61DdB+RldJyrh/8=
 github.com/rancher/client-go v1.22.3-rancher.1 h1:aNVLaIY5YGah1i9wRVXLOGRbLyekohjQAKHXeQm6Cxo=
 github.com/rancher/client-go v1.22.3-rancher.1/go.mod h1:ElDjYf8gvZsKDYexmsmnMQ0DYO8W9RwBjfQ1PI53yow=
-github.com/rancher/dynamiclistener v0.2.1-0.20201110045217-9b1b7d3132e8 h1:B4dt8sHPyt+hzYzFoWtKWTppls0KzSu2jEIV2jyY4sY=
-github.com/rancher/dynamiclistener v0.2.1-0.20201110045217-9b1b7d3132e8/go.mod h1:qr0QfhwzcVCR+Ao9WyfnE+jmOpfEAdRhXtNOZGJ3nCQ=
+github.com/rancher/dynamiclistener v0.3.1-0.20211119182849-962b63526960 h1:ahE9XbsyFzWteQB5etFl9OacXzVGtm0XJe1tHoOtC+4=
+github.com/rancher/dynamiclistener v0.3.1-0.20211119182849-962b63526960/go.mod h1:xbxyiF1/UaPrOrFUOZeYMQW82RPgZIe5UfiT9CyE3Ks=
 github.com/rancher/eks-operator v1.1.1-rc3 h1:I52WG985NvawYW7mKTlv1SpeucOkYtk8nathPiqtItU=
 github.com/rancher/eks-operator v1.1.1-rc3/go.mod h1:hoVQqXsC02Yk3Xy5jGH/rqJX5KUVvvQBrYAJdRh+kgQ=
 github.com/rancher/fleet/pkg/apis v0.0.0-20210608014113-99e848822739 h1:EjFWJZH42LoYCRV56ZPNzaiIPO6cfFDP7+LlyY3b20Y=
@@ -805,10 +805,10 @@ github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210424054953-634d
 github.com/rancher/wrangler v0.6.1/go.mod h1:L4HtjPeX8iqLgsxfJgz+JjKMcX2q3qbRXSeTlC/CSd4=
 github.com/rancher/wrangler v0.6.2-0.20200427172034-da9b142ae061/go.mod h1:n5Du/gGD7WoiqnEo0SHnPirDIp1V9Zu+6guc8lXS2dk=
 github.com/rancher/wrangler v0.6.2-0.20200515155908-1923f3f8ec3f/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
-github.com/rancher/wrangler v0.6.2-0.20200714200521-c61fae623942/go.mod h1:8LdIqAQPHysxNlHqmKbUiDIx9ULt9IHUauh9aOnr67k=
 github.com/rancher/wrangler v0.6.2-0.20200820173016-2068de651106/go.mod h1:iKqQcYs4YSDjsme52OZtQU4jHPmLlIiM93aj2c8c/W8=
 github.com/rancher/wrangler v0.6.2-0.20200829053106-7e1dd4260224/go.mod h1:I7qe4DZNMOLKVa9ax7DJdBZ0XtKOppLF/dalhPX3vaE=
 github.com/rancher/wrangler v0.7.3-0.20201020003736-e86bc912dfac/go.mod h1:goezjesEKwMxHLfltdjg9DW0xWV7txQee6vOuSDqXAI=
+github.com/rancher/wrangler v0.8.0/go.mod h1:zSV5oh3+YZboilwcJmFHO3J6FZba82BTQft1b6ijx2I=
 github.com/rancher/wrangler v0.8.1-0.20210618171953-ab479ee75244/go.mod h1:aj/stIidTzU6UEKKRB8JyrrqNMJAfDMziL1+zhG8lc0=
 github.com/rancher/wrangler v0.8.7 h1:WN9EWycceZ9gP5hEqIRJMrwi7cprxETMyKk/qXl+9ZU=
 github.com/rancher/wrangler v0.8.7/go.mod h1:dKEaHNB4izxmPUtpq1Hvr3z3Oh+9k5pCZyFO9sUhlaY=


### PR DESCRIPTION
Tested using a modified version of `./scripts/build` and `k3d`:
```bash
#!/bin/bash
set -e

if kubectl get ns cattle-system; then
    kubectl delete ns cattle-system
fi
source $(dirname $0)/version
cd $(dirname $0)/..

mkdir -p bin
LINKFLAGS="-X github.com/rancher/webhook.Version=$VERSION"
LINKFLAGS="-X github.com/rancher/webhook.GitCommit=$COMMIT $LINKFLAGS"
GOOS=darwin go build -ldflags "$LINKFLAGS" -o bin/webhook

kubectl create ns cattle-system
./bin/webhook
```

End date is expected value:
```bash
% k get secrets -n cattle-system cattle-webhook-tls -o json | jq -r ".data.\"tls.crt\"" | base64 -d | openssl x509 -enddate
notAfter=Nov 17 19:20:28 2031 GMT
```

Relevant issue: https://github.com/rancher/rancher/issues/35366