### PR TITLE
[release/v0.3] Print correct version on startup

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -9,8 +9,8 @@ mkdir -p bin
 if [ "$(uname)" = "Linux" ]; then
     OTHER_LINKFLAGS="-extldflags -static -s"
 fi
-LINKFLAGS="-X github.com/rancher/webhook.Version=$VERSION"
-LINKFLAGS="-X github.com/rancher/webhook.GitCommit=$COMMIT $LINKFLAGS"
+LINKFLAGS="-X main.Version=$VERSION"
+LINKFLAGS="-X main.GitCommit=$COMMIT $LINKFLAGS"
 CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/webhook
 if [ "$CROSS" = "true" ] && [ "$ARCH" = "amd64" ]; then
     GOOS=darwin go build -ldflags "$LINKFLAGS" -o bin/webhook-darwin


### PR DESCRIPTION
Variables are correctly substituted at build time with this change.

Current:
```
INFO[0000] Rancher-webhook version dev (HEAD) is starting 
```

This change:
```
INFO[0000] Rancher-webhook version 0.0.0-6187da1 (6187da1) is starting
```