### PR TITLE
Add validation for tokens

### DIFF
--- a/pkg/codegen/main.go
+++ b/pkg/codegen/main.go
@@ -59,6 +59,7 @@ func main() {
 				&v3.GlobalRoleBinding{},
 				&v3.RoleTemplate{},
 				&v3.ProjectRoleTemplateBinding{},
+				&v3.Token{},
 			},
 		},
 		"provisioning.cattle.io": {

--- a/pkg/generated/objects/management.cattle.io/v3/objects.go
+++ b/pkg/generated/objects/management.cattle.io/v3/objects.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	admissionv1 "k8s.io/api/admission/v1"
 )
 
@@ -483,4 +483,24 @@ func ProjectRoleTemplateBindingFromRequest(request *admissionv1.AdmissionRequest
 	}
 
 	return object, nil
+}
+
+func TokenOldAndNewFromRequest(request *admissionv1.AdmissionRequest) (*v3.Token, *v3.Token, error) {
+	if request == nil {
+		return nil, nil, fmt.Errorf("nil request")
+	}
+
+	object := &v3.Token{}
+	oldObject := &v3.Token{}
+
+	err := json.Unmarshal(request.Object.Raw, object)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to unmarshal request object: %w", err)
+	}
+
+	err = json.Unmarshal(request.OldObject.Raw, oldObject)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to unmarshal request oldObject: %w", err)
+	}
+	return oldObject, object, err
 }

--- a/pkg/resources/management.cattle.io/v3/token/validator.go
+++ b/pkg/resources/management.cattle.io/v3/token/validator.go
@@ -1,0 +1,87 @@
+package token
+
+import (
+	"fmt"
+	"net/http"
+
+	apisv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/webhook/pkg/admission"
+	objectsv3 "github.com/rancher/webhook/pkg/generated/objects/management.cattle.io/v3"
+	admissionv1 "k8s.io/api/admission/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/trace"
+)
+
+var tokenGVR = schema.GroupVersionResource{
+	Group:    "management.cattle.io",
+	Version:  "v3",
+	Resource: "token",
+}
+
+func NewValidator() *Validator {
+	return &Validator{}
+}
+
+type Validator struct {
+}
+
+func (v *Validator) GVR() schema.GroupVersionResource {
+	return tokenGVR
+}
+
+// Operations returns list of operations handled by this validator.
+func (v *Validator) Operations() []admissionregistrationv1.OperationType {
+	return []admissionregistrationv1.OperationType{admissionregistrationv1.Update, admissionregistrationv1.Create}
+}
+
+// ValidatingWebhook returns the ValidatingWebhook used for this CRD.
+func (v *Validator) ValidatingWebhook(clientConfig admissionregistrationv1.WebhookClientConfig) []admissionregistrationv1.ValidatingWebhook {
+	return []admissionregistrationv1.ValidatingWebhook{*admission.NewDefaultValidatingWebhook(v, clientConfig, admissionregistrationv1.NamespacedScope, v.Operations())}
+}
+
+func (v *Validator) Admit(request *admission.Request) (*admissionv1.AdmissionResponse, error) {
+	listTrace := trace.New("token Admit", trace.Field{Key: "user", Value: request.UserInfo.Username})
+	defer listTrace.LogIfLong(admission.SlowTraceDuration)
+
+	// The only validation that needs to be done is on Update actions
+	if request.Operation != admissionv1.Update {
+		return &admissionv1.AdmissionResponse{Allowed: true}, nil
+	}
+
+	fieldPath := field.NewPath("token")
+	var fieldErr *field.Error
+
+	oldToken, newToken, err := objectsv3.TokenOldAndNewFromRequest(&request.AdmissionRequest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get old and new CRTB from request: %w", err)
+	}
+
+	if fieldErr = validateUpdateFields(oldToken, newToken, fieldPath); fieldErr != nil {
+		return &admissionv1.AdmissionResponse{
+			Result: &metav1.Status{
+				Status:  "Failure",
+				Message: fieldErr.Error(),
+				Reason:  metav1.StatusReasonBadRequest,
+				Code:    http.StatusBadRequest,
+			},
+			Allowed: false,
+		}, nil
+	}
+	return &admissionv1.AdmissionResponse{Allowed: true}, nil
+}
+
+// validateUpdateFields checks if the fields being changed are valid update fields
+func validateUpdateFields(oldToken, newToken *apisv3.Token, fieldPath *field.Path) *field.Error {
+	const reason = "field is immutable"
+	switch {
+	case oldToken.Token != newToken.Token:
+		return field.Invalid(fieldPath.Child("token"), newToken.Token, reason)
+	case oldToken.ClusterName != newToken.ClusterName:
+		return field.Invalid(fieldPath.Child("clusterName"), newToken.ClusterName, reason)
+	default:
+		return nil
+	}
+}

