### PR TITLE
Adds check for circular references to RoleTemplates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/rancher/rancher/pkg/apis v0.0.0-20210628154046-7a2fc74f9598
 	github.com/rancher/wrangler v0.8.11-0.20220217210408-3ecd23dfea3b
 	github.com/sirupsen/logrus v1.8.1
+	github.com/stretchr/testify v1.7.0
 	golang.org/x/tools v0.1.6-0.20210820212750-d4cc65f0b2ff
 	k8s.io/api v0.23.3
 	k8s.io/apiextensions-apiserver v0.23.0
@@ -75,6 +76,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/onsi/gomega v1.17.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.12.2 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect

--- a/pkg/mocks/RoleTemplateCache.go
+++ b/pkg/mocks/RoleTemplateCache.go
@@ -1,0 +1,77 @@
+package mocks
+
+import (
+	"fmt"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	controllerv3 "github.com/rancher/webhook/pkg/generated/controllers/management.cattle.io/v3"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type MockRoleTemplateCache struct {
+	// state is the internal state used to store our role templates for test purposes
+	state []*v3.RoleTemplate
+	// errAfterNext determines after how many calls to the cache an error will be thrown. If -1 don't ever throw error
+	errAfterNext int
+	// nextError is the next error that will be returned after errAfterNext calls
+	nextError error
+}
+
+func NewMockRoleTemplateCache() *MockRoleTemplateCache {
+	return &MockRoleTemplateCache{
+		state:        []*v3.RoleTemplate{},
+		errAfterNext: -1,
+		nextError:    nil,
+	}
+}
+
+func (mc *MockRoleTemplateCache) Get(name string) (*v3.RoleTemplate, error) {
+	if mc.shouldReturnErr() {
+		mc.decrementErrorCounter()
+		return nil, mc.nextError
+	}
+	mc.decrementErrorCounter()
+	for _, template := range mc.state {
+		if template.Name == name {
+			return template, nil
+		}
+	}
+	return nil, apierrors.NewNotFound(schema.GroupResource{Group: "management.cattle.io", Resource: "roletemplate"}, name)
+}
+
+func (mc *MockRoleTemplateCache) List(selector labels.Selector) ([]*v3.RoleTemplate, error) {
+	if mc.shouldReturnErr() {
+		mc.decrementErrorCounter()
+		return nil, mc.nextError
+	}
+	mc.decrementErrorCounter()
+	return mc.state, nil
+}
+
+func (mc *MockRoleTemplateCache) AddIndexer(indexName string, indexer controllerv3.RoleTemplateIndexer) {
+	//TODO: Add indexer method
+}
+
+func (mc *MockRoleTemplateCache) GetByIndex(indexName, key string) ([]*v3.RoleTemplate, error) {
+	//TODO: Add GetByIndexer method
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (mc *MockRoleTemplateCache) Add(template *v3.RoleTemplate) {
+	mc.state = append(mc.state, template)
+}
+
+func (mc *MockRoleTemplateCache) AddErr(calls int, err error) {
+	mc.errAfterNext = calls
+	mc.nextError = err
+}
+
+func (mc *MockRoleTemplateCache) shouldReturnErr() bool {
+	return false
+}
+
+func (mc *MockRoleTemplateCache) decrementErrorCounter() {
+
+}

--- a/pkg/resources/validation/roletemplate/roletemplate_test.go
+++ b/pkg/resources/validation/roletemplate/roletemplate_test.go
@@ -1,0 +1,143 @@
+package roletemplate
+
+import (
+	"strconv"
+	"testing"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	controllerv3 "github.com/rancher/webhook/pkg/generated/controllers/management.cattle.io/v3"
+	"github.com/rancher/webhook/pkg/mocks"
+	"github.com/stretchr/testify/assert"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var defaultRules = []rbacv1.PolicyRule{
+	{
+		APIGroups: []string{""},
+		Resources: []string{"pods"},
+		Verbs:     []string{"get", "list", "watch"},
+	},
+}
+
+var circleRoleTemplateName = "circleRef"
+
+func TestCheckCircularRef(t *testing.T) {
+	tests := []struct {
+		name           string
+		depth          int
+		circleDepth    int
+		errorDepth     int
+		hasCircularRef bool
+		errDesired     bool
+	}{
+		{
+			name:           "basic test case - no inheritance, no circular ref or error",
+			depth:          0,
+			circleDepth:    -1,
+			errorDepth:     -1,
+			hasCircularRef: false,
+			errDesired:     false,
+		},
+		{
+			name:           "basic inheritance case - depth 1 of input is circular",
+			depth:          1,
+			circleDepth:    0,
+			errorDepth:     -1,
+			hasCircularRef: true,
+			errDesired:     false,
+		},
+		{
+			name:           "self-reference inheritance case - single role template which inherits itself",
+			depth:          0,
+			circleDepth:    0,
+			errorDepth:     -1,
+			hasCircularRef: true,
+			errDesired:     false,
+		},
+		{
+			name:           "deeply nested inheritance case - role template inherits other templates which eventually becomes circular",
+			depth:          3,
+			circleDepth:    2,
+			errorDepth:     -1,
+			hasCircularRef: true,
+			errDesired:     false,
+		},
+		{
+			name:           "basic error case - role inherits another role which doesn't exist",
+			depth:          1,
+			circleDepth:    -1,
+			errorDepth:     0,
+			hasCircularRef: false,
+			errDesired:     true,
+		},
+	}
+
+	for _, testCase := range tests {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			mockCache := mocks.NewMockRoleTemplateCache()
+			rtName := "input-role"
+			if testCase.circleDepth == 0 && testCase.hasCircularRef {
+				rtName = circleRoleTemplateName
+			}
+			inputRole := createNestedRoleTemplate(rtName, mockCache, testCase.depth, testCase.circleDepth, testCase.errorDepth)
+			validator := createValidator(mockCache)
+			result, err := validator.checkCircularRef(inputRole)
+			if testCase.errDesired {
+				assert.NotNil(t, err, "checkCircularRef(), expected err but did not get an error")
+			} else {
+				assert.Nil(t, err, "checkCircularRef(), got error %v but did not expect an error", err)
+			}
+			if testCase.hasCircularRef {
+				assert.NotNil(t, result, "checkCircularRef(), expected result but was nil")
+				assert.Equal(t, circleRoleTemplateName, result.Name, "checkCircularRef(), expected roleTemplate with name %s but got %v", circleRoleTemplateName, result)
+			} else {
+				assert.Nil(t, result, "checkCircularRef(), expected result to be nil but was %v", result)
+			}
+		})
+	}
+}
+
+func createNestedRoleTemplate(name string, cache *mocks.MockRoleTemplateCache, depth int, circleDepth int, errDepth int) *v3.RoleTemplate {
+	start := createRoleTemplate(name, defaultRules)
+	prior := start
+
+	if depth == 0 && circleDepth == 0 {
+		start.RoleTemplateNames = []string{start.Name}
+		cache.Add(start)
+	}
+	for i := 0; i < depth; i++ {
+		current := createRoleTemplate("current-"+strconv.Itoa(i), defaultRules)
+		if i != errDepth {
+			cache.Add(current)
+		}
+		priorInherits := []string{current.Name}
+		if i == circleDepth {
+			circle := createRoleTemplate(circleRoleTemplateName, defaultRules)
+			cache.Add(circle)
+			priorInherits = append(priorInherits, circle.Name)
+			circle.RoleTemplateNames = []string{name}
+		}
+		prior.RoleTemplateNames = priorInherits
+		prior = current
+	}
+
+	return start
+}
+
+func createRoleTemplate(name string, rules []rbacv1.PolicyRule) *v3.RoleTemplate {
+	return &v3.RoleTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Rules: rules,
+	}
+}
+
+func createValidator(cache controllerv3.RoleTemplateCache) *roleTemplateValidator {
+	return &roleTemplateValidator{
+		templates: cache,
+	}
+}

--- a/pkg/server/validation.go
+++ b/pkg/server/validation.go
@@ -33,7 +33,7 @@ func Validation(clients *clients.Clients) (http.Handler, error) {
 		globalRoles := globalrole.NewValidator(clients.EscalationChecker)
 		prtbs := projectroletemplatebinding.NewValidator(clients.Management.RoleTemplate().Cache(), clients.EscalationChecker)
 		crtbs := clusterroletemplatebinding.NewValidator(clients.Management.RoleTemplate().Cache(), clients.EscalationChecker)
-		roleTemplates := roletemplate.NewValidator(clients.EscalationChecker)
+		roleTemplates := roletemplate.NewValidator(clients.Management.RoleTemplate().Cache(), clients.EscalationChecker)
 
 		router.Kind("RoleTemplate").Group(management.GroupName).Type(&v3.RoleTemplate{}).Handle(roleTemplates)
 		router.Kind("GlobalRoleBinding").Group(management.GroupName).Type(&v3.GlobalRoleBinding{}).Handle(globalRoleBindings)


### PR DESCRIPTION
When 2 role templates inherit from each other, this can cause
performance issues or an outright crash. This change aims to
ensure that role templates can't form circular references like
this in the future.