### PR TITLE
Port remaining PRTB validation rules from Norman

### DIFF
--- a/tests/integration/projectRoleTemplateBinding_test.go
+++ b/tests/integration/projectRoleTemplateBinding_test.go
@@ -57,6 +57,7 @@ func (m *IntegrationSuite) TestProjectRoleTemplateBinding() {
 				Resources: []string{"pods"},
 			},
 		},
+		Context: "project",
 	}
 	m.createObj(testRT, schema.GroupVersionKind{})
 	validateEndpoints(m.T(), endPoints, m.clientFactory)


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
Remaining validation logic from Norman needs to be ported over to the Webhook.
 
## Solution
1. Validators
exists = Role template must exist.
exists = Role template must be unlocked.
**new  = Role template must belong to its appropriate context (project).**
exists = Either user/userPrincipal OR group/groupPrincipal must exist.

2. Struct tags
        UserName           norman:"noupdate,type=reference[user]"
        UserPrincipalName  norman:"noupdate,type=reference[principal]"
        GroupName          norman:"noupdate,type=reference[group]"
        GroupPrincipalName norman:"noupdate,type=reference[principal]"
        ProjectName        norman:"required,noupdate,type=reference[project]"
        RoleTemplateName   norman:"required,noupdate,type=reference[roleTemplate]"
**new =   ServiceAccount     norman:"nocreate,noupdate"** - will only implement noupdate

3. Store
rtb_store.go Create method - will use a controller
 
4. Formatters: none

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
