### PR TITLE
Prepare rancher-webhook charts for rancher 2.7.

### DIFF
--- a/charts/rancher-webhook/Chart.yaml
+++ b/charts/rancher-webhook/Chart.yaml
@@ -10,8 +10,8 @@ annotations:
   catalog.cattle.io/release-name: rancher-webhook
   catalog.cattle.io/os: linux
   catalog.cattle.io/permits-os: linux,windows
-  catalog.cattle.io/rancher-version: '>= 2.6.0-0 < 2.7.0-0'
-  catalog.cattle.io/kube-version: '>= 1.16.0-0 < 1.25.0-0'
+  catalog.cattle.io/rancher-version: ">= 2.7.0-0 < 2.8.0-0"
+  catalog.cattle.io/kube-version: ">= 1.16.0-0 < 1.25.0-0"
 dependencies:
-- name: capi
-  condition: capi.enabled
+  - name: capi
+    condition: capi.enabled


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/38943
updates rancher version in charts.