### PR TITLE
Remove cluster name local restriction

### DIFF
--- a/pkg/resources/provisioning.cattle.io/v1/cluster/validator.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/validator.go
@@ -172,7 +172,7 @@ func (p *provisioningAdmitter) validateClusterName(request *admission.Request, r
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
-	if !isValidName(cluster.Name, cluster.Namespace, err == nil) {
+	if !isValidName(cluster.Name, err == nil) {
 		response.Result = &metav1.Status{
 			Status:  "Failure",
 			Message: "cluster name must be 63 characters or fewer, must not begin with a hyphen, cannot be \"local\" nor of the form \"c-xxxxx\", and can only contain lowercase alphanumeric characters or ' - '",
@@ -287,12 +287,7 @@ func validateACEConfig(cluster *v1.Cluster) *metav1.Status {
 	return nil
 }
 
-func isValidName(clusterName, clusterNamespace string, clusterExists bool) bool {
-	// A provisioning cluster with name "local" is only expected to be created in the "fleet-local" namespace.
-	if clusterName == "local" {
-		return clusterNamespace == "fleet-local"
-	}
-
+func isValidName(clusterName string, clusterExists bool) bool {
 	if mgmtNameRegex.MatchString(clusterName) {
 		// A provisioning cluster with a name of the form "c-xxxxx" is expected to be created if a management cluster
 		// of the same name already exists because Rancher will create such a provisioning cluster.

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/validator_test.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/validator_test.go
@@ -29,7 +29,7 @@ func Test_isValidName(t *testing.T) {
 			clusterName:      "local",
 			clusterNamespace: "fleet-default",
 			clusterExists:    true,
-			want:             false,
+			want:             true,
 		},
 		{
 			name:             "c-xxxxx cluster exists",
@@ -125,7 +125,7 @@ func Test_isValidName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isValidName(tt.clusterName, tt.clusterNamespace, tt.clusterExists); got != tt.want {
+			if got := isValidName(tt.clusterName, tt.clusterExists); got != tt.want {
 				t.Errorf("isValidName() = %v, want %v", got, tt.want)
 			}
 		})

--- a/tests/integration/provCluster_test.go
+++ b/tests/integration/provCluster_test.go
@@ -16,7 +16,7 @@ func (m *IntegrationSuite) TestProvisioningCluster() {
 	}
 	invalidCreate := func() *provisioningv1.Cluster {
 		invalidCreate := validCreateObj.DeepCopy()
-		invalidCreate.Name = "local"
+		invalidCreate.Name = "this-name-is-too-long-bigger-than-63-characters-it-should-be-rejected"
 		return invalidCreate
 	}
 	invalidUpdate := func(created *provisioningv1.Cluster) *provisioningv1.Cluster {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
https://github.com/rancher/fleet/issues/1489
 
## Problem
Users can't migrate the local cluster to the `fleet-default` workspace. Cluster creation is rejected by the webhook. This is the error displayed:
```
[ERROR] error syncing ‘local’: handler provisioning-cluster-create: failed to create fleet-default/local [provisioning.cattle.io/v1](http://provisioning.cattle.io/v1), Kind=Cluster for provisioning-cluster-create local: admission webhook “[rancherauth.cattle.io](http://rancherauth.cattle.io/)” denied the requeset: cluster name must be 63 characters or fewer, cannot be “local” nor of the form “c-xxxxx”, requeuing
```
 
## Solution
Remove the local cluster name validation, so users are able to move the local cluster to a different workspace.
 
