### PR TITLE
Update CRTB/PRTB validation handlers to disallow RoleTemplateName updates

### DIFF
--- a/pkg/resources/validation/clusterroletemplatebinding/clusterrtb.go
+++ b/pkg/resources/validation/clusterroletemplatebinding/clusterrtb.go
@@ -1,13 +1,17 @@
 package clusterroletemplatebinding
 
 import (
+	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/rancher/webhook/pkg/auth"
 	v3 "github.com/rancher/webhook/pkg/generated/controllers/management.cattle.io/v3"
 	objectsv3 "github.com/rancher/webhook/pkg/generated/objects/management.cattle.io/v3"
 	"github.com/rancher/wrangler/pkg/webhook"
+	admissionv1 "k8s.io/api/admission/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/trace"
 )
 
@@ -26,6 +30,23 @@ type clusterRoleTemplateBindingValidator struct {
 func (c *clusterRoleTemplateBindingValidator) Admit(response *webhook.Response, request *webhook.Request) error {
 	listTrace := trace.New("clusterRoleTemplateBindingValidator Admit", trace.Field{Key: "user", Value: request.UserInfo.Username})
 	defer listTrace.LogIfLong(2 * time.Second)
+
+	// disallow updates to the referenced role template
+	if request.Operation == admissionv1.Update {
+		oldCrtb, newCrtb, err := objectsv3.ClusterRoleTemplateBindingOldAndNewFromRequest(request)
+		if err != nil {
+			return err
+		}
+		if oldCrtb.RoleTemplateName != newCrtb.RoleTemplateName {
+			response.Result = &metav1.Status{
+				Status:  "Failure",
+				Message: fmt.Sprintf("cannot update referenced roleTemplate for clusterRoleTemplateBinding %s", oldCrtb.Name),
+				Reason:  metav1.StatusReasonBadRequest,
+				Code:    http.StatusBadRequest,
+			}
+			return nil
+		}
+	}
 
 	crtb, err := objectsv3.ClusterRoleTemplateBindingFromRequest(request)
 	if err != nil {

--- a/pkg/resources/validation/projectroletemplatebinding/projectrtb.go
+++ b/pkg/resources/validation/projectroletemplatebinding/projectrtb.go
@@ -1,6 +1,8 @@
 package projectroletemplatebinding
 
 import (
+	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -8,7 +10,9 @@ import (
 	v3 "github.com/rancher/webhook/pkg/generated/controllers/management.cattle.io/v3"
 	objectsv3 "github.com/rancher/webhook/pkg/generated/objects/management.cattle.io/v3"
 	"github.com/rancher/wrangler/pkg/webhook"
+	admissionv1 "k8s.io/api/admission/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/trace"
 )
 
@@ -28,13 +32,29 @@ func (p *projectRoleTemplateBindingValidator) Admit(response *webhook.Response, 
 	listTrace := trace.New("projectRoleTemplateBindingValidator Admit", trace.Field{Key: "user", Value: request.UserInfo.Username})
 	defer listTrace.LogIfLong(2 * time.Second)
 
+	// disallow updates to the referenced role template
+	if request.Operation == admissionv1.Update {
+		oldPrtb, newPrtb, err := objectsv3.ProjectRoleTemplateBindingOldAndNewFromRequest(request)
+		if err != nil {
+			return err
+		}
+		if oldPrtb.RoleTemplateName != newPrtb.RoleTemplateName {
+			response.Result = &metav1.Status{
+				Status:  "Failure",
+				Message: fmt.Sprintf("cannot update referenced roleTemplate for projectRoleTemplateBinding %s", oldPrtb.Name),
+				Reason:  metav1.StatusReasonBadRequest,
+				Code:    http.StatusBadRequest,
+			}
+			return nil
+		}
+	}
+
 	prtb, err := objectsv3.ProjectRoleTemplateBindingFromRequest(request)
 	if err != nil {
 		return err
 	}
 
 	clusterID, projectNS := clusterFromProject(prtb.ProjectName)
-
 	if clusterID != "local" {
 		response.Allowed = true
 		return nil


### PR DESCRIPTION
These changes bring the CRTB and PRTB CRs more in line with the underlying k8s RBAC types, which disallow updates to RoleRef. This also addresses a bug with Apply in Rancher, where a CRTB can't be synced because a RoleBinding is applied with a different RoleRef after the CRTB had it's RoleTemplateName updated