### PR TITLE
[2.7] Update PSACT validation rules

### DIFF
--- a/pkg/resources/validation/podsecurityadmissionconfigurationtemplate/podsecurityact.go
+++ b/pkg/resources/validation/podsecurityadmissionconfigurationtemplate/podsecurityact.go
@@ -177,27 +177,27 @@ func (v *Validator) handleDeletion(oldTemplate *mgmtv3.PodSecurityAdmissionConfi
 }
 
 func (v *Validator) validateConfiguration(configurationTemplate *mgmtv3.PodSecurityAdmissionConfigurationTemplate) error {
-	configuration := configurationTemplate.Configuration
-	// validate defaults
-	if err := validateLevel(field.NewPath("defaults", "enforce"), configuration.Defaults.Enforce).ToAggregate(); err != nil {
+	defaults := configurationTemplate.Configuration.Defaults
+
+	// validate any provided defaults
+	if err := validateLevel(field.NewPath("defaults", "enforce"), defaults.Enforce).ToAggregate(); err != nil {
+		return err
+	}
+	if err := validateVersion(field.NewPath("defaults", "enforce-version"), defaults.EnforceVersion).ToAggregate(); err != nil {
 		return err
 	}
 
-	if err := validateVersion(field.NewPath("defaults", "enforce-version"), configuration.Defaults.EnforceVersion).ToAggregate(); err != nil {
+	if err := validateLevel(field.NewPath("defaults", "warn"), defaults.Warn).ToAggregate(); err != nil {
 		return err
 	}
-	if err := validateLevel(field.NewPath("defaults", "warn"), configuration.Defaults.Warn).ToAggregate(); err != nil {
-		return err
-	}
-
-	if err := validateVersion(field.NewPath("defaults", "warn-version"), configuration.Defaults.WarnVersion).ToAggregate(); err != nil {
-		return err
-	}
-	if err := validateLevel(field.NewPath("defaults", "audit"), configuration.Defaults.Audit).ToAggregate(); err != nil {
+	if err := validateVersion(field.NewPath("defaults", "warn-version"), defaults.WarnVersion).ToAggregate(); err != nil {
 		return err
 	}
 
-	if err := validateVersion(field.NewPath("defaults", "audit-version"), configuration.Defaults.AuditVersion).ToAggregate(); err != nil {
+	if err := validateLevel(field.NewPath("defaults", "audit"), defaults.Audit).ToAggregate(); err != nil {
+		return err
+	}
+	if err := validateVersion(field.NewPath("defaults", "audit-version"), defaults.AuditVersion).ToAggregate(); err != nil {
 		return err
 	}
 
@@ -218,6 +218,9 @@ func (v *Validator) validateConfiguration(configurationTemplate *mgmtv3.PodSecur
 }
 
 func validateLevel(p *field.Path, value string) field.ErrorList {
+	if value == "" {
+		return nil
+	}
 	errs := field.ErrorList{}
 	_, err := api.ParseLevel(value)
 	if err != nil {
@@ -227,6 +230,9 @@ func validateLevel(p *field.Path, value string) field.ErrorList {
 }
 
 func validateVersion(p *field.Path, value string) field.ErrorList {
+	if value == "" {
+		return nil
+	}
 	errs := field.ErrorList{}
 	_, err := api.ParseVersion(value)
 	if err != nil {

--- a/pkg/resources/validation/podsecurityadmissionconfigurationtemplate/podsecurityact_test.go
+++ b/pkg/resources/validation/podsecurityadmissionconfigurationtemplate/podsecurityact_test.go
@@ -142,6 +142,72 @@ func TestAdmit(t *testing.T) {
 			wantAllowed: true,
 		},
 		{
+			testName: "Completely Valid Template Test With a Level And Version Omitted",
+			template: &v3.PodSecurityAdmissionConfigurationTemplate{
+				Description: "a valid test template",
+				Configuration: v3.PodSecurityAdmissionConfigurationTemplateSpec{
+					Defaults: v3.PodSecurityAdmissionConfigurationTemplateDefaults{
+						Enforce:        "",
+						EnforceVersion: "",
+						Audit:          string(api.LevelBaseline),
+						AuditVersion:   "v1.25",
+						Warn:           string(api.LevelBaseline),
+						WarnVersion:    "v1.25",
+					},
+					Exemptions: v3.PodSecurityAdmissionConfigurationTemplateExemptions{
+						Usernames:      nil,
+						RuntimeClasses: nil,
+						Namespaces:     nil,
+					},
+				},
+			},
+			wantAllowed: true,
+		},
+		{
+			testName: "Completely Valid Template Test With a Level Omitted",
+			template: &v3.PodSecurityAdmissionConfigurationTemplate{
+				Description: "a valid test template",
+				Configuration: v3.PodSecurityAdmissionConfigurationTemplateSpec{
+					Defaults: v3.PodSecurityAdmissionConfigurationTemplateDefaults{
+						Enforce:        "",
+						EnforceVersion: "v1.25",
+						Audit:          string(api.LevelBaseline),
+						AuditVersion:   "v1.25",
+						Warn:           string(api.LevelBaseline),
+						WarnVersion:    "v1.25",
+					},
+					Exemptions: v3.PodSecurityAdmissionConfigurationTemplateExemptions{
+						Usernames:      nil,
+						RuntimeClasses: nil,
+						Namespaces:     nil,
+					},
+				},
+			},
+			wantAllowed: true,
+		},
+		{
+			testName: "Completely Valid Template Test With a Version Omitted",
+			template: &v3.PodSecurityAdmissionConfigurationTemplate{
+				Description: "a valid test template",
+				Configuration: v3.PodSecurityAdmissionConfigurationTemplateSpec{
+					Defaults: v3.PodSecurityAdmissionConfigurationTemplateDefaults{
+						Enforce:        string(api.LevelBaseline),
+						EnforceVersion: "",
+						Audit:          string(api.LevelBaseline),
+						AuditVersion:   "v1.25",
+						Warn:           string(api.LevelBaseline),
+						WarnVersion:    "v1.25",
+					},
+					Exemptions: v3.PodSecurityAdmissionConfigurationTemplateExemptions{
+						Usernames:      nil,
+						RuntimeClasses: nil,
+						Namespaces:     nil,
+					},
+				},
+			},
+			wantAllowed: true,
+		},
+		{
 			testName: "Ensure a bad enforce level is caught",
 			template: &v3.PodSecurityAdmissionConfigurationTemplate{
 				Description: "a test template",


### PR DESCRIPTION
### Issue: https://github.com/rancher/rancher/issues/40166

### Problem: 

When creating `PodSecurityAdmissionConfiguration` objects in Kubernetes you are able to omit fields within the `defaults` section without issue. Prior implementation of the validation for Rancher's specific `PodSecurityAdmissionConfigurationTemplates` required users to provide a valid value for the level and version attributes of each `defaults` element. 

### Solution:
This PR modifies the validating web-hook for the `PodSecurityAdmissionConfigurationTemplate` CRD so that the behavior seen in Rancher matches the behavior seen in Kubernetes. Now, users can omit a level, version, or both when defining the `defaults` of a `PodSecurityAdmissionConfigurationTemplate`. If you do provide a value, it must be either `restricted`, `privileged`, or `baseline`

### Testing:
+ build a local image of the modified webhook
+ modify the rancher-webhook deployment to use this new image 
+ Create a `PodSecurityAdmissionConfigurationTemplate` which has a `defaults` field partially omitted

I used these yaml files 
```yaml
apiVersion: management.cattle.io/v3
kind: PodSecurityAdmissionConfigurationTemplate
metadata:
  name: testing
configuration:
  defaults:
    enforce: ""
    enforce-version: "latest"
    audit: "restricted"
    audit-version: "latest"
    warn: "privileged"
    warn-version: "latest"
  exemptions:
    usernames: []
    runtimeClasses: []
    namespaces: []
```
```yaml
apiVersion: management.cattle.io/v3
kind: PodSecurityAdmissionConfigurationTemplate
metadata:
  name: testing
configuration:
  defaults:
    enforce: "privileged"
    enforce-version: ""
    audit: "restricted"
    audit-version: "latest"
    warn: "privileged"
    warn-version: "latest"
  exemptions:
    usernames: []
    runtimeClasses: []
    namespaces: []
```

### Automation:
I've updated the unit tests to check for this scenario, new tests have been added which omit the version and level of a `defaults` field. 