### PR TITLE
Adding default linux tolerations and node selectors

### DIFF
--- a/charts/rancher-webhook/Chart.yaml
+++ b/charts/rancher-webhook/Chart.yaml
@@ -9,6 +9,7 @@ annotations:
   catalog.cattle.io/namespace: cattle-system
   catalog.cattle.io/release-name: rancher-webhook
   catalog.cattle.io/os: linux
+  catalog.cattle.io/permits-os: linux,windows
 dependencies:
 - name: capi
   condition: capi.enabled

--- a/charts/rancher-webhook/templates/_helpers.tpl
+++ b/charts/rancher-webhook/templates/_helpers.tpl
@@ -9,3 +9,14 @@
 {{- define "rancher-webhook.labels" -}}
 app: rancher-webhook
 {{- end }}
+
+{{- define "linux-node-tolerations" -}}
+- key: "cattle.io/os"
+  value: "linux"
+  effect: "NoSchedule"
+  operator: "Equal"
+{{- end -}}
+
+{{- define "linux-node-selector" -}}
+kubernetes.io/os: linux
+{{- end -}}

--- a/charts/rancher-webhook/templates/deployment.yaml
+++ b/charts/rancher-webhook/templates/deployment.yaml
@@ -18,9 +18,13 @@ spec:
       {{- if .Values.global.hostNetwork }}
       hostNetwork: true
       {{- end }}
-      {{- with .Values.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
+      nodeSelector: {{ include "linux-node-selector" . | nindent 8 }}
+      {{- if .Values.nodeSelector }}
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
+      tolerations: {{ include "linux-node-tolerations" . | nindent 6 }}
+      {{- if .Values.tolerations }}
+{{ toYaml .Values.tolerations | indent 6 }}
       {{- end }}
       containers:
       - env:

--- a/charts/rancher-webhook/templates/pre-delete-hook-job.yaml
+++ b/charts/rancher-webhook/templates/pre-delete-hook-job.yaml
@@ -18,9 +18,13 @@ spec:
     spec:
       serviceAccountName: rancher-webhook-pre-delete
       restartPolicy: OnFailure
-      {{- with .Values.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
+      nodeSelector: {{ include "linux-node-selector" . | nindent 8 }}
+      {{- if .Values.nodeSelector }}
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
+      tolerations: {{ include "linux-node-tolerations" . | nindent 6 }}
+      {{- if .Values.tolerations }}
+{{ toYaml .Values.tolerations | indent 6 }}
       {{- end }}
       containers:
         - name: rancher-webhook-pre-delete

--- a/charts/rancher-webhook/values.yaml
+++ b/charts/rancher-webhook/values.yaml
@@ -22,3 +22,4 @@ preDelete:
 
 # tolerations for the webhook deployment. See https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ for more info
 tolerations: []
+nodeSelector: {}


### PR DESCRIPTION
Adding default toleration/node selector to ensure webhook pods
are scheduled on linux nodes. Related to rancher/rancher#36401