### PR TITLE
Rename integration test

### DIFF
--- a/scripts/integration-test
+++ b/scripts/integration-test
@@ -47,4 +47,4 @@ while ! kubectl rollout status -w -n cattle-system deploy/rancher-webhook; do
     sleep 2
 done
 
-./bin/webhook-integration.test -test.v
+./bin/rancher-webhook-integration.test -test.v

--- a/scripts/test
+++ b/scripts/test
@@ -3,7 +3,7 @@ set -e
 
 cd $(dirname $0)/..
 
-go test ./tests/integration/... -c -o ./bin/webhook-integration.test
+go test ./tests/integration/... -c -o ./bin/rancher-webhook-integration.test
 
 echo "Running tests"
 go test --coverpkg=./pkg/... -coverprofile=coverage.out --count=1 ./pkg/...


### PR DESCRIPTION
The integration test binary was being uploaded into the release assets because of the code section [here](https://github.com/rancher/webhook/blob/716525619509df709ec3e1ddcb5304f2f3a9e736/scripts/package#L28-#L36) 
I updated the name of the integration test binary so that it no longer matches the expression.