### PR TITLE
Add Startup probe to charts.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -20,6 +20,7 @@ steps:
     image: rancher/rancher:v2.7-head
     privileged: true
     commands:
+      - zypper -n install helm
       - scripts/integration-test
 
   - name: github_binary_release
@@ -88,6 +89,7 @@ steps:
     image: rancher/rancher:v2.7-head
     privileged: true
     commands:
+      - zypper -n install helm
       - scripts/integration-test
 
   - name: github_binary_release
@@ -160,6 +162,7 @@ steps:
     image: rancher/rancher:v2.7-head
     privileged: true
     commands:
+      - zypper -n install helm
       - scripts/integration-test
 
   - name: github_binary_release

--- a/charts/rancher-webhook/templates/deployment.yaml
+++ b/charts/rancher-webhook/templates/deployment.yaml
@@ -48,6 +48,21 @@ spec:
           containerPort: 9443
         - name: capi-https
           containerPort: 8777
+        startupProbe:
+          httpGet:
+            path: "/healthz"
+            port: "https"
+            scheme: "HTTPS"
+          failureThreshold: 60
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        livenessProbe:
+          httpGet:
+            path: "/healthz"
+            port: "https"
+            scheme: "HTTPS"
+          periodSeconds: 5
         {{- if .Values.capi.enabled }}
         volumeMounts:
         - name: tls

--- a/charts/rancher-webhook/templates/deployment.yaml
+++ b/charts/rancher-webhook/templates/deployment.yaml
@@ -55,8 +55,6 @@ spec:
             scheme: "HTTPS"
           failureThreshold: 60
           periodSeconds: 5
-          successThreshold: 1
-          timeoutSeconds: 1
         livenessProbe:
           httpGet:
             path: "/healthz"

--- a/scripts/integration-test
+++ b/scripts/integration-test
@@ -6,42 +6,41 @@ export CATTLE_SERVER_URL="https://$(ip route get 8.8.8.8 | awk '{print $7}'):443
 export CATTLE_BOOTSTRAP_PASSWORD="admin"
 export CATTLE_FEATURES="harvester=false"
 
+cd $(dirname $0)/../
+
 echo "Starting Rancher Server"
 entrypoint.sh >./rancher.log 2>&1 &
 
 echo "Waiting for Rancher health check..."
-while ! curl -sf http://localhost:80/healthz; do
+while ! curl -sf http://localhost:80/healthz >/dev/null 2>&1; do
+    echo "Waiting for Rancher's /healthz endpoint to become available"
     sleep 2
 done
 
-echo "Waiting for Rancher install and rollout rancher-webhook..."
-while ! kubectl rollout status -w -n cattle-system deploy/rancher-webhook; do
+# Tail the rancher logs if rancher fails to deploy the webhook after 5 minutes.
+bash -c "sleep 300 && echo 'Rancher has not deployed webhook after 5m tailing logs' && tail -f ./rancher.log" &
+# Get PID of the tail command so we can kill it if needed
+TAIL_PID=$!
+
+# Wait for Rancher to deploy rancher-webhook.
+while ! kubectl rollout status -w -n cattle-system deploy/rancher-webhook >/dev/null 2>&1; do
+    echo "Waiting for rancher to deploy rancher-webhook..."
     sleep 2
 done
 
-###### Replace the installed webhook image with the one we created
-IMAGE_FILE=$(dirname ${0})/../dist/rancher-webhook-image.tar
+# After rancher deploys webhook kill the bash command running tail.
+kill ${TAIL_PID}
+
+###### Upload the newly created webhook image to containerd, then install the webhook chart using the new image
+IMAGE_FILE=./dist/rancher-webhook-image.tar
 # import image to containerd and get the image name
-WEBHOOK_IMAGE=$(ctr image import ${IMAGE_FILE} | cut -d ' ' -f 2)
+WEBHOOK_REPO=$(ctr image import ${IMAGE_FILE} | cut -d ' ' -f 2 | cut -d ':' -f 1)
 
-# patch the webhook deployment so that it uses are newly created image
-kubectl patch deployment -n cattle-system rancher-webhook --patch \
-    "{ \"spec\": { \"template\": {\"spec\": { \"containers\": [
-    {
-        \"name\": \"rancher-webhook\",
-        \"image\" :\"${WEBHOOK_IMAGE}\",
-        \"startupProbe\": {
-            \"failureThreshold\": 360,
-            \"httpGet\": {
-                \"path\": \"/healthz\",
-                \"port\": \"https\",
-                \"scheme\": \"HTTPS\"
-            },
-            \"periodSeconds\": 5,
-            \"successThreshold\": 1,
-            \"timeoutSeconds\": 1
-        }
-    }]}}}}"
+# Source tags file to get the last built tags
+source ./dist/tags
+
+# Install the webhook chart we just built.
+helm upgrade rancher-webhook ./dist/artifacts/rancher-webhook-${HELM_VERSION}.tgz -n cattle-system --set image.repository=${WEBHOOK_REPO} --set image.tag=${TAG} --reuse-values
 
 while ! kubectl rollout status -w -n cattle-system deploy/rancher-webhook; do
     sleep 2
@@ -49,6 +48,7 @@ done
 
 ./bin/rancher-webhook-integration.test -test.v -test.run IntegrationTest
 
+# Scale down rancher-webhook so that we can run tests on the FailurePolicy
 kubectl scale deploy rancher-webhook -n cattle-system --replicas=0
 kubectl wait pods -l app=rancher-webhook --for=delete -n cattle-system
 ./bin/rancher-webhook-integration.test -test.v -test.run FailurePolicyTest

--- a/scripts/version
+++ b/scripts/version
@@ -29,3 +29,7 @@ if echo $TAG | grep -q dirty; then
     HELM_TAG=dev
     HELM_VERSION=0.0.0-dev
 fi
+
+DIST_DIR="$(dirname $0)/../dist/"
+mkdir -p ${DIST_DIR}
+echo "export TAG=${TAG}; export HELM_TAG=${HELM_TAG}; export HELM_VERSION=${HELM_VERSION};" >${DIST_DIR}/tags


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/40824

Added the startup probe to the rancher-webhook chart so that the Webhook does not appear to be ready before it has updated the validating webhook configuration.
The startup probe checks every 5 seconds for 10 minutes before declaring that the webhook failed to start.
These values seemed reasonable to me but are up for discussion. `5s periodSeconds * 120 failureThreshold`

In the second commit, I updated the integration test to install the newly packaged charts created in CI to provide us with a larger test coverage. I also added a command that will start tailing the rancher logs if Rancher-Webhook fails to deploy after 5 minutes.