### PR TITLE
[2.7] Properly return response obj when denying requests

### DIFF
--- a/pkg/resources/validation/cluster/provisioningcluster.go
+++ b/pkg/resources/validation/cluster/provisioningcluster.go
@@ -70,7 +70,7 @@ func (p *ProvisioningClusterValidator) Admit(request *admission.Request) (*admis
 	}
 	response := &admissionv1.AdmissionResponse{}
 	if err := p.validateClusterName(request, response, cluster); err != nil || response.Result != nil {
-		return nil, err
+		return response, err
 	}
 
 	if response.Result = validation.CheckCreatorID(request, oldCluster, cluster); response.Result != nil {
@@ -82,7 +82,7 @@ func (p *ProvisioningClusterValidator) Admit(request *admission.Request) (*admis
 	}
 
 	if err := p.validateCloudCredentialAccess(request, response, oldCluster, cluster); err != nil || response.Result != nil {
-		return nil, err
+		return response, err
 	}
 
 	response.Allowed = true
@@ -152,7 +152,6 @@ func (p *ProvisioningClusterValidator) validateClusterName(request *admission.Re
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
-
 	if !isValidName(cluster.Name, cluster.Namespace, err == nil) {
 		response.Result = &metav1.Status{
 			Status:  "Failure",


### PR DESCRIPTION
### Issue: https://github.com/rancher/rancher/issues/39248

### Problem:
Implementation of https://github.com/rancher/webhook/pull/136 was done before the general refactor of the webhook, and as such treated the response object as a pointer which could be mutated directly without the need to return it from the `Admit` handler. The webhook now requires all response objects to be returned explicitly, however certain handling within the provisioning cluster validator did not take this fact into account.

This results in messages being omitted from denied webhook requests, degrading the UX and preventing users from knowing the root cause of their denied request. 


### Solution: 
Explicitly return the response object if it has been modified during validation checks.

I recognize that it is not a good pattern to modify the response object outside of the `Admit` function, however I feel that a full refactor of this package would unnessicarily increase the testing requirements of this issue. That said, a refactor of this package should be done in the future, but ideally under a tech debt work item of its own.

### Testing: 
+ Create a cluster that does not conform to the provisioning cluster requirements, either due to the name exceeding 63 characters, or the name including a `.`
+ Ensure the Rancher UI shows the appropriate error message

### Engineering testing:
I've done the above and can confirm the UI will now properly show the root cause of the denied request. 

