### PR TITLE
Auto-adjust the API version of the PodSecurityConfiguration resource based on the cluster k8s version

### DIFF
--- a/pkg/resources/mutation/cluster/cluster.go
+++ b/pkg/resources/mutation/cluster/cluster.go
@@ -108,7 +108,7 @@ func (m *ManagementClusterMutator) setPSAConfig(cluster *apisv3.Cluster) error {
 	if err != nil {
 		return fmt.Errorf("failed to get PodSecurityAdmissionConfigurationTemplate: %w", err)
 	}
-	plugin, err := psa.GetPluginConfigFromTemplate(template)
+	plugin, err := psa.GetPluginConfigFromTemplate(template, cluster.Spec.RancherKubernetesEngineConfig.Version)
 	if err != nil {
 		return fmt.Errorf("failed to get plugin config from template: %w", err)
 	}


### PR DESCRIPTION
 Issue https://github.com/rancher/rancher/issues/39992

Problem:
Different API versions for `PodSecurityConfiguration` is used in different k8s versions: the API version `v1beta1` is used in k8s 1.23 and 1.24;  `v1` is used in k8s 1.25 and above. 
Previously, the mutator used version `v1` when mutating  RKE1  1.23 and 1.24 clusters, which failed to provision clusters due to the error of `API version is unknown`.

Fix:
This PR allows the mutator to auto-adjust the API version of the PodSecurityConfiguration resource based on the cluster k8s version. 
 
Tests:
The test is done by running the webhook locally and pointing it to a Rancher setup.  The provision of the RKE1 cluster with k8s version 1.23, 1,24, and 1,25 all succeed. 