### PR TITLE
Adds group checking to ruleResolvers.

### DIFF
--- a/pkg/resolvers/aggregateResolver_test.go
+++ b/pkg/resolvers/aggregateResolver_test.go
@@ -1,4 +1,4 @@
-package resolvers_test
+package resolvers
 
 import (
 	"fmt"
@@ -6,7 +6,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/rancher/webhook/pkg/fakes"
-	"github.com/rancher/webhook/pkg/resolvers"
 	"github.com/stretchr/testify/suite"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apiserver/pkg/authentication/user"
@@ -145,7 +144,7 @@ func (a *AggregateResolverSuite) TestAggregateRuleResolverGetRules() {
 	for _, tt := range tests {
 		a.Run(tt.name, func() {
 			resolverList, expectedRules := tt.resolvers(a.T())
-			agg := resolvers.NewAggregateRuleResolver(resolverList...)
+			agg := NewAggregateRuleResolver(resolverList...)
 			gotRules, err := agg.RulesFor(tt.user, tt.namespace)
 			if tt.wantErr {
 				a.Errorf(err, "AggregateRuleResolver.RulesFor() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/resolvers/crtbResolver.go
+++ b/pkg/resolvers/crtbResolver.go
@@ -3,11 +3,15 @@ package resolvers
 import (
 	"fmt"
 
+	apisv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/webhook/pkg/auth"
 	v3 "github.com/rancher/webhook/pkg/generated/controllers/management.cattle.io/v3"
 	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+const (
+	crtbSubjectIndex = "management.cattle.io/crtb-by-subject"
 )
 
 // CRTBRuleResolver implements the rbacv1.AuthorizationRuleResolver interface.
@@ -17,7 +21,10 @@ type CRTBRuleResolver struct {
 }
 
 // NewCRTBRuleResolver returns a new resolver for resolving rules given through ClusterRoleTemplateBindings.
+// This function can only be called once for each unique instance of crtbCache.
 func NewCRTBRuleResolver(crtbCache v3.ClusterRoleTemplateBindingCache, roleTemplateResolver *auth.RoleTemplateResolver) *CRTBRuleResolver {
+	crtbCache.AddIndexer(crtbSubjectIndex, crtbBySubject)
+
 	return &CRTBRuleResolver{
 		ClusterRoleTemplateBindings: crtbCache,
 		RoleTemplateResolver:        roleTemplateResolver,
@@ -33,7 +40,7 @@ func (c *CRTBRuleResolver) GetRoleReferenceRules(roleRef rbacv1.RoleRef, namespa
 // RulesFor returns the list of rules that apply to a given user in a given namespace and error.  If an error is returned, the slice of
 // PolicyRules may not be complete, but it contains all retrievable rules.  This is done because policy rules are purely additive and policy determinations
 // can be made on the basis of those rules that are found.
-func (c *CRTBRuleResolver) RulesFor(user user.Info, namespace string) (rules []rbacv1.PolicyRule, retError error) {
+func (c *CRTBRuleResolver) RulesFor(user user.Info, namespace string) ([]rbacv1.PolicyRule, error) {
 	visitor := &ruleAccumulator{}
 	c.VisitRulesFor(user, namespace, visitor.visit)
 	return visitor.rules, visitor.getError()
@@ -42,18 +49,45 @@ func (c *CRTBRuleResolver) RulesFor(user user.Info, namespace string) (rules []r
 // VisitRulesFor invokes visitor() with each rule that applies to a given user in a given namespace, and each error encountered resolving those rules.
 // If visitor() returns false, visiting is short-circuited.
 func (c *CRTBRuleResolver) VisitRulesFor(user user.Info, namespace string, visitor func(source fmt.Stringer, rule *rbacv1.PolicyRule, err error) bool) {
-	crtbs, err := c.ClusterRoleTemplateBindings.List(namespace, labels.Everything())
-	if err != nil {
-		visitor(nil, nil, err)
-	}
-
-	for _, crtb := range crtbs {
-		if crtb.UserName != user.GetName() {
+	// for each group check if there are any CRTBs that match subject and namespace using the indexer.
+	// For each returned binding get a list of it's rules with the RoleTemplateResolver and call visit for each rule.
+	for _, group := range user.GetGroups() {
+		crtbs, err := c.ClusterRoleTemplateBindings.GetByIndex(crtbSubjectIndex, GetGroupKey(group, namespace))
+		if err != nil {
+			visitor(nil, nil, err)
 			continue
 		}
+		for _, crtb := range crtbs {
+			rtRules, err := c.RoleTemplateResolver.RulesFromTemplateName(crtb.RoleTemplateName)
+			if !visitRules(nil, rtRules, err, visitor) {
+				return
+			}
+		}
+	}
+
+	// gather all CRTBs that match this userName and namespace and resolve there rules.
+	crtbs, err := c.ClusterRoleTemplateBindings.GetByIndex(crtbSubjectIndex, GetUserKey(user.GetName(), namespace))
+	if err != nil {
+		visitor(nil, nil, err)
+		return
+	}
+	for _, crtb := range crtbs {
 		rtRules, err := c.RoleTemplateResolver.RulesFromTemplateName(crtb.RoleTemplateName)
 		if !visitRules(nil, rtRules, err, visitor) {
 			return
 		}
 	}
+}
+
+func crtbBySubject(crtb *apisv3.ClusterRoleTemplateBinding) ([]string, error) {
+	if crtb.UserName != "" {
+		return []string{GetUserKey(crtb.UserName, crtb.ClusterName)}, nil
+	}
+	if crtb.GroupName != "" {
+		return []string{GetGroupKey(crtb.GroupName, crtb.ClusterName)}, nil
+	}
+	if crtb.GroupPrincipalName != "" {
+		return []string{GetGroupKey(crtb.GroupPrincipalName, crtb.ClusterName)}, nil
+	}
+	return nil, nil
 }

--- a/pkg/resolvers/crtbResolver_test.go
+++ b/pkg/resolvers/crtbResolver_test.go
@@ -1,4 +1,4 @@
-package resolvers_test
+package resolvers
 
 import (
 	"testing"
@@ -8,7 +8,6 @@ import (
 	"github.com/rancher/webhook/pkg/auth"
 	"github.com/rancher/webhook/pkg/fakes"
 	v3 "github.com/rancher/webhook/pkg/generated/controllers/management.cattle.io/v3"
-	"github.com/rancher/webhook/pkg/resolvers"
 	"github.com/stretchr/testify/suite"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,6 +24,10 @@ type CRTBResolverSuite struct {
 	user1InvalidNS2CRTB *apisv3.ClusterRoleTemplateBinding
 	user2WriteCRTB      *apisv3.ClusterRoleTemplateBinding
 	user2ReadCRTB       *apisv3.ClusterRoleTemplateBinding
+	groupAdminCRTB      *apisv3.ClusterRoleTemplateBinding
+	groupWriteCRTB      *apisv3.ClusterRoleTemplateBinding
+	group2WriteCRTB     *apisv3.ClusterRoleTemplateBinding
+	groupReadCRTB       *apisv3.ClusterRoleTemplateBinding
 }
 
 func TestCRTBResolver(t *testing.T) {
@@ -82,96 +85,172 @@ func (c *CRTBResolverSuite) SetupSuite() {
 	}
 	c.user1AdminCRTB = &apisv3.ClusterRoleTemplateBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "user1-admin",
-			Namespace: "namespace1",
+			Name: "user1-admin",
 		},
+		ClusterName:      "namespace1",
 		UserName:         "user1",
 		RoleTemplateName: c.adminRT.Name,
 	}
 	c.user1AReadNS2CRTB = &apisv3.ClusterRoleTemplateBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "user1-read",
-			Namespace: "namespace2",
+			Name: "user1-read",
 		},
+		ClusterName:      "namespace2",
 		UserName:         "user1",
 		RoleTemplateName: c.readRT.Name,
 	}
 	c.user1InvalidNS2CRTB = &apisv3.ClusterRoleTemplateBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "user1-invalid",
-			Namespace: "namespace2",
+			Name: "user1-invalid",
 		},
+		ClusterName:      "namespace2",
 		UserName:         "user1",
 		RoleTemplateName: invalidName,
 	}
 	c.user2WriteCRTB = &apisv3.ClusterRoleTemplateBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "user2-write",
-			Namespace: "namespace1",
+			Name: "user2-write",
 		},
+		ClusterName:      "namespace1",
 		UserName:         "user2",
 		RoleTemplateName: c.writeRT.Name,
 	}
 	c.user2ReadCRTB = &apisv3.ClusterRoleTemplateBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "user2-read",
-			Namespace: "namespace1",
+			Name: "user2-read",
 		},
+		ClusterName:      "namespace1",
 		UserName:         "user2",
 		RoleTemplateName: c.readRT.Name,
 	}
 
+	c.groupWriteCRTB = &apisv3.ClusterRoleTemplateBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "group-write",
+		},
+		ClusterName:      "namespace1",
+		GroupName:        authGroup,
+		RoleTemplateName: c.writeRT.Name,
+	}
+	c.groupReadCRTB = &apisv3.ClusterRoleTemplateBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "group-read",
+		},
+		ClusterName:      "namespace1",
+		GroupName:        authGroup,
+		RoleTemplateName: c.readRT.Name,
+	}
+	c.group2WriteCRTB = &apisv3.ClusterRoleTemplateBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "group2-write",
+		},
+		ClusterName:        "namespace2",
+		GroupPrincipalName: adminGroup,
+		RoleTemplateName:   c.writeRT.Name,
+	}
+	c.groupAdminCRTB = &apisv3.ClusterRoleTemplateBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "group-admin",
+		},
+		ClusterName:      "namespace1",
+		GroupName:        adminGroup,
+		RoleTemplateName: c.adminRT.Name,
+	}
 }
 
 func (c *CRTBResolverSuite) TestCRTBRuleResolver() {
 	resolver := c.NewTestCRTBResolver()
 	tests := []struct {
-		name      string
-		user      user.Info
-		namespace string
-		wantRules Rules
-		wantErr   bool
+		name        string
+		user        user.Info
+		clusterName string
+		wantRules   Rules
+		wantErr     bool
 	}{
 		// user with one CRTB in the namespace
 		{
-			name:      "single CRTB rules",
-			user:      NewUserInfo(c.user1AdminCRTB.UserName),
-			namespace: c.user1AdminCRTB.Namespace,
-			wantRules: c.adminRT.Rules,
+			name:        "single CRTB rules",
+			user:        NewUserInfo(c.user1AdminCRTB.UserName),
+			clusterName: c.user1AdminCRTB.ClusterName,
+			wantRules:   c.adminRT.Rules,
 		},
 		// user that belongs to no CRTBs no rules
 		{
-			name:      "user with no rules",
-			user:      NewUserInfo("invalidUser"),
-			namespace: c.user1AdminCRTB.Namespace,
-			wantRules: nil,
+			name:        "user with no rules",
+			user:        NewUserInfo("invalidUser"),
+			clusterName: c.user1AdminCRTB.ClusterName,
+			wantRules:   nil,
 		},
 		// users with CRTB in different namespace no rules
 		{
-			name:      "user with no rules in namespace",
-			user:      NewUserInfo(c.user2WriteCRTB.UserName),
-			namespace: c.user1AReadNS2CRTB.Namespace,
-			wantRules: nil,
+			name:        "user with no rules in namespace",
+			user:        NewUserInfo(c.user2WriteCRTB.UserName),
+			clusterName: c.user1AReadNS2CRTB.ClusterName,
+			wantRules:   nil,
 		},
 		// user with two CRTB
 		{
-			name:      "user with multiple CRTB",
-			user:      NewUserInfo(c.user2ReadCRTB.UserName),
-			namespace: c.user2ReadCRTB.Namespace,
-			wantRules: append(c.readRT.Rules, c.writeRT.Rules...),
+			name:        "user with multiple CRTB",
+			user:        NewUserInfo(c.user2ReadCRTB.UserName),
+			clusterName: c.user2ReadCRTB.ClusterName,
+			wantRules:   copySlices(c.readRT.Rules, c.writeRT.Rules),
 		},
 		// users with one valid and one invalid CRTB partial rules
 		{
-			name:      "partial rules",
-			user:      NewUserInfo(c.user1InvalidNS2CRTB.UserName),
-			namespace: c.user1InvalidNS2CRTB.Namespace,
-			wantRules: c.readRT.Rules,
-			wantErr:   true,
+			name:        "partial rules",
+			user:        NewUserInfo(c.user1InvalidNS2CRTB.UserName),
+			clusterName: c.user1InvalidNS2CRTB.ClusterName,
+			wantRules:   c.readRT.Rules,
+			wantErr:     true,
+		},
+		// user with a CRTB from a group
+		{
+			name:        "admin rules from group",
+			user:        NewUserInfo("invalidUser", adminGroup),
+			clusterName: c.groupAdminCRTB.ClusterName,
+			wantRules:   c.adminRT.Rules,
+			wantErr:     false,
+		},
+
+		// user with a CRTB from a group in different namespace with different permissions
+		{
+			name:        "admin rules from group different namespace",
+			user:        NewUserInfo("invalidUser", adminGroup),
+			clusterName: c.group2WriteCRTB.ClusterName,
+			wantRules:   c.writeRT.Rules,
+			wantErr:     false,
+		},
+
+		// user with CRTB from a group in unknown namespace
+		{
+			name:        "admin rules from group wrong namespace",
+			user:        NewUserInfo("invalidUser", adminGroup),
+			clusterName: "invalid-namespace",
+			wantRules:   nil,
+			wantErr:     false,
+		},
+
+		// user with two CRTBs from the same group
+		{
+			name:        "partial rules from groups",
+			user:        NewUserInfo("invalidUser", authGroup),
+			clusterName: c.groupAdminCRTB.ClusterName,
+			wantRules:   copySlices(c.readRT.Rules, c.writeRT.Rules),
+			wantErr:     false,
+		},
+
+		// user with three CRTBs from different groups
+		{
+			name:        "multiple groups",
+			user:        NewUserInfo("invalidUser", authGroup, adminGroup),
+			clusterName: c.groupAdminCRTB.ClusterName,
+			wantRules:   copySlices(c.readRT.Rules, c.writeRT.Rules, c.adminRT.Rules),
+			wantErr:     false,
 		},
 	}
 	for _, tt := range tests {
 		c.Run(tt.name, func() {
-			gotRules, err := resolver.RulesFor(tt.user, tt.namespace)
+			gotRules, err := resolver.RulesFor(tt.user, tt.clusterName)
 			if tt.wantErr {
 				c.Errorf(err, "CRTBRuleResolver.RulesFor() error = %v, wantErr %v", err, tt.wantErr)
 				// still check result because function is suppose to return partial results.
@@ -188,9 +267,10 @@ func (c *CRTBResolverSuite) TestCRTBRuleResolver() {
 		})
 	}
 }
-func (c *CRTBResolverSuite) NewTestCRTBResolver() *resolvers.CRTBRuleResolver {
+func (c *CRTBResolverSuite) NewTestCRTBResolver() *CRTBRuleResolver {
 	ctrl := gomock.NewController(c.T())
-	bindings := []*apisv3.ClusterRoleTemplateBinding{c.user1AdminCRTB, c.user1AReadNS2CRTB, c.user1InvalidNS2CRTB, c.user2WriteCRTB, c.user2ReadCRTB}
+	bindings := []*apisv3.ClusterRoleTemplateBinding{c.user1AdminCRTB, c.user1AReadNS2CRTB, c.user1InvalidNS2CRTB,
+		c.user2WriteCRTB, c.user2ReadCRTB, c.groupAdminCRTB, c.groupReadCRTB, c.groupWriteCRTB, c.group2WriteCRTB}
 	crtbCache := NewCRTBCache(ctrl, bindings)
 	clusterRoleCache := fakes.NewMockClusterRoleCache(ctrl)
 	roleTemplateCache := fakes.NewMockRoleTemplateCache(ctrl)
@@ -199,7 +279,7 @@ func (c *CRTBResolverSuite) NewTestCRTBResolver() *resolvers.CRTBRuleResolver {
 	roleTemplateCache.EXPECT().Get(c.writeRT.Name).Return(c.writeRT, nil).AnyTimes()
 	roleTemplateCache.EXPECT().Get(invalidName).Return(nil, errNotFound).AnyTimes()
 	roleResolver := auth.NewRoleTemplateResolver(roleTemplateCache, clusterRoleCache)
-	return resolvers.NewCRTBRuleResolver(crtbCache, roleResolver)
+	return NewCRTBRuleResolver(crtbCache, roleResolver)
 }
 
 func NewCRTBCache(ctrl *gomock.Controller, bindings []*apisv3.ClusterRoleTemplateBinding) v3.ClusterRoleTemplateBindingCache {
@@ -213,12 +293,18 @@ func NewCRTBCache(ctrl *gomock.Controller, bindings []*apisv3.ClusterRoleTemplat
 		}
 		return nil, errNotFound
 	}).AnyTimes()
-
-	clusterCache.EXPECT().List(gomock.Any(), gomock.Any()).DoAndReturn(func(namespace string, _ interface{}) ([]*apisv3.ClusterRoleTemplateBinding, error) {
+	clusterCache.EXPECT().AddIndexer(crtbSubjectIndex, gomock.Any()).AnyTimes()
+	clusterCache.EXPECT().GetByIndex(crtbSubjectIndex, gomock.Any()).DoAndReturn(func(index string, subject string) ([]*apisv3.ClusterRoleTemplateBinding, error) {
 		retList := []*apisv3.ClusterRoleTemplateBinding{}
+		// for each binding create a lists of subject keys from the binding
+		// if the provided subject matches any of those keys at the binding to the returned list
 		for _, binding := range bindings {
-			if binding.Namespace == namespace {
-				retList = append(retList, binding)
+			keys, _ := crtbBySubject(binding)
+			for _, key := range keys {
+				if key == subject {
+					retList = append(retList, binding)
+					break
+				}
 			}
 		}
 		return retList, nil

--- a/pkg/resolvers/prtbResolver.go
+++ b/pkg/resolvers/prtbResolver.go
@@ -2,12 +2,17 @@ package resolvers
 
 import (
 	"fmt"
+	"strings"
 
+	apisv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/webhook/pkg/auth"
 	v3 "github.com/rancher/webhook/pkg/generated/controllers/management.cattle.io/v3"
 	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+const (
+	prtbSubjectIndex = "management.cattle.io/prtb-by-subject"
 )
 
 // PRTBRuleResolver implements the validation.AuthorizationRuleResolver interface.
@@ -17,9 +22,12 @@ type PRTBRuleResolver struct {
 }
 
 // NewPRTBRuleResolver will create a new PRTBRuleResolver.
-func NewPRTBRuleResolver(prtb v3.ProjectRoleTemplateBindingCache, roleTemplateResolver *auth.RoleTemplateResolver) *PRTBRuleResolver {
+// This function can only be called once for each unique instance of prtbCache.
+func NewPRTBRuleResolver(prtbCache v3.ProjectRoleTemplateBindingCache, roleTemplateResolver *auth.RoleTemplateResolver) *PRTBRuleResolver {
+	prtbCache.AddIndexer(prtbSubjectIndex, prtbBySubject)
+
 	return &PRTBRuleResolver{
-		ProjectRoleTemplateBindings: prtb,
+		ProjectRoleTemplateBindings: prtbCache,
 		RoleTemplateResolver:        roleTemplateResolver,
 	}
 }
@@ -42,18 +50,61 @@ func (p *PRTBRuleResolver) RulesFor(user user.Info, namespace string) ([]rbacv1.
 // VisitRulesFor invokes visitor() with each rule that applies to a given user in a given namespace, and each error encountered resolving those rules.
 // If visitor() returns false, visiting is short-circuited.
 func (p *PRTBRuleResolver) VisitRulesFor(user user.Info, namespace string, visitor func(source fmt.Stringer, rule *rbacv1.PolicyRule, err error) bool) {
-	prtbs, err := p.ProjectRoleTemplateBindings.List(namespace, labels.Everything())
-	if err != nil {
-		visitor(nil, nil, err)
-	}
-
-	for _, prtb := range prtbs {
-		if prtb.UserName != user.GetName() {
+	// for each group check if there are any PRTBs that match subject and namespace using the indexer.
+	// For each returned binding get a list of it's rules with the RoleTemplateResolver and call visit for each rule.
+	for _, group := range user.GetGroups() {
+		prtbs, err := p.ProjectRoleTemplateBindings.GetByIndex(prtbSubjectIndex, GetGroupKey(group, namespace))
+		if err != nil {
+			visitor(nil, nil, err)
 			continue
 		}
+		for _, prtb := range prtbs {
+			rtRules, err := p.RoleTemplateResolver.RulesFromTemplateName(prtb.RoleTemplateName)
+			if !visitRules(nil, rtRules, err, visitor) {
+				return
+			}
+		}
+	}
+
+	// gather all PRTBs that match this userName and namespace and resolve there rules.
+	prtbs, err := p.ProjectRoleTemplateBindings.GetByIndex(prtbSubjectIndex, GetUserKey(user.GetName(), namespace))
+	if err != nil {
+		visitor(nil, nil, err)
+		return
+	}
+	for _, prtb := range prtbs {
 		rtRules, err := p.RoleTemplateResolver.RulesFromTemplateName(prtb.RoleTemplateName)
 		if !visitRules(nil, rtRules, err, visitor) {
 			return
 		}
 	}
+}
+
+func prtbBySubject(prtb *apisv3.ProjectRoleTemplateBinding) ([]string, error) {
+	namespace, ok := namespaceFromProject(prtb.ProjectName)
+	if !ok {
+		// if we can not determine the namespace from the project name do not index
+		return nil, nil
+	}
+	if prtb.UserName != "" {
+		return []string{GetUserKey(prtb.UserName, namespace)}, nil
+	}
+	if prtb.GroupName != "" {
+		return []string{GetGroupKey(prtb.GroupName, namespace)}, nil
+	}
+	if prtb.GroupPrincipalName != "" {
+		return []string{GetGroupKey(prtb.GroupPrincipalName, namespace)}, nil
+	}
+	return nil, nil
+}
+
+// split a project name on ":" if there are not two parts
+// then we can not confidently discern which namespace this project belongs too.
+func namespaceFromProject(projectName string) (string, bool) {
+	// example projectName c-m-csdf:p-sersd
+	pieces := strings.Split(projectName, ":")
+	if len(pieces) != 2 {
+		return "", false
+	}
+	return pieces[1], true
 }

--- a/pkg/resolvers/prtbResolver_test.go
+++ b/pkg/resolvers/prtbResolver_test.go
@@ -1,4 +1,4 @@
-package resolvers_test
+package resolvers
 
 import (
 	"testing"
@@ -8,7 +8,6 @@ import (
 	"github.com/rancher/webhook/pkg/auth"
 	"github.com/rancher/webhook/pkg/fakes"
 	v3 "github.com/rancher/webhook/pkg/generated/controllers/management.cattle.io/v3"
-	"github.com/rancher/webhook/pkg/resolvers"
 	"github.com/stretchr/testify/suite"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,6 +24,10 @@ type PRTBResolverSuite struct {
 	user1InvalidNS2PRTB *apisv3.ProjectRoleTemplateBinding
 	user2WritePRTB      *apisv3.ProjectRoleTemplateBinding
 	user2ReadPRTB       *apisv3.ProjectRoleTemplateBinding
+	groupReadPRTB       *apisv3.ProjectRoleTemplateBinding
+	groupWritePRTB      *apisv3.ProjectRoleTemplateBinding
+	groupAdminPRTB      *apisv3.ProjectRoleTemplateBinding
+	group2WritePRTB     *apisv3.ProjectRoleTemplateBinding
 }
 
 func TestPRTBResolver(t *testing.T) {
@@ -82,43 +85,75 @@ func (p *PRTBResolverSuite) SetupSuite() {
 	}
 	p.user1AdminPRTB = &apisv3.ProjectRoleTemplateBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "user1-admin",
-			Namespace: "namespace1",
+			Name: "user1-admin",
 		},
+		ProjectName:      "p-2d2:p-ort",
 		UserName:         "user1",
 		RoleTemplateName: p.adminRT.Name,
 	}
 	p.user1AReadNS2PRTB = &apisv3.ProjectRoleTemplateBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "user1-read",
-			Namespace: "namespace2",
+			Name: "user1-read",
 		},
+		ProjectName:      "p-over:p-ork",
 		UserName:         "user1",
 		RoleTemplateName: p.readRT.Name,
 	}
 	p.user1InvalidNS2PRTB = &apisv3.ProjectRoleTemplateBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "user1-invalid",
-			Namespace: "namespace2",
+			Name: "user1-invalid",
 		},
+		ProjectName:      "p-over:p-ork",
 		UserName:         "user1",
 		RoleTemplateName: invalidName,
 	}
 	p.user2WritePRTB = &apisv3.ProjectRoleTemplateBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "user2-write",
-			Namespace: "namespace1",
+			Name: "user2-write",
 		},
+		ProjectName:      "p-2d2:p-ort",
 		UserName:         "user2",
 		RoleTemplateName: p.writeRT.Name,
 	}
 	p.user2ReadPRTB = &apisv3.ProjectRoleTemplateBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "user2-read",
-			Namespace: "namespace1",
+			Name: "user2-read",
 		},
+		ProjectName:      "p-2d2:p-ort",
 		UserName:         "user2",
 		RoleTemplateName: p.readRT.Name,
+	}
+	p.groupReadPRTB = &apisv3.ProjectRoleTemplateBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "group-read",
+		},
+		ProjectName:      "p-3p0:p-appy",
+		GroupName:        authGroup,
+		RoleTemplateName: p.readRT.Name,
+	}
+	p.groupWritePRTB = &apisv3.ProjectRoleTemplateBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "group-write",
+		},
+		ProjectName:        "p-3p0:p-appy",
+		GroupPrincipalName: authGroup,
+		RoleTemplateName:   p.writeRT.Name,
+	}
+	p.group2WritePRTB = &apisv3.ProjectRoleTemplateBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "group2-write",
+		},
+		ProjectName:        "p-3p0:p-aul",
+		GroupPrincipalName: adminGroup,
+		RoleTemplateName:   p.writeRT.Name,
+	}
+	p.groupAdminPRTB = &apisv3.ProjectRoleTemplateBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "group-admin",
+		},
+		ProjectName:      "p-3p0:p-appy",
+		GroupName:        adminGroup,
+		RoleTemplateName: p.adminRT.Name,
 	}
 }
 
