### PR TITLE
[DNM] Do not allow CRTB and PRTB names to be longer than 63 characters

### DIFF
--- a/pkg/resources/validation/clusterroletemplatebinding/clusterrtb_test.go
+++ b/pkg/resources/validation/clusterroletemplatebinding/clusterrtb_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -616,6 +617,22 @@ func (c *ClusterRoleTemplateBindingSuite) Test_Create() {
 				newCRTB: func() *apisv3.ClusterRoleTemplateBinding {
 					baseCRTB := newDefaultCRTB()
 					baseCRTB.ClusterName = ""
+					return baseCRTB
+				},
+			},
+			allowed: false,
+		},
+		{
+			name: "combined name too long",
+			args: args{
+				username: adminUser,
+				oldCRTB: func() *apisv3.ClusterRoleTemplateBinding {
+					return nil
+				},
+				newCRTB: func() *apisv3.ClusterRoleTemplateBinding {
+					baseCRTB := newDefaultCRTB()
+					baseCRTB.ClusterName = "foobar"
+					baseCRTB.Name = strings.Repeat("hello", 12)
 					return baseCRTB
 				},
 			},

--- a/pkg/resources/validation/projectroletemplatebinding/projectrtb_test.go
+++ b/pkg/resources/validation/projectroletemplatebinding/projectrtb_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -642,6 +643,22 @@ func (p *ProjectRoleTemplateBindingSuite) Test_Create() {
 				},
 			},
 			allowed: true,
+		},
+		{
+			name: "combined name too long",
+			args: args{
+				username: adminUser,
+				oldPRTB: func() *apisv3.ProjectRoleTemplateBinding {
+					return nil
+				},
+				newPRTB: func() *apisv3.ProjectRoleTemplateBinding {
+					basePRTB := newBasePRTB()
+					basePRTB.ProjectName = "foobar"
+					basePRTB.Name = strings.Repeat("hello", 12)
+					return basePRTB
+				},
+			},
+			allowed: false,
 		},
 		{
 			name: "missing roleTemplate",


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/33795

This PR adds validation to CRTB and PRTB names.
The webhook will ensure that a combined name (`projectName_bindingName` for PRTBs and `clusterName_bindingName` for CRTBs) will not exceed 63 characters.