### PR TITLE
Run pre-delete-hook-job as root

### DIFF
--- a/charts/rancher-webhook/templates/pre-delete-hook-job.yaml
+++ b/charts/rancher-webhook/templates/pre-delete-hook-job.yaml
@@ -22,5 +22,7 @@ spec:
         - name: rancher-webhook-pre-delete
           image: "{{ include "system_default_registry" . }}{{ .Values.preDelete.image.repository }}:{{ .Values.preDelete.image.tag }}"
           imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 0
           command: [ "kubectl", "delete", "--ignore-not-found=true", "mutatingwebhookconfigurations", "rancher.cattle.io" ]
 {{- end }}


### PR DESCRIPTION
No default securityContext is defined for the pre-delete job, so we end up getting an error like:

```
container has runAsNonRoot and image will run as root (pod: "rancher-webhook-pre-delete-v6bqp_cattle-system(a90e6d04-3086-41ff-876a-52401bd25d56)
```

To fix, I've added a securityContext to the pod that marks it as running as user 0 (aka root).

Related Issue: https://github.com/rancher/rancher/issues/33724