### PR TITLE
Fixing package script bug

### DIFF
--- a/scripts/package-helm
+++ b/scripts/package-helm
@@ -13,7 +13,7 @@ mkdir -p build dist/artifacts
 cp -rf charts build/
 
 sed -i \
-    -e 's/version:.*/version: '${HELM_VERSION}'/' \
+    -e 's/^version:.*/version: '${HELM_VERSION}'/' \
     -e 's/appVersion:.*/appVersion: '${HELM_VERSION}'/' \
     build/charts/rancher-webhook/Chart.yaml
 


### PR DESCRIPTION
Package script didn't anchor the version regex causing the
kube-version/rancher-version to be errantly overwritten