### PR TITLE
Add mutation/validation webhooks for rke-machine-configs

### DIFF
--- a/pkg/codegen/main.go
+++ b/pkg/codegen/main.go
@@ -14,6 +14,7 @@ import (
 	controllergen "github.com/rancher/wrangler/pkg/controller-gen"
 	"github.com/rancher/wrangler/pkg/controller-gen/args"
 	"golang.org/x/tools/imports"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 type typeInfo struct {
@@ -53,6 +54,11 @@ func main() {
 		"provisioning.cattle.io": {
 			Types: []interface{}{
 				&v1.Cluster{},
+			},
+		},
+		"core": {
+			Types: []interface{}{
+				&unstructured.Unstructured{},
 			},
 		}}); err != nil {
 		fmt.Printf("ERROR: %v\n", err)

--- a/pkg/generated/objects/core/unstructured/objects.go
+++ b/pkg/generated/objects/core/unstructured/objects.go
@@ -1,0 +1,54 @@
+package unstructured
+
+import (
+	"github.com/rancher/wrangler/pkg/webhook"
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// UnstructuredOldAndNewFromRequest gets the old and new Unstructured objects, respectively, from the webhook request.
+// If the request is a Delete operation, then the new object is the zero value for Unstructured.
+// Similarly, if the request is a Create operation, then the old object is the zero value for Unstructured.
+func UnstructuredOldAndNewFromRequest(request *webhook.Request) (*unstructured.Unstructured, *unstructured.Unstructured, error) {
+	var object runtime.Object
+	var err error
+	if request.Operation != admissionv1.Delete {
+		object, err = request.DecodeObject()
+		if err != nil {
+			return nil, nil, err
+		}
+	} else {
+		object = &unstructured.Unstructured{}
+	}
+
+	if request.Operation == admissionv1.Create {
+		return &unstructured.Unstructured{}, object.(*unstructured.Unstructured), nil
+	}
+
+	oldObject, err := request.DecodeOldObject()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return oldObject.(*unstructured.Unstructured), object.(*unstructured.Unstructured), nil
+}
+
+// UnstructuredFromRequest returns a Unstructured object from the webhook request.
+// If the operation is a Delete operation, then the old object is returned.
+// Otherwise, the new object is returned.
+func UnstructuredFromRequest(request *webhook.Request) (*unstructured.Unstructured, error) {
+	var object runtime.Object
+	var err error
+	if request.Operation == admissionv1.Delete {
+		object, err = request.DecodeOldObject()
+	} else {
+		object, err = request.DecodeObject()
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return object.(*unstructured.Unstructured), nil
+}

--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -4,13 +4,12 @@ import (
 	"encoding/json"
 
 	"github.com/rancher/wrangler/pkg/webhook"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 // CreatePatch accepts an old and a new object and creates a patch of the differences as
 // specified in http://jsonpatch.com/ and updates the response accordingly.
-func CreatePatch(old runtime.Object, new runtime.Object, response *webhook.Response) error {
+func CreatePatch(old, new interface{}, response *webhook.Response) error {
 	oldJSON, err := json.Marshal(old)
 	if err != nil {
 		return err

--- a/pkg/resources/mutation/machineconfigs/machineconfigs.go
+++ b/pkg/resources/mutation/machineconfigs/machineconfigs.go
@@ -1,9 +1,9 @@
-package cluster
+package machineconfigs
 
 import (
 	"time"
 
-	objectsv1 "github.com/rancher/webhook/pkg/generated/objects/provisioning.cattle.io/v1"
+	"github.com/rancher/webhook/pkg/generated/objects/core/unstructured"
 	"github.com/rancher/webhook/pkg/resources/mutation"
 	"github.com/rancher/wrangler/pkg/webhook"
 	"k8s.io/utils/trace"
@@ -22,13 +22,13 @@ func (m *mutator) Admit(response *webhook.Response, request *webhook.Request) er
 		return nil
 	}
 
-	listTrace := trace.New("provisioningCluster Admit", trace.Field{Key: "user", Value: request.UserInfo.Username})
+	listTrace := trace.New("machine config Admit", trace.Field{Key: "user", Value: request.UserInfo.Username})
 	defer listTrace.LogIfLong(2 * time.Second)
 
-	cluster, err := objectsv1.ClusterFromRequest(request)
+	config, err := unstructured.UnstructuredFromRequest(request)
 	if err != nil {
 		return err
 	}
 
-	return mutation.SetCreatorIDAnnotation(request, response, cluster, cluster.DeepCopy())
+	return mutation.SetCreatorIDAnnotation(request, response, config, config.DeepCopy())
 }

--- a/pkg/resources/mutation/mutation.go
+++ b/pkg/resources/mutation/mutation.go
@@ -1,0 +1,20 @@
+package mutation
+
+import (
+	"github.com/rancher/webhook/pkg/auth"
+	"github.com/rancher/webhook/pkg/patch"
+	"github.com/rancher/wrangler/pkg/webhook"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func SetCreatorIDAnnotation(request *webhook.Request, response *webhook.Response, obj runtime.Object, newObj metav1.Object) error {
+	annotations := newObj.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[auth.CreatorIDAnn] = request.UserInfo.Username
+	newObj.SetAnnotations(annotations)
+
+	return patch.CreatePatch(obj, newObj, response)
+}

--- a/pkg/resources/mutation/secret/secret.go
+++ b/pkg/resources/mutation/secret/secret.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/rancher/webhook/pkg/auth"
-	"github.com/rancher/webhook/pkg/clients"
 	"github.com/rancher/webhook/pkg/patch"
 	"github.com/rancher/wrangler/pkg/webhook"
 	"github.com/sirupsen/logrus"
@@ -14,7 +13,7 @@ import (
 	"k8s.io/utils/trace"
 )
 
-func NewMutator(client *clients.Clients) webhook.Handler {
+func NewMutator() webhook.Handler {
 	return &mutator{}
 }
 

--- a/pkg/resources/validation/machineconfig/machineconfig.go
+++ b/pkg/resources/validation/machineconfig/machineconfig.go
@@ -1,0 +1,34 @@
+package machineconfig
+
+import (
+	"time"
+
+	"github.com/rancher/webhook/pkg/generated/objects/core/unstructured"
+	"github.com/rancher/webhook/pkg/resources/validation"
+	"github.com/rancher/wrangler/pkg/webhook"
+	"k8s.io/utils/trace"
+)
+
+func NewMachineConfigValidator() webhook.Handler {
+	return &machineConfigValidator{}
+}
+
+type machineConfigValidator struct {
+}
+
+func (p *machineConfigValidator) Admit(response *webhook.Response, request *webhook.Request) error {
+	listTrace := trace.New("machineConfigValidator Admit", trace.Field{Key: "user", Value: request.UserInfo.Username})
+	defer listTrace.LogIfLong(2 * time.Second)
+
+	oldUnstrConfig, unstrConfig, err := unstructured.UnstructuredOldAndNewFromRequest(request)
+	if err != nil {
+		return err
+	}
+
+	if response.Result = validation.CheckCreatorID(request, oldUnstrConfig, unstrConfig); response.Result != nil {
+		return nil
+	}
+
+	response.Allowed = true
+	return nil
+}

--- a/pkg/resources/validation/validation.go
+++ b/pkg/resources/validation/validation.go
@@ -1,0 +1,43 @@
+package validation
+
+import (
+	"net/http"
+
+	"github.com/rancher/webhook/pkg/auth"
+	"github.com/rancher/wrangler/pkg/webhook"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func CheckCreatorID(request *webhook.Request, oldObj, newObj metav1.Object) *metav1.Status {
+	status := &metav1.Status{
+		Status: "Failure",
+		Reason: metav1.StatusReasonInvalid,
+		Code:   http.StatusUnprocessableEntity,
+	}
+
+	newAnnotations := newObj.GetAnnotations()
+	if request.Operation == admissionv1.Create {
+		// When creating the newObj the annotation must match the user creating it
+		if newAnnotations[auth.CreatorIDAnn] != request.UserInfo.Username {
+			status.Message = "creatorID annotation does not match user"
+			return status
+		}
+		return nil
+	}
+
+	// Check that the anno doesn't exist on the update object, the only allowed
+	// update to this field is deleting it.
+	if _, ok := newAnnotations[auth.CreatorIDAnn]; !ok {
+		return nil
+	}
+
+	// Compare old vs new because they need to be the same, no updates are allowed for
+	// the CreatorIDAnn
+	if oldObj.GetAnnotations()[auth.CreatorIDAnn] != newAnnotations[auth.CreatorIDAnn] {
+		status.Message = "creatorID annotation cannot be changed"
+		return status
+	}
+
+	return nil
+}

--- a/pkg/server/mutation.go
+++ b/pkg/server/mutation.go
@@ -10,19 +10,18 @@ import (
 	"github.com/rancher/webhook/pkg/clients"
 	"github.com/rancher/webhook/pkg/resources/mutation/cluster"
 	"github.com/rancher/webhook/pkg/resources/mutation/fleetworkspace"
+	"github.com/rancher/webhook/pkg/resources/mutation/machineconfigs"
 	"github.com/rancher/webhook/pkg/resources/mutation/secret"
 	"github.com/rancher/wrangler/pkg/webhook"
 	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func Mutation(client *clients.Clients) (http.Handler, error) {
-	fleetworkspaceMutator := fleetworkspace.NewMutator(client)
-	provisioningCluster := cluster.NewMutator(client)
-	secret := secret.NewMutator(client)
-
 	router := webhook.NewRouter()
-	router.Kind("FleetWorkspace").Group(management.GroupName).Type(&v3.FleetWorkspace{}).Handle(fleetworkspaceMutator)
-	router.Kind("Cluster").Group(provisioning.GroupName).Type(&v1.Cluster{}).Handle(provisioningCluster)
-	router.Kind("Secret").Group("").Type(&k8sv1.Secret{}).Handle(secret)
+	router.Kind("FleetWorkspace").Group(management.GroupName).Type(&v3.FleetWorkspace{}).Handle(fleetworkspace.NewMutator(client))
+	router.Kind("Cluster").Group(provisioning.GroupName).Type(&v1.Cluster{}).Handle(cluster.NewMutator())
+	router.Kind("Secret").Type(&k8sv1.Secret{}).Handle(secret.NewMutator())
+	router.Group("rke-machine-config.cattle.io").Type(&unstructured.Unstructured{}).Handle(machineconfigs.NewMutator())
 	return router, nil
 }

--- a/pkg/server/rules.go
+++ b/pkg/server/rules.go
@@ -41,6 +41,18 @@ var rancherAuthBaseRules = []v1.RuleWithOperations{
 			Scope:       &namespaceScope,
 		},
 	},
+	{
+		Operations: []v1.OperationType{
+			v1.Create,
+			v1.Update,
+		},
+		Rule: v1.Rule{
+			APIGroups:   []string{"rke-machine-config.cattle.io"},
+			APIVersions: []string{"v1"},
+			Resources:   []string{"*"},
+			Scope:       &namespaceScope,
+		},
+	},
 }
 
 var rancherAuthMCMRules = []v1.RuleWithOperations{
@@ -130,6 +142,17 @@ var rancherMutationRules = []v1.RuleWithOperations{
 			APIGroups:   []string{"provisioning.cattle.io"},
 			APIVersions: []string{"v1"},
 			Resources:   []string{"clusters"},
+			Scope:       &namespaceScope,
+		},
+	},
+	{
+		Operations: []v1.OperationType{
+			v1.Create,
+		},
+		Rule: v1.Rule{
+			APIGroups:   []string{"rke-machine-config.cattle.io"},
+			APIVersions: []string{"v1"},
+			Resources:   []string{"*"},
 			Scope:       &namespaceScope,
 		},
 	},

--- a/pkg/server/validation.go
+++ b/pkg/server/validation.go
@@ -13,21 +13,20 @@ import (
 	"github.com/rancher/webhook/pkg/resources/validation/feature"
 	"github.com/rancher/webhook/pkg/resources/validation/globalrole"
 	"github.com/rancher/webhook/pkg/resources/validation/globalrolebinding"
+	"github.com/rancher/webhook/pkg/resources/validation/machineconfig"
 	"github.com/rancher/webhook/pkg/resources/validation/projectroletemplatebinding"
 	"github.com/rancher/webhook/pkg/resources/validation/roletemplate"
 	"github.com/rancher/wrangler/pkg/webhook"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func Validation(clients *clients.Clients) (http.Handler, error) {
 	router := webhook.NewRouter()
 
-	features := feature.NewValidator()
-	clusters := cluster.NewValidator(clients.K8s.AuthorizationV1().SubjectAccessReviews())
-	provisioningCluster := cluster.NewProvisioningClusterValidator(clients)
-
-	router.Kind("Feature").Group(management.GroupName).Type(&v3.Feature{}).Handle(features)
-	router.Kind("Cluster").Group(management.GroupName).Type(&v3.Cluster{}).Handle(clusters)
-	router.Kind("Cluster").Group(provisioning.GroupName).Type(&v1.Cluster{}).Handle(provisioningCluster)
+	router.Kind("Feature").Group(management.GroupName).Type(&v3.Feature{}).Handle(feature.NewValidator())
+	router.Kind("Cluster").Group(management.GroupName).Type(&v3.Cluster{}).Handle(cluster.NewValidator(clients.K8s.AuthorizationV1().SubjectAccessReviews()))
+	router.Kind("Cluster").Group(provisioning.GroupName).Type(&v1.Cluster{}).Handle(cluster.NewProvisioningClusterValidator(clients))
+	router.Group("rke-machine-config.cattle.io").Type(&unstructured.Unstructured{}).Handle(machineconfig.NewMachineConfigValidator())
 
 	if clients.MultiClusterManagement {
 		globalRoleBindings := globalrolebinding.NewValidator(clients.Management.GlobalRole().Cache(), clients.EscalationChecker)


### PR DESCRIPTION
In order to provide RBAC access to rke-machine-configs created by a user, a
creatorID annotation is added as a mutation webhook on create. In addition, a
validation webhook is added, similar to the provisioning cluster objects, so
that the creatorID annotation can only be updated in certain situations.

Issue:
https://github.com/rancher/rancher/issues/35868