### PR TITLE
Limit provisioning cluster name to 63 characters

### DIFF
--- a/pkg/resources/validation/cluster/provisioningcluster.go
+++ b/pkg/resources/validation/cluster/provisioningcluster.go
@@ -131,7 +131,7 @@ func (p *provisioningClusterValidator) validateClusterName(request *webhook.Requ
 	if !isValidName(cluster.Name, cluster.Namespace, err == nil) {
 		response.Result = &metav1.Status{
 			Status:  "Failure",
-			Message: "cluster name cannot be \"local\" nor of the form \"c-xxxxx\"",
+			Message: "cluster name must be 63 characters or fewer, cannot be \"local\" nor of the form \"c-xxxxx\"",
 			Reason:  metav1.StatusReasonInvalid,
 			Code:    http.StatusUnprocessableEntity,
 		}
@@ -166,5 +166,8 @@ func isValidName(clusterName, clusterNamespace string, clusterExists bool) bool 
 		return clusterExists
 	}
 
-	return true
+	// Even though the name of the provisioning cluster object can be 253 characters, the name of the cluster is put in
+	// various labels, by Rancher controllers and CAPI controllers. Because of this, the name of the cluster object should
+	// be limited to 63 characters instead.
+	return len(clusterName) <= 63
 }

--- a/pkg/resources/validation/cluster/provisioningcluster_test.go
+++ b/pkg/resources/validation/cluster/provisioningcluster_test.go
@@ -73,6 +73,27 @@ func Test_isValidName(t *testing.T) {
 			clusterExists:    false,
 			want:             true,
 		},
+		{
+			name:             "name length is exactly 63 characters",
+			clusterName:      "Cq8Oh6UVnTyPOITcfwrXFjJRuZ4KV2q6ItimQkcGeX1ZQGm7oa3jbLd9N0diIka",
+			clusterNamespace: "fleet-default",
+			clusterExists:    false,
+			want:             true,
+		},
+		{
+			name:             "name length is 64 characters",
+			clusterName:      "xD0PeGoO51IsWFKx173UPikNoT0dsgp0JKUauSssk2VwunJRWaLB2rAYpJntVTPA",
+			clusterNamespace: "fleet-default",
+			clusterExists:    false,
+			want:             false,
+		},
+		{
+			name:             "name length is 253 characters",
+			clusterName:      "DxHt2WGXBASk8LPj4nFqMYCyKCsmZV6bWTL7xeo3NUXnW6tK07voFJJJmEpY6AvDhd03oR2hnW8UQJTDh2LVBPrh4V0rJoChGeaLMPTz4sQt3pt5sTcce4EiRk37YtjFQuHOdXKnQQzpIdll6TXReIQ9pPaASWuwpQ8opadHQITFlN2txSgOwc80WWGkgikcZh6f8fuihvviZF65tn2WBeySuDyEOFgLTaduG1CJwohm7n9Yovrd0fiYxM0BK",
+			clusterNamespace: "fleet-default",
+			clusterExists:    false,
+			want:             false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Issues:
https://github.com/rancher/rancher/issues/37535
https://github.com/rancher/rancher/issues/37544

## Problem
Although the cluster name can be 253 characters, the cluster name is put in
several labels by both Rancher and CAPI controllers. Therefore, the name should
really be limited to 63 characters.

## Solution
This change includes this validation in the name validation webhook for the
provisioning cluster objects.