@@ -126,52 +161,98 @@ func (p *PRTBResolverSuite) TestPRTBRuleResolver() {
 	resolver := p.NewTestPRTBResolver()
 
 	tests := []struct {
-		name      string
-		user      user.Info
-		namespace string
-		wantRules Rules
-		wantErr   bool
+		name        string
+		user        user.Info
+		projectName string
+		wantRules   Rules
+		wantErr     bool
 	}{
 		// user with one PRTB in the namespace
 		{
-			name:      "single PRTB rules",
-			user:      NewUserInfo(p.user1AdminPRTB.UserName),
-			namespace: p.user1AdminPRTB.Namespace,
-			wantRules: p.adminRT.Rules,
+			name:        "single PRTB rules",
+			user:        NewUserInfo(p.user1AdminPRTB.UserName),
+			projectName: p.user1AdminPRTB.ProjectName,
+			wantRules:   p.adminRT.Rules,
 		},
 		// user that belongs to no PRTBs no rules
 		{
-			name:      "user with no rules",
-			user:      NewUserInfo("invalidUser"),
-			namespace: p.user1AdminPRTB.Namespace,
-			wantRules: nil,
+			name:        "user with no rules",
+			user:        NewUserInfo("invalidUser"),
+			projectName: p.user1AdminPRTB.ProjectName,
+			wantRules:   nil,
 		},
 		// users with PRTB in different namespace no rules
 		{
-			name:      "user with no rules in namespace",
-			user:      NewUserInfo(p.user2WritePRTB.UserName),
-			namespace: p.user1AReadNS2PRTB.Namespace,
-			wantRules: nil,
+			name:        "user with no rules in namespace",
+			user:        NewUserInfo(p.user2WritePRTB.UserName),
+			projectName: p.user1AReadNS2PRTB.ProjectName,
+			wantRules:   nil,
 		},
 		// user with two PRTB
 		{
-			name:      "user with multiple PRTB",
-			user:      NewUserInfo(p.user2ReadPRTB.UserName),
-			namespace: p.user2ReadPRTB.Namespace,
-			wantRules: append(p.readRT.Rules, p.writeRT.Rules...),
+			name:        "user with multiple PRTB",
+			user:        NewUserInfo(p.user2ReadPRTB.UserName),
+			projectName: p.user2ReadPRTB.ProjectName,
+			wantRules:   append(p.readRT.Rules, p.writeRT.Rules...),
 		},
 		// users with one valid and one invalid PRTB partial rules
 		{
-			name:      "partial rules",
-			user:      NewUserInfo(p.user1InvalidNS2PRTB.UserName),
-			namespace: p.user1InvalidNS2PRTB.Namespace,
-			wantRules: p.readRT.Rules,
-			wantErr:   true,
+			name:        "partial rules",
+			user:        NewUserInfo(p.user1InvalidNS2PRTB.UserName),
+			projectName: p.user1InvalidNS2PRTB.ProjectName,
+			wantRules:   p.readRT.Rules,
+			wantErr:     true,
+		},
+		// user with a PRTB from a group
+		{
+			name:        "admin rules from group",
+			user:        NewUserInfo("invalidUser", adminGroup),
+			projectName: p.groupAdminPRTB.ProjectName,
+			wantRules:   p.adminRT.Rules,
+			wantErr:     false,
+		},
+
+		// user with a PRTB from a group in different namespace with different permissions
+		{
+			name:        "admin rules from group different namespace",
+			user:        NewUserInfo("invalidUser", adminGroup),
+			projectName: p.group2WritePRTB.ProjectName,
+			wantRules:   p.writeRT.Rules,
+			wantErr:     false,
+		},
+
+		// user with a PRTB from the group in unknown namespace
+		{
+			name:        "admin rules from group wrong namespace",
+			user:        NewUserInfo("invalidUser", adminGroup),
+			projectName: "invalid-namespace:invalid-project",
+			wantRules:   nil,
+			wantErr:     false,
+		},
+
+		// user with two PRTBs from the same group
+		{
+			name:        "partial rules from groups",
+			user:        NewUserInfo("invalidUser", authGroup),
+			projectName: p.groupAdminPRTB.ProjectName,
+			wantRules:   copySlices(p.readRT.Rules, p.writeRT.Rules),
+			wantErr:     false,
+		},
+
+		// user with three PRTBs from different group
+		{
+			name:        "multiple groups",
+			user:        NewUserInfo("invalidUser", authGroup, adminGroup),
+			projectName: p.groupAdminPRTB.ProjectName,
+			wantRules:   copySlices(p.readRT.Rules, p.writeRT.Rules, p.adminRT.Rules),
+			wantErr:     false,
 		},
 	}
 	for _, tt := range tests {
 		p.Run(tt.name, func() {
-			gotRules, err := resolver.RulesFor(tt.user, tt.namespace)
+			namespace, ok := namespaceFromProject(tt.projectName)
+			p.Require().True(ok, "failed to split project namespace from project name")
+			gotRules, err := resolver.RulesFor(tt.user, namespace)
 			if tt.wantErr {
 				p.Errorf(err, "PRTBRuleResolver.RulesFor() error = %v, wantErr %v", err, tt.wantErr)
 				// still check result because function is suppose to return partial results.
@@ -189,9 +270,10 @@ func (p *PRTBResolverSuite) TestPRTBRuleResolver() {
 	}
 }
 
-func (p *PRTBResolverSuite) NewTestPRTBResolver() *resolvers.PRTBRuleResolver {
+func (p *PRTBResolverSuite) NewTestPRTBResolver() *PRTBRuleResolver {
 	ctrl := gomock.NewController(p.T())
-	bindings := []*apisv3.ProjectRoleTemplateBinding{p.user1AdminPRTB, p.user1AReadNS2PRTB, p.user1InvalidNS2PRTB, p.user2WritePRTB, p.user2ReadPRTB}
+	bindings := []*apisv3.ProjectRoleTemplateBinding{p.user1AdminPRTB, p.user1AReadNS2PRTB, p.user1InvalidNS2PRTB,
+		p.user2WritePRTB, p.user2ReadPRTB, p.groupAdminPRTB, p.groupReadPRTB, p.groupWritePRTB, p.group2WritePRTB}
 	PRTBCache := NewPRTBCache(ctrl, bindings)
 	clusterRoleCache := fakes.NewMockClusterRoleCache(ctrl)
 	roleTemplateCache := fakes.NewMockRoleTemplateCache(ctrl)
@@ -200,26 +282,26 @@ func (p *PRTBResolverSuite) NewTestPRTBResolver() *resolvers.PRTBRuleResolver {
 	roleTemplateCache.EXPECT().Get(p.writeRT.Name).Return(p.writeRT, nil).AnyTimes()
 	roleTemplateCache.EXPECT().Get(invalidName).Return(nil, errNotFound).AnyTimes()
 	roleResolver := auth.NewRoleTemplateResolver(roleTemplateCache, clusterRoleCache)
-	return resolvers.NewPRTBRuleResolver(PRTBCache, roleResolver)
+	return NewPRTBRuleResolver(PRTBCache, roleResolver)
 }
 
 func NewPRTBCache(ctrl *gomock.Controller, bindings []*apisv3.ProjectRoleTemplateBinding) v3.ProjectRoleTemplateBindingCache {
 	projectCache := fakes.NewMockProjectRoleTemplateBindingCache(ctrl)
 
-	projectCache.EXPECT().Get(gomock.Any(), gomock.Any()).DoAndReturn(func(namespace, name string) (*apisv3.ProjectRoleTemplateBinding, error) {
-		for _, binding := range bindings {
-			if binding.Namespace == namespace && binding.Name == name {
-				return binding, nil
-			}
-		}
-		return nil, errNotFound
-	}).AnyTimes()
+	projectCache.EXPECT().AddIndexer(prtbSubjectIndex, gomock.Any()).AnyTimes()
 
-	projectCache.EXPECT().List(gomock.Any(), gomock.Any()).DoAndReturn(func(namespace string, _ interface{}) ([]*apisv3.ProjectRoleTemplateBinding, error) {
+	projectCache.EXPECT().GetByIndex(prtbSubjectIndex, gomock.Any()).DoAndReturn(func(index string, subject string) ([]*apisv3.ProjectRoleTemplateBinding, error) {
 		retList := []*apisv3.ProjectRoleTemplateBinding{}
+
+		// for each binding create a lists of subject keys from the binding
+		// if the provided subject matches any of those keys at the binding to the returned list
 		for _, binding := range bindings {
-			if binding.Namespace == namespace {
-				retList = append(retList, binding)
+			keys, _ := prtbBySubject(binding)
+			for _, key := range keys {
+				if key == subject {
+					retList = append(retList, binding)
+					break
+				}
 			}
 		}
 		return retList, nil

--- a/pkg/resolvers/resolvers.go
+++ b/pkg/resolvers/resolvers.go
@@ -53,3 +53,13 @@ func visitRules(source fmt.Stringer, rules []rbacv1.PolicyRule, err error, visit
 	}
 	return true
 }
+
+// GetUserKey creates a indexer key based on the userName, and namespace of an object.
+func GetUserKey(userName, namespace string) string {
+	return fmt.Sprintf("user:%s-%s", userName, namespace)
+}
+
+// GetGroupKey creates a indexer key based on the groupName, and namespace of an object.
+func GetGroupKey(groupName, namespace string) string {
+	return fmt.Sprintf("group:%s-%s", groupName, namespace)
+}

--- a/pkg/resolvers/resolvers_test.go
+++ b/pkg/resolvers/resolvers_test.go
@@ -1,4 +1,4 @@
-package resolvers_test
+package resolvers
 
 import (
 	"encoding/json"
@@ -12,7 +12,11 @@ import (
 
 var errNotFound = errors.New("notFound")
 
-const invalidName = "invalidName"
+const (
+	invalidName = "invalidName"
+	adminGroup  = "adminGroup"
+	authGroup   = "auth://group"
+)
 
 type Rules []rbacv1.PolicyRule
 
@@ -46,8 +50,21 @@ func (r Rules) Equal(r2 Rules) bool {
 	}
 	return true
 }
-func NewUserInfo(username string) *user.DefaultInfo {
+func NewUserInfo(username string, groups ...string) *user.DefaultInfo {
 	return &user.DefaultInfo{
-		Name: username,
+		Name:   username,
+		Groups: groups,
 	}
+}
+
+// copySlices copies multiple rule list into one large list.
+// this is used instead of append so that the original list are not modified.
+func copySlices(slices ...[]rbacv1.PolicyRule) []rbacv1.PolicyRule {
+	ret := []rbacv1.PolicyRule{}
+	for _, slice := range slices {
+		for _, rule := range slice {
+			ret = append(ret, rule)
+		}
+	}
+	return ret
 }

--- a/pkg/resources/validation/clusterroletemplatebinding/clusterrtb.go
+++ b/pkg/resources/validation/clusterroletemplatebinding/clusterrtb.go
@@ -8,7 +8,6 @@ import (
 	apisv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/webhook/pkg/admission"
 	"github.com/rancher/webhook/pkg/auth"
-	v3 "github.com/rancher/webhook/pkg/generated/controllers/management.cattle.io/v3"
 	objectsv3 "github.com/rancher/webhook/pkg/generated/objects/management.cattle.io/v3"
 	"github.com/rancher/webhook/pkg/resolvers"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -27,9 +26,9 @@ var gvr = schema.GroupVersionResource{
 }
 
 // NewValidator will create a newly allocated Validator.
-func NewValidator(crtb v3.ClusterRoleTemplateBindingCache, defaultResolver k8validation.AuthorizationRuleResolver,
+func NewValidator(crtb *resolvers.CRTBRuleResolver, defaultResolver k8validation.AuthorizationRuleResolver,
 	roleTemplateResolver *auth.RoleTemplateResolver) *Validator {
-	resolver := resolvers.NewAggregateRuleResolver(defaultResolver, resolvers.NewCRTBRuleResolver(crtb, roleTemplateResolver))
+	resolver := resolvers.NewAggregateRuleResolver(defaultResolver, crtb)
 	return &Validator{
 		resolver:             resolver,
 		roleTemplateResolver: roleTemplateResolver,

--- a/pkg/resources/validation/projectroletemplatebinding/projectrtb.go
+++ b/pkg/resources/validation/projectroletemplatebinding/projectrtb.go
@@ -9,7 +9,6 @@ import (
 	apisv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/webhook/pkg/admission"
 	"github.com/rancher/webhook/pkg/auth"
-	v3 "github.com/rancher/webhook/pkg/generated/controllers/management.cattle.io/v3"
 	objectsv3 "github.com/rancher/webhook/pkg/generated/objects/management.cattle.io/v3"
 	"github.com/rancher/webhook/pkg/resolvers"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -28,10 +27,10 @@ var gvr = schema.GroupVersionResource{
 }
 
 // NewValidator returns a new validator used for validation PRTB.
-func NewValidator(prtb v3.ProjectRoleTemplateBindingCache, crtb v3.ClusterRoleTemplateBindingCache,
+func NewValidator(prtb *resolvers.PRTBRuleResolver, crtb *resolvers.CRTBRuleResolver,
 	defaultResolver k8validation.AuthorizationRuleResolver, roleTemplateResolver *auth.RoleTemplateResolver) *Validator {
-	clusterResolver := resolvers.NewAggregateRuleResolver(defaultResolver, resolvers.NewCRTBRuleResolver(crtb, roleTemplateResolver))
-	projectResolver := resolvers.NewAggregateRuleResolver(defaultResolver, resolvers.NewPRTBRuleResolver(prtb, roleTemplateResolver))
+	clusterResolver := resolvers.NewAggregateRuleResolver(defaultResolver, crtb)
+	projectResolver := resolvers.NewAggregateRuleResolver(defaultResolver, prtb)
 	return &Validator{
 		clusterResolver:      clusterResolver,
 		projectResolver:      projectResolver,

--- a/pkg/resources/validation/projectroletemplatebinding/projectrtb_test.go
+++ b/pkg/resources/validation/projectroletemplatebinding/projectrtb_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rancher/webhook/pkg/admission"
 	"github.com/rancher/webhook/pkg/auth"
 	"github.com/rancher/webhook/pkg/fakes"
+	"github.com/rancher/webhook/pkg/resolvers"
 	"github.com/rancher/webhook/pkg/resources/validation/projectroletemplatebinding"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -143,22 +144,26 @@ func (p *ProjectRoleTemplateBindingSuite) Test_PrivilegeEscalation() {
 	clusterRoleCache := fakes.NewMockClusterRoleCache(ctrl)
 	roleResolver := auth.NewRoleTemplateResolver(roleTemplateCache, clusterRoleCache)
 	prtbCache := fakes.NewMockProjectRoleTemplateBindingCache(ctrl)
-	prtbCache.EXPECT().List(projectID, gomock.Any()).Return([]*apisv3.ProjectRoleTemplateBinding{
-		{
-			UserName:         prtbUser,
-			RoleTemplateName: p.adminRT.Name,
-		},
+	prtbCache.EXPECT().AddIndexer(gomock.Any(), gomock.Any())
+	prtbCache.EXPECT().GetByIndex(gomock.Any(), resolvers.GetUserKey(prtbUser, projectID)).Return([]*apisv3.ProjectRoleTemplateBinding{{
+		UserName:         prtbUser,
+		RoleTemplateName: p.adminRT.Name,
+	},
 	}, nil).AnyTimes()
+	prtbCache.EXPECT().GetByIndex(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	crtbCache := fakes.NewMockClusterRoleTemplateBindingCache(ctrl)
-	crtbCache.EXPECT().List(clusterID, gomock.Any()).Return([]*apisv3.ClusterRoleTemplateBinding{
+	crtbCache.EXPECT().AddIndexer(gomock.Any(), gomock.Any())
+	crtbCache.EXPECT().GetByIndex(gomock.Any(), resolvers.GetUserKey(crtbUser, clusterID)).Return([]*apisv3.ClusterRoleTemplateBinding{
 		{
 			UserName:         crtbUser,
 			RoleTemplateName: p.adminRT.Name,
 		},
 	}, nil).AnyTimes()
-	validator := projectroletemplatebinding.NewValidator(prtbCache, crtbCache, resolver,
-		roleResolver,
-	)
+	crtbCache.EXPECT().GetByIndex(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+	crtbResolver := resolvers.NewCRTBRuleResolver(crtbCache, roleResolver)
+	prtbResolver := resolvers.NewPRTBRuleResolver(prtbCache, roleResolver)
+	validator := projectroletemplatebinding.NewValidator(prtbResolver, crtbResolver, resolver, roleResolver)
 	type args struct {
 		oldPRTB  func() *apisv3.ProjectRoleTemplateBinding
 		newPRTB  func() *apisv3.ProjectRoleTemplateBinding
@@ -306,10 +311,14 @@ func (p *ProjectRoleTemplateBindingSuite) Test_UpdateValidation() {
 	clusterRoleCache := fakes.NewMockClusterRoleCache(ctrl)
 	roleResolver := auth.NewRoleTemplateResolver(roleTemplateCache, clusterRoleCache)
 	prtbCache := fakes.NewMockProjectRoleTemplateBindingCache(ctrl)
-	prtbCache.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	prtbCache.EXPECT().AddIndexer(gomock.Any(), gomock.Any())
+	prtbCache.EXPECT().GetByIndex(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	crtbCache := fakes.NewMockClusterRoleTemplateBindingCache(ctrl)
-	crtbCache.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
-	validator := projectroletemplatebinding.NewValidator(prtbCache, crtbCache, resolver, roleResolver)
+	crtbCache.EXPECT().AddIndexer(gomock.Any(), gomock.Any())
+	crtbCache.EXPECT().GetByIndex(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	crtbResolver := resolvers.NewCRTBRuleResolver(crtbCache, roleResolver)
+	prtbResolver := resolvers.NewPRTBRuleResolver(prtbCache, roleResolver)
+	validator := projectroletemplatebinding.NewValidator(prtbResolver, crtbResolver, resolver, roleResolver)
 	type args struct {
 		oldPRTB  func() *apisv3.ProjectRoleTemplateBinding
 		newPRTB  func() *apisv3.ProjectRoleTemplateBinding
@@ -601,11 +610,14 @@ func (p *ProjectRoleTemplateBindingSuite) Test_Create() {
 	clusterRoleCache := fakes.NewMockClusterRoleCache(ctrl)
 	roleResolver := auth.NewRoleTemplateResolver(roleTemplateCache, clusterRoleCache)
 	prtbCache := fakes.NewMockProjectRoleTemplateBindingCache(ctrl)
-	prtbCache.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	prtbCache.EXPECT().AddIndexer(gomock.Any(), gomock.Any())
+	prtbCache.EXPECT().GetByIndex(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	crtbCache := fakes.NewMockClusterRoleTemplateBindingCache(ctrl)
-	crtbCache.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
-	validator := projectroletemplatebinding.NewValidator(prtbCache, crtbCache, resolver, roleResolver)
-
+	crtbCache.EXPECT().AddIndexer(gomock.Any(), gomock.Any())
+	crtbCache.EXPECT().GetByIndex(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	crtbResolver := resolvers.NewCRTBRuleResolver(crtbCache, roleResolver)
+	prtbResolver := resolvers.NewPRTBRuleResolver(prtbCache, roleResolver)
+	validator := projectroletemplatebinding.NewValidator(prtbResolver, crtbResolver, resolver, roleResolver)
 	type args struct {
 		oldPRTB  func() *apisv3.ProjectRoleTemplateBinding
 		newPRTB  func() *apisv3.ProjectRoleTemplateBinding


### PR DESCRIPTION
Forward Port: https://github.com/rancher/webhook/pull/195
This commit updates the CRTB and PRTB ruleResolvers to use CRTBs and PRTBs with matching groups as well as matching usernames. This commit also updates the caches used by the resolvers to have a new indexer that index on a composite key of the binding subject and the clusterName or ProjectName of the binding.