### PR TITLE
Helm version in env var to automatically update

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -7,7 +7,8 @@ RUN zypper -n install git docker vim less file curl wget awk
 RUN if [ "${ARCH}" = "amd64" ]; then \
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.50.1; \
     fi
-RUN curl -sL https://get.helm.sh/helm-v3.8.0-linux-${ARCH}.tar.gz | tar xvzf - -C /usr/local/bin --strip-components=1
+ENV HELM_VERSION v3.11.2
+RUN curl -sL https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz | tar xvzf - -C /usr/local/bin --strip-components=1
 RUN GOBIN=/usr/local/bin go install github.com/golang/mock/mockgen@v1.6.0
 
 ENV DAPPER_ENV REPO TAG DRONE_TAG CROSS


### PR DESCRIPTION
- Updates to latest
- Puts `HELM_VERSION` in environment variable so it can be automatically updated, see https://github.com/rancher/renovate-config/blob/main/default.json#L27