### PR TITLE
Fix for 2.5 pipeline on github release phase

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -140,7 +140,7 @@ steps:
     path: /var/run/docker.sock
 
 - name: github_binary_release
-  image: plugins/github-release
+  image: plugins/github-release@sha256:fffa518fb430e8e890ec9fcf616d0ef6930a9b3fb67fd6de9c3171b6d921a944 
   settings:
     api_key:
       from_secret: github_token


### PR DESCRIPTION
Drone CI is currently broken on the github release phase. It looks like the github release plugin removed support for arm v32 (see https://github.com/drone-plugins/drone-github-release/pull/143), so we are pinning to a version which recently worked, for this phase. 