--- a/pkg/resources/management.cattle.io/v3/token/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/token/validator_test.go
@@ -1,0 +1,140 @@
+package token_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	apisv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/webhook/pkg/admission"
+	"github.com/rancher/webhook/pkg/resources/management.cattle.io/v3/token"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	v1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type TokenSuite struct {
+	suite.Suite
+}
+
+func TestTokens(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(TokenSuite))
+}
+
+func (t *TokenSuite) Test_UpdateValidation() {
+	validator := token.NewValidator()
+
+	type args struct {
+		oldToken func() *apisv3.Token
+		newToken func() *apisv3.Token
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+		allowed bool
+	}{
+		{
+			name: "base test valid Token",
+			args: args{
+				oldToken: func() *apisv3.Token {
+					baseToken := newDefaultToken()
+					return baseToken
+				},
+				newToken: func() *apisv3.Token {
+					baseToken := newDefaultToken()
+					return baseToken
+				},
+			},
+			allowed: true,
+		},
+		{
+			name: "attempting to update token",
+			args: args{
+				oldToken: func() *apisv3.Token {
+					return newDefaultToken()
+				},
+				newToken: func() *apisv3.Token {
+					baseToken := newDefaultToken()
+					baseToken.Token = "xyz"
+					return baseToken
+				},
+			},
+			allowed: false,
+		},
+		{
+			name: "attempting to update cluster name",
+			args: args{
+				oldToken: func() *apisv3.Token {
+					baseToken := newDefaultToken()
+					return baseToken
+				},
+				newToken: func() *apisv3.Token {
+					baseToken := newDefaultToken()
+					baseToken.ClusterName = ""
+					return baseToken
+				},
+			},
+			allowed: false,
+		},
+		{
+			name: "non update requests pass",
+			args: args{
+				oldToken: func() *apisv3.Token { return nil },
+				newToken: func() *apisv3.Token {
+					return newDefaultToken()
+				},
+			},
+			allowed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func() {
+			req := createTokenRequest(t.T(), tt.args.oldToken(), tt.args.newToken())
+			resp, err := validator.Admit(req)
+			t.NoError(err, "Admit failed")
+			assert.Equal(t.T(), resp.Allowed, tt.allowed, "Response was incorrectly validated. Wanted response.Allowed = '%v' got '%v': result='%+v", tt.allowed, resp.Allowed, resp.Result)
+		})
+	}
+}
+
+func createTokenRequest(t *testing.T, oldToken, newToken *apisv3.Token) *admission.Request {
+	t.Helper()
+	gvk := metav1.GroupVersionKind{Group: "management.cattle.io", Version: "v3", Kind: "Token"}
+	gvr := metav1.GroupVersionResource{Group: "management.cattle.io", Version: "v3", Resource: "token"}
+	req := &admission.Request{
+		AdmissionRequest: v1.AdmissionRequest{
+			UID:             "1",
+			Kind:            gvk,
+			Resource:        gvr,
+			RequestKind:     &gvk,
+			RequestResource: &gvr,
+			Name:            newToken.Name,
+			Namespace:       newToken.Namespace,
+			Operation:       v1.Create,
+			Object:          runtime.RawExtension{},
+			OldObject:       runtime.RawExtension{},
+		},
+		Context: context.Background(),
+	}
+	var err error
+	req.Object.Raw, err = json.Marshal(newToken)
+	assert.NoError(t, err, "Failed to marshal Token while creating request")
+	if oldToken != nil {
+		req.Operation = v1.Update
+		req.OldObject.Raw, err = json.Marshal(oldToken)
+		assert.NoError(t, err, "Failed to marshal old Token while creating request")
+	}
+	return req
+}
+
+func newDefaultToken() *apisv3.Token {
+	return &apisv3.Token{
+		Token:       "abc",
+		ClusterName: "t-namespace",
+	}
+}


### PR DESCRIPTION
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
This ports the validation logic from norman for Tokens to webhook. There are only 2 validations that needed to be migrated:

| Tag | Rule |
| --- | --- |
| Token | noupdate |
| ClusterName | noupdate |

There were no store or other validations required to be added.

## Testing

Unit tests:

```
% go test --cover
PASS
        github.com/rancher/webhook/pkg/resources/management.cattle.io/v3/token  coverage: 81.0% of statements
ok      github.com/rancher/webhook/pkg/resources/management.cattle.io/v3/token  0.239s
```