### PR TITLE
Adjusting secrets mutator to only run in local

### DIFF
--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -46,11 +46,16 @@ func Validation(clients *clients.Clients) ([]admission.ValidatingAdmissionHandle
 
 // Mutation returns a list of all MutatingAdmissionHandlers used by the webhook.
 func Mutation(clients *clients.Clients) ([]admission.MutatingAdmissionHandler, error) {
-	return []admission.MutatingAdmissionHandler{
+	handlers := []admission.MutatingAdmissionHandler{
 		provisioningCluster.NewProvisioningClusterMutator(clients.Core.Secret(), clients.Management.PodSecurityAdmissionConfigurationTemplate().Cache()),
 		managementCluster.NewManagementClusterMutator(clients.Management.PodSecurityAdmissionConfigurationTemplate().Cache()),
 		fleetworkspace.NewMutator(clients),
-		&secret.Mutator{},
 		&machineconfig.Mutator{},
-	}, nil
+	}
+
+	if clients.MultiClusterManagement {
+		handlers = append(handlers, &secret.Mutator{})
+	}
+
+	return handlers, nil
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
rancher/rancher#41613
 
## Problem
The secrets mutator, which has the default failPolicy of `fail` was running in downstream clusters. This was creating edge cases where internal k8s operations on downstream clusters (outlined in the above cases) would fail.
 
## Solution
The secrets mutator will only run in the local cluster, which is the only cluster where it is required.
 
## Testing
Ran basic test case - mutator was registered in local but not in remote. The logs were also clear of errors.