### PR TITLE
update the names of Rancher builtin PSACTs

### DIFF
--- a/pkg/resources/validation/podsecurityadmissionconfigurationtemplate/podsecurityact.go
+++ b/pkg/resources/validation/podsecurityadmissionconfigurationtemplate/podsecurityact.go
@@ -36,7 +36,11 @@ type Validator struct {
 	provisioningClusterCache v1.ClusterCache
 }
 
-const byPodSecurityAdmissionConfigurationName = "podSecurityAdmissionConfigurationName"
+const (
+	byPodSecurityAdmissionConfigurationName = "podSecurityAdmissionConfigurationName"
+	rancherPrivilegedPSACTName              = "rancher-privileged"
+	rancherRestrictedPSACTName              = "rancher-restricted"
+)
 
 // NewValidator returns a validator for PodSecurityAdmissionConfigurationTemplates
 func NewValidator(managementCache v3.ClusterCache, provisioningCache v1.ClusterCache) *Validator {
@@ -107,7 +111,7 @@ func (v *Validator) Admit(req *admission.Request) (*admissionv1.AdmissionRespons
 		resp.Allowed = true
 	case admissionv1.Delete:
 		// do not allow the default 'restricted' and 'privileged' templates from being deleted
-		if oldTemplate.Name == "restricted" || oldTemplate.Name == "privileged" {
+		if oldTemplate.Name == rancherPrivilegedPSACTName || oldTemplate.Name == rancherRestrictedPSACTName {
 			resp.Result = &metav1.Status{
 				Status:  "Failure",
 				Message: fmt.Sprintf("Cannot delete built-in template '%s'", oldTemplate.Name),

--- a/pkg/resources/validation/podsecurityadmissionconfigurationtemplate/podsecurityact_test.go
+++ b/pkg/resources/validation/podsecurityadmissionconfigurationtemplate/podsecurityact_test.go
@@ -61,7 +61,7 @@ func TestAdmit(t *testing.T) {
 			template: &v3.PodSecurityAdmissionConfigurationTemplate{
 				TypeMeta: metav1.TypeMeta{},
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "restricted",
+					Name: rancherRestrictedPSACTName,
 				},
 				Description:   "",
 				Configuration: validConfiguration,
@@ -73,7 +73,7 @@ func TestAdmit(t *testing.T) {
 			template: &v3.PodSecurityAdmissionConfigurationTemplate{
 				TypeMeta: metav1.TypeMeta{},
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "privileged",
+					Name: rancherPrivilegedPSACTName,
 				},
 				Description:   "",
 				Configuration: validConfiguration,


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/40478

Because we decided to rename the two built-in PSACTs to have a prefix of `rancher-`, we need to update the checks for names here. 

Once this PR is merged and a new tag is cut,  [This PR in rancher/rancher](https://github.com/rancher/rancher/pull/40479) will be updated to include both the name changing and chart version bumping. 