### PR TITLE
Add validation and mutation for Projects

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -121,6 +121,24 @@ Note: checks only run if a node driver is being disabled or deleted
 
 This admission webhook prevents the disabling or deletion of a NodeDriver if there are any Nodes that are under management by said driver. If there are _any_ nodes that use the driver the request will be denied.
 
+## Project 
+
+### Validation Checks
+
+#### Protects system project
+
+The system project cannot be deleted.
+
+#### Quota validation
+
+Project quotas and default limits must be consistent with one another and must be sufficient for the requirements of active namespaces.
+
+### Mutations
+
+#### On create
+
+Adds the authz.management.cattle.io/creator-role-bindings annotation.
+
 ## ProjectRoleTemplateBinding 
 
 ### Validation Checks

--- a/pkg/codegen/main.go
+++ b/pkg/codegen/main.go
@@ -65,6 +65,7 @@ func main() {
 				&v3.RoleTemplate{},
 				&v3.ProjectRoleTemplateBinding{},
 				&v3.NodeDriver{},
+				&v3.Project{},
 			},
 		},
 		"provisioning.cattle.io": {

--- a/pkg/generated/objects/management.cattle.io/v3/objects.go
+++ b/pkg/generated/objects/management.cattle.io/v3/objects.go
@@ -537,3 +537,56 @@ func NodeDriverFromRequest(request *admissionv1.AdmissionRequest) (*v3.NodeDrive
 
 	return object, nil
 }
+
+// ProjectOldAndNewFromRequest gets the old and new Project objects, respectively, from the webhook request.
+// If the request is a Delete operation, then the new object is the zero value for Project.
+// Similarly, if the request is a Create operation, then the old object is the zero value for Project.
+func ProjectOldAndNewFromRequest(request *admissionv1.AdmissionRequest) (*v3.Project, *v3.Project, error) {
+	if request == nil {
+		return nil, nil, fmt.Errorf("nil request")
+	}
+
+	object := &v3.Project{}
+	oldObject := &v3.Project{}
+
+	if request.Operation != admissionv1.Delete {
+		err := json.Unmarshal(request.Object.Raw, object)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to unmarshal request object: %w", err)
+		}
+	}
+
+	if request.Operation == admissionv1.Create {
+		return oldObject, object, nil
+	}
+
+	err := json.Unmarshal(request.OldObject.Raw, oldObject)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to unmarshal request oldObject: %w", err)
+	}
+
+	return oldObject, object, nil
+}
+
+// ProjectFromRequest returns a Project object from the webhook request.
+// If the operation is a Delete operation, then the old object is returned.
+// Otherwise, the new object is returned.
+func ProjectFromRequest(request *admissionv1.AdmissionRequest) (*v3.Project, error) {
+	if request == nil {
+		return nil, fmt.Errorf("nil request")
+	}
+
+	object := &v3.Project{}
+	raw := request.Object.Raw
+
+	if request.Operation == admissionv1.Delete {
+		raw = request.OldObject.Raw
+	}
+
+	err := json.Unmarshal(raw, object)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal request object: %w", err)
+	}
+
+	return object, nil
+}

--- a/pkg/resources/management.cattle.io/v3/project/Project.md
+++ b/pkg/resources/management.cattle.io/v3/project/Project.md
@@ -1,0 +1,15 @@
+## Validation Checks
+
+### Protects system project
+
+The system project cannot be deleted.
+
+### Quota validation
+
+Project quotas and default limits must be consistent with one another and must be sufficient for the requirements of active namespaces.
+
+## Mutations
+
+### On create
+
+Adds the authz.management.cattle.io/creator-role-bindings annotation.

--- a/pkg/resources/management.cattle.io/v3/project/mutator.go
+++ b/pkg/resources/management.cattle.io/v3/project/mutator.go
@@ -1,0 +1,128 @@
+package project
+
+import (
+	"encoding/json"
+	"fmt"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/webhook/pkg/admission"
+	ctrlv3 "github.com/rancher/webhook/pkg/generated/controllers/management.cattle.io/v3"
+	objectsv3 "github.com/rancher/webhook/pkg/generated/objects/management.cattle.io/v3"
+	"github.com/rancher/webhook/pkg/patch"
+	"github.com/sirupsen/logrus"
+	admissionv1 "k8s.io/api/admission/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/trace"
+)
+
+const (
+	roleTemplatesRequired           = "authz.management.cattle.io/creator-role-bindings"
+	indexKey                        = "creatorDefaultUnlocked"
+	mutatorCreatorRoleTemplateIndex = "webhook.cattle.io/creator-role-template-index"
+)
+
+var gvr = schema.GroupVersionResource{
+	Group:    "management.cattle.io",
+	Version:  "v3",
+	Resource: "projects",
+}
+
+// Mutator implements admission.MutatingAdmissionWebhook.
+type Mutator struct {
+	roleTemplateCache ctrlv3.RoleTemplateCache
+}
+
+// NewMutator returns a new mutator which mutates projects
+func NewMutator(roleTemplateCache ctrlv3.RoleTemplateCache) *Mutator {
+	roleTemplateCache.AddIndexer(mutatorCreatorRoleTemplateIndex, creatorRoleTemplateIndexer)
+	return &Mutator{
+		roleTemplateCache: roleTemplateCache,
+	}
+}
+
+// creatorRoleTemplateIndexer indexes a role template based on whether it's an owner type role template.
+func creatorRoleTemplateIndexer(roleTemplate *v3.RoleTemplate) ([]string, error) {
+	if roleTemplate.ProjectCreatorDefault && !roleTemplate.Locked {
+		return []string{indexKey}, nil
+	}
+	return nil, nil
+}
+
+// GVR returns the GroupVersionKind for this CRD.
+func (m *Mutator) GVR() schema.GroupVersionResource {
+	return gvr
+}
+
+// Operations returns list of operations handled by this mutator.
+func (m *Mutator) Operations() []admissionregistrationv1.OperationType {
+	return []admissionregistrationv1.OperationType{
+		admissionregistrationv1.Create,
+	}
+}
+
+// MutatingWebhook returns the MutatingWebhook used for this CRD.
+func (m *Mutator) MutatingWebhook(clientConfig admissionregistrationv1.WebhookClientConfig) []admissionregistrationv1.MutatingWebhook {
+	mutatingWebhook := admission.NewDefaultMutatingWebhook(m, clientConfig, admissionregistrationv1.NamespacedScope, m.Operations())
+	mutatingWebhook.SideEffects = admission.Ptr(admissionregistrationv1.SideEffectClassNone)
+	return []admissionregistrationv1.MutatingWebhook{*mutatingWebhook}
+}
+
+// Admit is the entrypoint for the mutator. Admit will return an error if it unable to process the request.
+func (m *Mutator) Admit(request *admission.Request) (*admissionv1.AdmissionResponse, error) {
+	if request.DryRun != nil && *request.DryRun {
+		return &admissionv1.AdmissionResponse{
+			Allowed: true,
+		}, nil
+	}
+
+	listTrace := trace.New("project Admit", trace.Field{Key: "user", Value: request.UserInfo.Username})
+	defer listTrace.LogIfLong(admission.SlowTraceDuration)
+
+	project, err := objectsv3.ProjectFromRequest(&request.AdmissionRequest)
+	if err != nil {
+		return nil, err
+	}
+	switch request.Operation {
+	case admissionv1.Create:
+		return m.admitCreate(project, request)
+	default:
+		return nil, fmt.Errorf("operation type %q not handled", request.Operation)
+	}
+}
+
+func (m *Mutator) admitCreate(project *v3.Project, request *admission.Request) (*admissionv1.AdmissionResponse, error) {
+	logrus.Debugf("[project-mutation] adding creator-role-bindings to project: %v", project.Name)
+	newProject := project.DeepCopy()
+
+	if newProject.Annotations == nil {
+		newProject.Annotations = make(map[string]string)
+	}
+	annotations, err := m.getCreatorRoleTemplateAnnotations()
+	if err != nil {
+		return nil, fmt.Errorf("failed to add annotation to project %s: %w", project.Name, err)
+	}
+	newProject.Annotations[roleTemplatesRequired] = annotations
+	response := &admissionv1.AdmissionResponse{}
+	if err := patch.CreatePatch(request.Object.Raw, newProject, response); err != nil {
+		return nil, fmt.Errorf("failed to create patch: %w", err)
+	}
+	response.Allowed = true
+	return response, nil
+}
+
+func (m *Mutator) getCreatorRoleTemplateAnnotations() (string, error) {
+	roleTemplates, err := m.roleTemplateCache.GetByIndex(mutatorCreatorRoleTemplateIndex, indexKey)
+	if err != nil {
+		return "", err
+	}
+	annoMap := make(map[string][]string)
+	for _, role := range roleTemplates {
+		annoMap["required"] = append(annoMap["required"], role.Name)
+	}
+	annotations, err := json.Marshal(annoMap)
+	if err != nil {
+		return "", err
+	}
+	return string(annotations), nil
+}

--- a/pkg/resources/management.cattle.io/v3/project/mutator_test.go
+++ b/pkg/resources/management.cattle.io/v3/project/mutator_test.go
@@ -1,0 +1,173 @@
+package project
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/wrangler/pkg/generic/fake"
+	"github.com/stretchr/testify/assert"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	expectedIndexerName = "webhook.cattle.io/creator-role-template-index"
+	expectedIndexKey    = "creatorDefaultUnlocked"
+)
+
+func TestAdmit(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		operation  admissionv1.Operation
+		dryRun     bool
+		oldProject *v3.Project
+		newProject *v3.Project
+		indexer    func() ([]*v3.RoleTemplate, error)
+		wantPatch  []map[string]interface{}
+		wantErr    bool
+	}{
+		{
+			name:       "dry run returns allowed",
+			operation:  admissionv1.Update,
+			dryRun:     true,
+			newProject: &v3.Project{},
+		},
+		{
+			name:       "failure to decode project returns error",
+			newProject: nil,
+			wantErr:    true,
+		},
+		{
+			name:       "delete operation is invalid",
+			operation:  admissionv1.Delete,
+			newProject: &v3.Project{},
+			oldProject: &v3.Project{},
+			wantErr:    true,
+		},
+		{
+			name:       "update operation is invalid",
+			operation:  admissionv1.Update,
+			newProject: &v3.Project{},
+			oldProject: &v3.Project{},
+			wantErr:    true,
+		},
+		{
+			name:       "connect operation is invalid",
+			operation:  admissionv1.Connect,
+			newProject: &v3.Project{},
+			oldProject: &v3.Project{},
+			wantErr:    true,
+		},
+		{
+			name:       "indexer error",
+			operation:  admissionv1.Create,
+			newProject: &v3.Project{},
+			indexer:    func() ([]*v3.RoleTemplate, error) { return nil, fmt.Errorf("indexer error") },
+			wantErr:    true,
+		},
+		{
+			name:      "indexer returns empty",
+			operation: admissionv1.Create,
+			newProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testproject",
+				},
+			},
+			indexer: func() ([]*v3.RoleTemplate, error) { return nil, nil },
+			wantPatch: []map[string]interface{}{
+				{
+					"op":   "add",
+					"path": "/metadata/annotations",
+					"value": map[string]string{
+						"authz.management.cattle.io/creator-role-bindings": "{}",
+					},
+				},
+			},
+		},
+		{
+			name:      "created project gets annotation added",
+			operation: admissionv1.Create,
+			newProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testproject",
+				},
+			},
+			wantPatch: []map[string]interface{}{
+				{
+					"op":   "add",
+					"path": "/metadata/annotations",
+					"value": map[string]string{
+						"authz.management.cattle.io/creator-role-bindings": "{\"required\":[\"project-owner\"]}",
+					},
+				},
+			},
+		},
+		{
+			name:      "override user-set annotations",
+			operation: admissionv1.Create,
+			newProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testproject",
+					Annotations: map[string]string{
+						"authz.management.cattle.io/creator-role-bindings": "my own setting",
+					},
+				},
+			},
+			wantPatch: []map[string]interface{}{
+				{
+					"op":    "replace",
+					"path":  "/metadata/annotations/authz.management.cattle.io~1creator-role-bindings",
+					"value": "{\"required\":[\"project-owner\"]}",
+				},
+			},
+		},
+	}
+
+	roleTemplates := []*v3.RoleTemplate{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "project-owner",
+			},
+			Context:               "project",
+			DisplayName:           "Project Owner",
+			ProjectCreatorDefault: true,
+		},
+	}
+	defaultIndexer := func() ([]*v3.RoleTemplate, error) {
+		return roleTemplates, nil
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			req, err := createProjectRequest(test.oldProject, test.newProject, test.operation, test.dryRun)
+			assert.NoError(t, err)
+			roleTemplateCache := fake.NewMockNonNamespacedCacheInterface[*v3.RoleTemplate](gomock.NewController(t))
+			roleTemplateCache.EXPECT().AddIndexer(expectedIndexerName, gomock.Any())
+			indexer := defaultIndexer
+			if test.indexer != nil {
+				indexer = test.indexer
+			}
+			returnedRTs, returnedErr := indexer()
+			roleTemplateCache.EXPECT().GetByIndex(expectedIndexerName, expectedIndexKey).Return(returnedRTs, returnedErr).AnyTimes()
+			m := NewMutator(roleTemplateCache)
+			resp, err := m.Admit(req)
+			if test.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.Equal(t, true, resp.Allowed)
+			var wantPatch []byte
+			if test.wantPatch != nil {
+				wantPatch, err = json.Marshal(test.wantPatch)
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, string(wantPatch), string(resp.Patch))
+		})
+	}
+}

--- a/pkg/resources/management.cattle.io/v3/project/quota_validate.go
+++ b/pkg/resources/management.cattle.io/v3/project/quota_validate.go
@@ -1,0 +1,74 @@
+package project
+
+import (
+	"sync"
+	"time"
+
+	"github.com/rancher/norman/types/convert"
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	api "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/cache"
+	quota "k8s.io/apiserver/pkg/quota/v1"
+)
+
+var (
+	projectLockCache = cache.NewLRUExpireCache(1000)
+)
+
+func GetProjectLock(projectID string) *sync.Mutex {
+	val, ok := projectLockCache.Get(projectID)
+	if !ok {
+		projectLockCache.Add(projectID, &sync.Mutex{}, time.Hour)
+		val, _ = projectLockCache.Get(projectID)
+	}
+	mu := val.(*sync.Mutex)
+	return mu
+}
+
+func IsQuotaFit(nsLimit *v32.ResourceQuotaLimit, nsLimits []*v32.ResourceQuotaLimit, projectLimit *v32.ResourceQuotaLimit) (bool, api.ResourceList, error) {
+	nssResourceList := api.ResourceList{}
+	nsResourceList, err := ConvertLimitToResourceList(nsLimit)
+	if err != nil {
+		return false, nil, err
+	}
+	nssResourceList = quota.Add(nssResourceList, nsResourceList)
+
+	for _, nsLimit := range nsLimits {
+		nsResourceList, err := ConvertLimitToResourceList(nsLimit)
+		if err != nil {
+			return false, nil, err
+		}
+		nssResourceList = quota.Add(nssResourceList, nsResourceList)
+	}
+
+	projectResourceList, err := ConvertLimitToResourceList(projectLimit)
+	if err != nil {
+		return false, nil, err
+	}
+
+	_, exceeded := quota.LessThanOrEqual(nssResourceList, projectResourceList)
+	// Include resources with negative values among exceeded resources.
+	exceeded = append(exceeded, quota.IsNegative(nsResourceList)...)
+	if len(exceeded) == 0 {
+		return true, nil, nil
+	}
+	failedHard := quota.Mask(nssResourceList, exceeded)
+	return false, failedHard, nil
+}
+
+func ConvertLimitToResourceList(limit *v32.ResourceQuotaLimit) (api.ResourceList, error) {
+	toReturn := api.ResourceList{}
+	converted, err := convert.EncodeToMap(limit)
+	if err != nil {
+		return nil, err
+	}
+	for key, value := range converted {
+		q, err := resource.ParseQuantity(convert.ToString(value))
+		if err != nil {
+			return nil, err
+		}
+		toReturn[api.ResourceName(key)] = q
+	}
+	return toReturn, nil
+}

--- a/pkg/resources/management.cattle.io/v3/project/validator.go
+++ b/pkg/resources/management.cattle.io/v3/project/validator.go
@@ -1,0 +1,217 @@
+package project
+
+import (
+	"fmt"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/webhook/pkg/admission"
+	objectsv3 "github.com/rancher/webhook/pkg/generated/objects/management.cattle.io/v3"
+	"github.com/rancher/wrangler/pkg/data/convert"
+	corev1controllers "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
+	admissionv1 "k8s.io/api/admission/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/kubernetes/pkg/kubelet/util/format"
+	"k8s.io/utils/trace"
+)
+
+const (
+	systemProjectLabel = "authz.management.cattle.io/system-project"
+)
+
+// Validator implements admission.ValidatingAdmissionWebhook.
+type Validator struct {
+	admitter admitter
+}
+
+// NewValidator returns a project validator.
+func NewValidator(namespaceCache corev1controllers.NamespaceCache) *Validator {
+	return &Validator{
+		admitter{
+			namespaceCache: namespaceCache,
+		},
+	}
+}
+
+// GVR returns the GroupVersionKind for this CRD.
+func (v *Validator) GVR() schema.GroupVersionResource {
+	return gvr
+}
+
+// Operations returns list of operations handled by this validator.
+func (v *Validator) Operations() []admissionregistrationv1.OperationType {
+	return []admissionregistrationv1.OperationType{
+		admissionregistrationv1.Create,
+		admissionregistrationv1.Update,
+		admissionregistrationv1.Delete,
+	}
+}
+
+// ValidatingWebhook returns the ValidatingWebhook used for this CRD.
+func (v *Validator) ValidatingWebhook(clientConfig admissionregistrationv1.WebhookClientConfig) []admissionregistrationv1.ValidatingWebhook {
+	validatingWebhook := admission.NewDefaultValidatingWebhook(v, clientConfig, admissionregistrationv1.NamespacedScope, v.Operations())
+	return []admissionregistrationv1.ValidatingWebhook{*validatingWebhook}
+}
+
+// Admitters returns the admitter objects used to validate secrets.
+func (v *Validator) Admitters() []admission.Admitter {
+	return []admission.Admitter{&v.admitter}
+}
+
+type admitter struct {
+	namespaceCache corev1controllers.NamespaceCache
+}
+
+// Admit handles the webhook admission request sent to this webhook.
+func (a *admitter) Admit(request *admission.Request) (*admissionv1.AdmissionResponse, error) {
+	listTrace := trace.New("project Admit", trace.Field{Key: "user", Value: request.UserInfo.Username})
+	defer listTrace.LogIfLong(admission.SlowTraceDuration)
+
+	oldProject, newProject, err := objectsv3.ProjectOldAndNewFromRequest(&request.AdmissionRequest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get old and new projects from request: %w", err)
+	}
+
+	if request.Operation == admissionv1.Delete {
+		return a.admitDelete(oldProject)
+	}
+	return a.admitCreateOrUpdate(oldProject, newProject)
+}
+
+func (a *admitter) admitDelete(project *v3.Project) (*admissionv1.AdmissionResponse, error) {
+	if project.Labels[systemProjectLabel] == "true" {
+		return admission.ResponseBadRequest("System Project cannot be deleted"), nil
+	}
+	return admission.ResponseAllowed(), nil
+}
+
+func (a *admitter) admitCreateOrUpdate(oldProject, newProject *v3.Project) (*admissionv1.AdmissionResponse, error) {
+	projectQuota := newProject.Spec.ResourceQuota
+	nsQuota := newProject.Spec.NamespaceDefaultResourceQuota
+	if projectQuota == nil && nsQuota == nil {
+		return admission.ResponseAllowed(), nil
+	}
+	if projectQuota == nil && nsQuota != nil {
+		return admission.ResponseBadRequest("field resourceQuota is required when namespaceDefaultResourceQuota is set"), nil
+	}
+	if projectQuota != nil && nsQuota == nil {
+		return admission.ResponseBadRequest("field namespaceDefaultResourceQuota is required when resourceQuota is set"), nil
+	}
+
+	projectQuotaLimitMap, err := convert.EncodeToMap(projectQuota.Limit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode project quota limit: %w", err)
+	}
+	nsQuotaLimitMap, err := convert.EncodeToMap(nsQuota.Limit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode namespace default quota limit: %w", err)
+	}
+	if len(projectQuotaLimitMap) != len(nsQuotaLimitMap) {
+		return admission.ResponseBadRequest("resource quota and namespace default quota do not have the same resources defined"), nil
+	}
+	for k := range projectQuotaLimitMap {
+		if _, ok := nsQuotaLimitMap[k]; !ok {
+			return admission.ResponseBadRequest(fmt.Sprintf("missing namespace default for resource %s defined on resourceQuota", k)), nil
+		}
+	}
+	err = a.checkQuotaRequest(&nsQuota.Limit, &projectQuota.Limit, oldProject)
+	if err != nil {
+		return admission.ResponseBadRequest(err.Error()), nil
+	}
+	return admission.ResponseAllowed(), nil
+}
+
+func (a *admitter) checkQuotaRequest(newNSQuotaLimit, newProjectQuotaLimit *v3.ResourceQuotaLimit, oldProject *v3.Project) error {
+	isFit, exceeded, err := IsQuotaFit(newNSQuotaLimit, []*v3.ResourceQuotaLimit{}, newProjectQuotaLimit)
+	if err != nil {
+		return err
+	}
+	if !isFit {
+		return fmt.Errorf("namespace default quota limit exceeds project limit on fields: %s", format.ResourceList(exceeded))
+	}
+
+	if oldProject == nil || oldProject.Spec.ResourceQuota == nil {
+		return nil
+	}
+
+	// check if fields were added or removed
+	// and update project's namespaces accordingly
+	defaultQuotaLimitMap, err := convert.EncodeToMap(newNSQuotaLimit)
+	if err != nil {
+		return err
+	}
+
+	usedQuotaLimitMap := map[string]interface{}{}
+	if oldProject.Spec.ResourceQuota != nil {
+		usedQuotaLimitMap, err = convert.EncodeToMap(oldProject.Spec.ResourceQuota.UsedLimit)
+		if err != nil {
+			return err
+		}
+	}
+
+	limitToAdd := map[string]interface{}{}
+	limitToRemove := map[string]interface{}{}
+	for key, value := range defaultQuotaLimitMap {
+		if _, ok := usedQuotaLimitMap[key]; !ok {
+			limitToAdd[key] = value
+		}
+	}
+
+	for key, value := range usedQuotaLimitMap {
+		if _, ok := defaultQuotaLimitMap[key]; !ok {
+			limitToRemove[key] = value
+		}
+	}
+
+	// check that used quota is not bigger than the project quota
+	for key := range limitToRemove {
+		delete(usedQuotaLimitMap, key)
+	}
+
+	usedLimit := &v3.ResourceQuotaLimit{}
+	err = convert.ToObj(usedQuotaLimitMap, usedLimit)
+	if err != nil {
+		return err
+	}
+
+	isFit, exceeded, err = IsQuotaFit(usedLimit, []*v3.ResourceQuotaLimit{}, newProjectQuotaLimit)
+	if err != nil {
+		return err
+	}
+	if !isFit {
+		return fmt.Errorf("resourceQuota is below the used limit on fields: %s", format.ResourceList(exceeded))
+	}
+
+	if len(limitToAdd) == 0 && len(limitToRemove) == 0 {
+		return nil
+	}
+
+	// check if default quota is enough to set on namespaces
+	toAppend := &v3.ResourceQuotaLimit{}
+	if err := convert.ToObj(limitToAdd, toAppend); err != nil {
+		return err
+	}
+	mu := GetProjectLock(oldProject.Name)
+	mu.Lock()
+	defer mu.Unlock()
+
+	namespaces, err := a.namespaceCache.List(labels.Set(map[string]string{"field.cattle.io/projectId": oldProject.Name}).AsSelector())
+	if err != nil {
+		return err
+	}
+	namespacesCount := len(namespaces)
+	var nsLimits []*v3.ResourceQuotaLimit
+	for i := 0; i < namespacesCount; i++ {
+		nsLimits = append(nsLimits, toAppend)
+	}
+
+	isFit, exceeded, err = IsQuotaFit(&v3.ResourceQuotaLimit{}, nsLimits, newProjectQuotaLimit)
+	if err != nil {
+		return err
+	}
+	if !isFit {
+		return fmt.Errorf("exceeds project limit on fields %s when applied to all namespaces in the project", format.ResourceList(exceeded))
+	}
+	return nil
+}

--- a/pkg/resources/management.cattle.io/v3/project/validator.go
+++ b/pkg/resources/management.cattle.io/v3/project/validator.go
@@ -7,18 +7,21 @@ import (
 	"github.com/rancher/webhook/pkg/admission"
 	objectsv3 "github.com/rancher/webhook/pkg/generated/objects/management.cattle.io/v3"
 	"github.com/rancher/wrangler/pkg/data/convert"
-	corev1controllers "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	admissionv1 "k8s.io/api/admission/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kubernetes/pkg/kubelet/util/format"
 	"k8s.io/utils/trace"
 )
 
 const (
-	systemProjectLabel = "authz.management.cattle.io/system-project"
+	systemProjectLabel  = "authz.management.cattle.io/system-project"
+	projectQuotaField   = "resourceQuota"
+	namespaceQuotaField = "namespaceDefaultResourceQuota"
 )
+
+var projectSpecFieldPath = field.NewPath("project").Child("spec")
 
 // Validator implements admission.ValidatingAdmissionWebhook.
 type Validator struct {
@@ -26,12 +29,8 @@ type Validator struct {
 }
 
 // NewValidator returns a project validator.
-func NewValidator(namespaceCache corev1controllers.NamespaceCache) *Validator {
-	return &Validator{
-		admitter{
-			namespaceCache: namespaceCache,
-		},
-	}
+func NewValidator() *Validator {
+	return &Validator{}
 }
 
 // GVR returns the GroupVersionKind for this CRD.
@@ -59,9 +58,7 @@ func (v *Validator) Admitters() []admission.Admitter {
 	return []admission.Admitter{&v.admitter}
 }
 
-type admitter struct {
-	namespaceCache corev1controllers.NamespaceCache
-}
+type admitter struct{}
 
 // Admit handles the webhook admission request sent to this webhook.
 func (a *admitter) Admit(request *admission.Request) (*admissionv1.AdmissionResponse, error) {
@@ -92,11 +89,30 @@ func (a *admitter) admitCreateOrUpdate(oldProject, newProject *v3.Project) (*adm
 	if projectQuota == nil && nsQuota == nil {
 		return admission.ResponseAllowed(), nil
 	}
+	fieldErr, err := checkQuotaFields(projectQuota, nsQuota)
+	if err != nil {
+		return nil, fmt.Errorf("error checking project fields: %w", err)
+	}
+	if fieldErr != nil {
+		return admission.ResponseBadRequest(fieldErr.Error()), nil
+	}
+	fieldErr, err = a.checkQuotaValues(&nsQuota.Limit, &projectQuota.Limit, oldProject)
+	if err != nil {
+		return nil, fmt.Errorf("error checking quota values: %w", err)
+	}
+	if fieldErr != nil {
+		return admission.ResponseBadRequest(fieldErr.Error()), nil
+	}
+	return admission.ResponseAllowed(), nil
+}
+
+func checkQuotaFields(projectQuota *v3.ProjectResourceQuota, nsQuota *v3.NamespaceResourceQuota) (*field.Error, error) {
+
 	if projectQuota == nil && nsQuota != nil {
-		return admission.ResponseBadRequest("field resourceQuota is required when namespaceDefaultResourceQuota is set"), nil
+		return field.Required(projectSpecFieldPath.Child(projectQuotaField), fmt.Sprintf("required when %s is set", namespaceQuotaField)), nil
 	}
 	if projectQuota != nil && nsQuota == nil {
-		return admission.ResponseBadRequest("field namespaceDefaultResourceQuota is required when resourceQuota is set"), nil
+		return field.Required(projectSpecFieldPath.Child(namespaceQuotaField), fmt.Sprintf("required when %s is set", projectQuotaField)), nil
 	}
 
 	projectQuotaLimitMap, err := convert.EncodeToMap(projectQuota.Limit)
@@ -108,110 +124,60 @@ func (a *admitter) admitCreateOrUpdate(oldProject, newProject *v3.Project) (*adm
 		return nil, fmt.Errorf("failed to decode namespace default quota limit: %w", err)
 	}
 	if len(projectQuotaLimitMap) != len(nsQuotaLimitMap) {
-		return admission.ResponseBadRequest("resource quota and namespace default quota do not have the same resources defined"), nil
+		return field.Invalid(projectSpecFieldPath.Child(projectQuotaField), projectQuota, "resource quota and namespace default quota do not have the same resources defined"), nil
 	}
 	for k := range projectQuotaLimitMap {
 		if _, ok := nsQuotaLimitMap[k]; !ok {
-			return admission.ResponseBadRequest(fmt.Sprintf("missing namespace default for resource %s defined on resourceQuota", k)), nil
+			return field.Invalid(projectSpecFieldPath.Child(namespaceQuotaField), nsQuota, fmt.Sprintf("missing namespace default for resource %s defined on %s", k, projectQuotaField)), nil
 		}
 	}
-	err = a.checkQuotaRequest(&nsQuota.Limit, &projectQuota.Limit, oldProject)
-	if err != nil {
-		return admission.ResponseBadRequest(err.Error()), nil
-	}
-	return admission.ResponseAllowed(), nil
+	return nil, nil
 }
 
-func (a *admitter) checkQuotaRequest(newNSQuotaLimit, newProjectQuotaLimit *v3.ResourceQuotaLimit, oldProject *v3.Project) error {
-	isFit, exceeded, err := IsQuotaFit(newNSQuotaLimit, []*v3.ResourceQuotaLimit{}, newProjectQuotaLimit)
-	if err != nil {
-		return err
-	}
-	if !isFit {
-		return fmt.Errorf("namespace default quota limit exceeds project limit on fields: %s", format.ResourceList(exceeded))
+func (a *admitter) checkQuotaValues(nsQuota, projectQuota *v3.ResourceQuotaLimit, oldProject *v3.Project) (*field.Error, error) {
+	// check quota on new project
+	fieldErr, err := namespaceQuotaFits(nsQuota, projectQuota)
+	if err != nil || fieldErr != nil {
+		return fieldErr, err
 	}
 
+	// if there is no old project or no quota on the old project, no further validation needed
 	if oldProject == nil || oldProject.Spec.ResourceQuota == nil {
-		return nil
+		return nil, nil
 	}
 
-	// check if fields were added or removed
-	// and update project's namespaces accordingly
-	defaultQuotaLimitMap, err := convert.EncodeToMap(newNSQuotaLimit)
+	// check quota relative to used quota
+	return usedQuotaFits(&oldProject.Spec.ResourceQuota.UsedLimit, projectQuota)
+}
+
+func namespaceQuotaFits(namespaceQuota, projectQuota *v3.ResourceQuotaLimit) (*field.Error, error) {
+	namespaceQuotaResourceList, err := convertLimitToResourceList(namespaceQuota)
 	if err != nil {
-		return err
+		return nil, err
 	}
-
-	usedQuotaLimitMap := map[string]interface{}{}
-	if oldProject.Spec.ResourceQuota != nil {
-		usedQuotaLimitMap, err = convert.EncodeToMap(oldProject.Spec.ResourceQuota.UsedLimit)
-		if err != nil {
-			return err
-		}
-	}
-
-	limitToAdd := map[string]interface{}{}
-	limitToRemove := map[string]interface{}{}
-	for key, value := range defaultQuotaLimitMap {
-		if _, ok := usedQuotaLimitMap[key]; !ok {
-			limitToAdd[key] = value
-		}
-	}
-
-	for key, value := range usedQuotaLimitMap {
-		if _, ok := defaultQuotaLimitMap[key]; !ok {
-			limitToRemove[key] = value
-		}
-	}
-
-	// check that used quota is not bigger than the project quota
-	for key := range limitToRemove {
-		delete(usedQuotaLimitMap, key)
-	}
-
-	usedLimit := &v3.ResourceQuotaLimit{}
-	err = convert.ToObj(usedQuotaLimitMap, usedLimit)
+	projectQuotaResourceList, err := convertLimitToResourceList(projectQuota)
 	if err != nil {
-		return err
+		return nil, err
 	}
+	fits, exceeded := quotaFits(namespaceQuotaResourceList, projectQuotaResourceList)
+	if !fits {
+		return field.Forbidden(projectSpecFieldPath.Child(namespaceQuotaField), fmt.Sprintf("namespace default quota limit exceeds project limit on fields: %s", format.ResourceList(exceeded))), nil
+	}
+	return nil, nil
+}
 
-	isFit, exceeded, err = IsQuotaFit(usedLimit, []*v3.ResourceQuotaLimit{}, newProjectQuotaLimit)
+func usedQuotaFits(usedQuota, projectQuota *v3.ResourceQuotaLimit) (*field.Error, error) {
+	usedQuotaResourceList, err := convertLimitToResourceList(usedQuota)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	if !isFit {
-		return fmt.Errorf("resourceQuota is below the used limit on fields: %s", format.ResourceList(exceeded))
-	}
-
-	if len(limitToAdd) == 0 && len(limitToRemove) == 0 {
-		return nil
-	}
-
-	// check if default quota is enough to set on namespaces
-	toAppend := &v3.ResourceQuotaLimit{}
-	if err := convert.ToObj(limitToAdd, toAppend); err != nil {
-		return err
-	}
-	mu := GetProjectLock(oldProject.Name)
-	mu.Lock()
-	defer mu.Unlock()
-
-	namespaces, err := a.namespaceCache.List(labels.Set(map[string]string{"field.cattle.io/projectId": oldProject.Name}).AsSelector())
+	projectQuotaResourceList, err := convertLimitToResourceList(projectQuota)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	namespacesCount := len(namespaces)
-	var nsLimits []*v3.ResourceQuotaLimit
-	for i := 0; i < namespacesCount; i++ {
-		nsLimits = append(nsLimits, toAppend)
+	fits, exceeded := quotaFits(usedQuotaResourceList, projectQuotaResourceList)
+	if !fits {
+		return field.Forbidden(projectSpecFieldPath.Child(projectQuotaField), fmt.Sprintf("resourceQuota is below the used limit on fields: %s", format.ResourceList(exceeded))), nil
 	}
-
-	isFit, exceeded, err = IsQuotaFit(&v3.ResourceQuotaLimit{}, nsLimits, newProjectQuotaLimit)
-	if err != nil {
-		return err
-	}
-	if !isFit {
-		return fmt.Errorf("exceeds project limit on fields %s when applied to all namespaces in the project", format.ResourceList(exceeded))
-	}
-	return nil
+	return nil, nil
 }

--- a/pkg/resources/management.cattle.io/v3/project/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/project/validator_test.go
@@ -1,0 +1,755 @@
+package project
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/webhook/pkg/admission"
+	"github.com/rancher/wrangler/pkg/generic/fake"
+	"github.com/stretchr/testify/assert"
+	admissionv1 "k8s.io/api/admission/v1"
+	v1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestProjectValidation(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		operation   v1.Operation
+		newProject  *v3.Project
+		oldProject  *v3.Project
+		namespaces  []*corev1.Namespace
+		wantAllowed bool
+		wantErr     bool
+	}{
+		{
+			name:        "failure to decode project returns error",
+			newProject:  nil,
+			oldProject:  nil,
+			wantAllowed: false,
+			wantErr:     true,
+		},
+		{
+			name:      "create new with no quotas",
+			operation: admissionv1.Create,
+			newProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+				Spec: v3.ProjectSpec{
+					DisplayName: "test1",
+					ClusterName: "testcluster",
+				},
+			},
+			wantAllowed: true,
+		},
+		{
+			name:      "create new with valid quotas",
+			operation: admissionv1.Create,
+			newProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+				Spec: v3.ProjectSpec{
+					DisplayName: "test",
+					ClusterName: "testcluster",
+					ResourceQuota: &v3.ProjectResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "10",
+						},
+					},
+					NamespaceDefaultResourceQuota: &v3.NamespaceResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "10",
+						},
+					},
+				},
+			},
+			wantAllowed: true,
+		},
+		{
+			name:      "create new with project quota present but namespace quota missing",
+			operation: admissionv1.Create,
+			newProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+				Spec: v3.ProjectSpec{
+					DisplayName: "test",
+					ClusterName: "testcluster",
+					ResourceQuota: &v3.ProjectResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "10",
+						},
+					},
+				},
+			},
+			wantAllowed: false,
+		},
+		{
+			name:      "create new with namespace quota present but project quota missing",
+			operation: admissionv1.Create,
+			newProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+				Spec: v3.ProjectSpec{
+					DisplayName: "test",
+					ClusterName: "testcluster",
+					NamespaceDefaultResourceQuota: &v3.NamespaceResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "10",
+						},
+					},
+				},
+			},
+			wantAllowed: false,
+		},
+		{
+			name:      "create new with namespace quota having unexpected resource fields",
+			operation: admissionv1.Create,
+			newProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+				Spec: v3.ProjectSpec{
+					DisplayName: "test",
+					ClusterName: "testcluster",
+					ResourceQuota: &v3.ProjectResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "10",
+						},
+					},
+					NamespaceDefaultResourceQuota: &v3.NamespaceResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "10",
+							LimitsCPU:  "10m",
+						},
+					},
+				},
+			},
+			wantAllowed: false,
+		},
+		{
+			name:      "create new with project quota having unexpected resource fields",
+			operation: admissionv1.Create,
+			newProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+				Spec: v3.ProjectSpec{
+					DisplayName: "test",
+					ClusterName: "testcluster",
+					ResourceQuota: &v3.ProjectResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "10",
+							LimitsCPU:  "10m",
+						},
+					},
+					NamespaceDefaultResourceQuota: &v3.NamespaceResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "10",
+						},
+					},
+				},
+			},
+			wantAllowed: false,
+		},
+		{
+			name:      "create new with project quota and namespace quota having mismatched resource fields",
+			operation: admissionv1.Create,
+			newProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+				Spec: v3.ProjectSpec{
+					DisplayName: "test",
+					ClusterName: "testcluster",
+					ResourceQuota: &v3.ProjectResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "10",
+							LimitsCPU:  "10m",
+						},
+					},
+					NamespaceDefaultResourceQuota: &v3.NamespaceResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps:   "10",
+							LimitsMemory: "2048Mi",
+						},
+					},
+				},
+			},
+			wantAllowed: false,
+		},
+		{
+			name:      "create new with namespace quota greater than project quota",
+			operation: admissionv1.Create,
+			newProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+				Spec: v3.ProjectSpec{
+					ResourceQuota: &v3.ProjectResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "10",
+						},
+					},
+					NamespaceDefaultResourceQuota: &v3.NamespaceResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "100",
+						},
+					},
+				},
+			},
+			wantAllowed: false,
+		},
+		{
+			name:      "create new with negative namespace quota",
+			operation: admissionv1.Create,
+			newProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+				Spec: v3.ProjectSpec{
+					ResourceQuota: &v3.ProjectResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "10",
+						},
+					},
+					NamespaceDefaultResourceQuota: &v3.NamespaceResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "-100",
+						},
+					},
+				},
+			},
+			wantAllowed: false,
+		},
+		{
+			name:      "update with no quotas (noop)",
+			operation: admissionv1.Update,
+			oldProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+			},
+			newProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+			},
+			wantAllowed: true,
+		},
+		{
+			name:      "update to reset quotas",
+			operation: admissionv1.Update,
+			oldProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+				Spec: v3.ProjectSpec{
+					ResourceQuota: &v3.ProjectResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "10",
+						},
+					},
+					NamespaceDefaultResourceQuota: &v3.NamespaceResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "10",
+						},
+					},
+				},
+			},
+			newProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+				Spec: v3.ProjectSpec{
+					ResourceQuota:                 nil,
+					NamespaceDefaultResourceQuota: nil,
+				},
+			},
+			wantAllowed: true,
+		},
+		{
+			name:      "update with new valid quotas",
+			operation: admissionv1.Update,
+			oldProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+			},
+			newProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+				Spec: v3.ProjectSpec{
+					ResourceQuota: &v3.ProjectResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "10",
+						},
+					},
+					NamespaceDefaultResourceQuota: &v3.NamespaceResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "10",
+						},
+					},
+				},
+			},
+			wantAllowed: true,
+		},
+		{
+			name:      "update with project quota present but namespace quota missing",
+			operation: admissionv1.Update,
+			oldProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+			},
+			newProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+				Spec: v3.ProjectSpec{
+					ResourceQuota: &v3.ProjectResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "10",
+						},
+					},
+				},
+			},
+			wantAllowed: false,
+		},
+		{
+			name:      "update with namespace quota present but project quota missing",
+			operation: admissionv1.Update,
+			oldProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+			},
+			newProject: &v3.Project{
+				Spec: v3.ProjectSpec{
+					NamespaceDefaultResourceQuota: &v3.NamespaceResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "10",
+						},
+					},
+				},
+			},
+			wantAllowed: false,
+		},
+		{
+			name:      "update with namespace quota having unexpected resource fields",
+			operation: admissionv1.Update,
+			oldProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+			},
+			newProject: &v3.Project{
+				Spec: v3.ProjectSpec{
+					ResourceQuota: &v3.ProjectResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "10",
+						},
+					},
+					NamespaceDefaultResourceQuota: &v3.NamespaceResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "10",
+							LimitsCPU:  "10m",
+						},
+					},
+				},
+			},
+			wantAllowed: false,
+		},
+		{
+			name:      "update with project quota having unexpected resource fields",
+			operation: admissionv1.Update,
+			oldProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+			},
+			newProject: &v3.Project{
+				Spec: v3.ProjectSpec{
+					ResourceQuota: &v3.ProjectResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "10",
+							LimitsCPU:  "10m",
+						},
+					},
+					NamespaceDefaultResourceQuota: &v3.NamespaceResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "10",
+						},
+					},
+				},
+			},
+			wantAllowed: false,
+		},
+		{
+			name:      "update with project quota and namespace quota having mismatched resource fields",
+			operation: admissionv1.Update,
+			oldProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+			},
+			newProject: &v3.Project{
+				Spec: v3.ProjectSpec{
+					ResourceQuota: &v3.ProjectResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "10",
+							LimitsCPU:  "10m",
+						},
+					},
+					NamespaceDefaultResourceQuota: &v3.NamespaceResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps:   "10",
+							LimitsMemory: "2048Mi",
+						},
+					},
+				},
+			},
+			wantAllowed: false,
+		},
+		{
+			name:      "update with namespace quota greater than project quota",
+			operation: admissionv1.Update,
+			oldProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+			},
+			newProject: &v3.Project{
+				Spec: v3.ProjectSpec{
+					ResourceQuota: &v3.ProjectResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "10",
+						},
+					},
+					NamespaceDefaultResourceQuota: &v3.NamespaceResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "100",
+						},
+					},
+				},
+			},
+			wantAllowed: false,
+		},
+		{
+			name:      "update with project quota less than used quota",
+			operation: admissionv1.Update,
+			oldProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+				Spec: v3.ProjectSpec{
+					ResourceQuota: &v3.ProjectResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "100",
+						},
+						UsedLimit: v3.ResourceQuotaLimit{
+							ConfigMaps: "100",
+						},
+					},
+					NamespaceDefaultResourceQuota: &v3.NamespaceResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "50",
+						},
+					},
+				},
+			},
+			newProject: &v3.Project{
+				Spec: v3.ProjectSpec{
+					ResourceQuota: &v3.ProjectResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "60",
+						},
+						UsedLimit: v3.ResourceQuotaLimit{
+							ConfigMaps: "100",
+						},
+					},
+					NamespaceDefaultResourceQuota: &v3.NamespaceResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "50",
+						},
+					},
+				},
+			},
+			wantAllowed: false,
+		},
+		{
+			name:      "update with project quota less than namespace quota times number of namespaces",
+			operation: admissionv1.Update,
+			oldProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+				Spec: v3.ProjectSpec{
+					ResourceQuota: &v3.ProjectResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "20",
+						},
+						UsedLimit: v3.ResourceQuotaLimit{
+							ConfigMaps: "10",
+						},
+					},
+					NamespaceDefaultResourceQuota: &v3.NamespaceResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "5",
+						},
+					},
+				},
+			},
+			newProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+				Spec: v3.ProjectSpec{
+					ResourceQuota: &v3.ProjectResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "20",
+							LimitsCPU:  "15m",
+						},
+						UsedLimit: v3.ResourceQuotaLimit{
+							ConfigMaps: "10",
+						},
+					},
+					NamespaceDefaultResourceQuota: &v3.NamespaceResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "5",
+							LimitsCPU:  "10m",
+						},
+					},
+				},
+			},
+			namespaces: []*corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testns1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testns2",
+					},
+				},
+			},
+			wantAllowed: false,
+		},
+		{
+			name:      "update with fields changed in project quota less than used quota",
+			operation: admissionv1.Update,
+			oldProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+				Spec: v3.ProjectSpec{
+					ResourceQuota: &v3.ProjectResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							LimitsCPU: "100m",
+						},
+						UsedLimit: v3.ResourceQuotaLimit{
+							LimitsCPU: "100m",
+						},
+					},
+					NamespaceDefaultResourceQuota: &v3.NamespaceResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							LimitsCPU: "50m",
+						},
+					},
+				},
+			},
+			newProject: &v3.Project{
+				Spec: v3.ProjectSpec{
+					ResourceQuota: &v3.ProjectResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "100",
+						},
+						UsedLimit: v3.ResourceQuotaLimit{
+							LimitsCPU: "100m",
+						},
+					},
+					NamespaceDefaultResourceQuota: &v3.NamespaceResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "50",
+						},
+					},
+				},
+			},
+			namespaces: []*corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testns1",
+					},
+				},
+			},
+			wantAllowed: true,
+		},
+		{
+			name:      "delete regular project",
+			operation: admissionv1.Delete,
+			oldProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+			},
+			wantAllowed: true,
+		},
+		{
+			name:      "delete system project",
+			operation: admissionv1.Delete,
+			oldProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+					Labels: map[string]string{
+						"authz.management.cattle.io/system-project": "true",
+					},
+				},
+			},
+			wantAllowed: false,
+		},
+		{
+			name:      "update with negative namespace quota",
+			operation: admissionv1.Update,
+			oldProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+				Spec: v3.ProjectSpec{
+					ResourceQuota: &v3.ProjectResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "100",
+						},
+					},
+					NamespaceDefaultResourceQuota: &v3.NamespaceResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "10",
+						},
+					},
+				},
+			},
+			newProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+				Spec: v3.ProjectSpec{
+					ResourceQuota: &v3.ProjectResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "100",
+						},
+					},
+					NamespaceDefaultResourceQuota: &v3.NamespaceResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "-200",
+						},
+					},
+				},
+			},
+			wantAllowed: false,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			req, err := createProjectRequest(test.oldProject, test.newProject, test.operation, false)
+			assert.NoError(t, err)
+			namespaceCache := fake.NewMockNonNamespacedCacheInterface[*corev1.Namespace](gomock.NewController(t))
+			if test.namespaces != nil {
+				namespaceCache.EXPECT().List(labels.Set(map[string]string{"field.cattle.io/projectId": test.oldProject.Name}).AsSelector()).Return(
+					test.namespaces,
+					nil,
+				).AnyTimes()
+			}
+			validator := NewValidator(namespaceCache)
+			admitters := validator.Admitters()
+			assert.Len(t, admitters, 1)
+			response, err := admitters[0].Admit(req)
+			if test.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, test.wantAllowed, response.Allowed)
+		})
+	}
+}
+
+func createProjectRequest(oldProject, newProject *v3.Project, operation v1.Operation, dryRun bool) (*admission.Request, error) {
+	gvk := metav1.GroupVersionKind{Group: "management.cattle.io", Version: "v3", Kind: "Project"}
+	gvr := metav1.GroupVersionResource{Group: "management.cattle.io", Version: "v3", Resource: "projects"}
+	req := &admission.Request{
+		Context: context.Background(),
+	}
+	if oldProject == nil && newProject == nil {
+		return req, nil
+	}
+	req.AdmissionRequest = v1.AdmissionRequest{
+		Kind:            gvk,
+		Resource:        gvr,
+		RequestKind:     &gvk,
+		RequestResource: &gvr,
+		Operation:       operation,
+		Object:          runtime.RawExtension{},
+		OldObject:       runtime.RawExtension{},
+		DryRun:          &dryRun,
+	}
+	if newProject != nil {
+		var err error
+		req.Object.Raw, err = json.Marshal(newProject)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if oldProject != nil {
+		obj, err := json.Marshal(oldProject)
+		if err != nil {
+			return nil, err
+		}
+		req.OldObject = runtime.RawExtension{
+			Raw: obj,
+		}
+	}
+	return req, nil
+}

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -42,7 +42,7 @@ func Validation(clients *clients.Clients) ([]admission.ValidatingAdmissionHandle
 		roleTemplates := roletemplate.NewValidator(clients.DefaultResolver, clients.RoleTemplateResolver, clients.K8s.AuthorizationV1().SubjectAccessReviews())
 		secrets := secret.NewValidator(clients.RBAC.Role().Cache(), clients.RBAC.RoleBinding().Cache())
 		nodeDriver := nodedriver.NewValidator(clients.Management.Node().Cache(), clients.Dynamic)
-		projects := project.NewValidator(clients.Core.Namespace().Cache())
+		projects := project.NewValidator()
 
 		handlers = append(handlers, psact, globalRoles, globalRoleBindings, prtbs, crtbs, roleTemplates, secrets, nodeDriver, projects)
 	}

--- a/tests/integration/project_test.go
+++ b/tests/integration/project_test.go
@@ -1,0 +1,137 @@
+package integration_test
+
+import (
+	"context"
+	"encoding/json"
+	"math/rand"
+	"time"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	clusterName = "local"
+	displayName = "p1"
+)
+
+func (m *IntegrationSuite) TestValidateProject() {
+	client, err := m.clientFactory.ForKind(schema.GroupVersionKind{Group: "management.cattle.io", Version: "v3", Kind: "Project"})
+	m.Require().NoError(err)
+	ctx := context.Background()
+	newObj := func() *v3.Project { return &v3.Project{} }
+	validCreateObj := &v3.Project{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      randomName(),
+			Namespace: clusterName,
+		},
+		Spec: v3.ProjectSpec{
+			DisplayName: displayName,
+			ClusterName: clusterName,
+			ResourceQuota: &v3.ProjectResourceQuota{
+				Limit: v3.ResourceQuotaLimit{
+					ConfigMaps: "20",
+				},
+			},
+			NamespaceDefaultResourceQuota: &v3.NamespaceResourceQuota{
+				Limit: v3.ResourceQuotaLimit{
+					ConfigMaps: "10",
+				},
+			},
+		},
+	}
+	invalidCreate := func() *v3.Project {
+		invalidCreateObj := validCreateObj.DeepCopy()
+		invalidCreateObj.Spec.NamespaceDefaultResourceQuota.Limit.ConfigMaps = "100"
+		return invalidCreateObj
+	}
+	validUpdate := func(created *v3.Project) *v3.Project {
+		validUpdateObj := created.DeepCopy()
+		validUpdateObj.Spec.ResourceQuota.Limit.ConfigMaps = "30"
+		return validUpdateObj
+	}
+	invalidUpdate := func(created *v3.Project) *v3.Project {
+		// Normally, rancher would update the used limit when more namespaces are created that use up the quota.
+		// Here, rancher isn't running so we have to simulate it by updating the used limit directly.
+		updateUsedLimitObj := created.DeepCopy()
+		updateUsedLimitObj.Spec.ResourceQuota.UsedLimit.ConfigMaps = "20"
+		result := &v3.Project{}
+		patch, err := createPatch(result, updateUsedLimitObj)
+		m.Require().NoError(err)
+		err = client.Patch(ctx, updateUsedLimitObj.GetNamespace(), updateUsedLimitObj.GetName(), types.JSONPatchType, patch, result, metav1.PatchOptions{})
+		m.Require().NoError(err)
+		result.Spec.ResourceQuota.Limit.ConfigMaps = "15"
+		return result
+	}
+	validDelete := func() *v3.Project {
+		return validCreateObj
+	}
+	invalidDelete := func() *v3.Project {
+		projects := &v3.ProjectList{}
+		opts := metav1.ListOptions{LabelSelector: "authz.management.cattle.io/system-project=true"}
+		err = client.List(ctx, "local", projects, opts)
+		require.NoError(m.T(), err)
+		systemProject := projects.Items[0]
+		return &systemProject
+	}
+	endpoints := &endPointObjs[*v3.Project]{
+		newObj:         newObj,
+		invalidCreate:  invalidCreate,
+		validCreateObj: validCreateObj,
+		invalidUpdate:  invalidUpdate,
+		validUpdate:    validUpdate,
+		validDelete:    validDelete,
+		invalidDelete:  invalidDelete,
+	}
+	validateEndpoints(m.T(), endpoints, m.clientFactory)
+}
+
+func (m *IntegrationSuite) TestMutateProject() {
+	projectClient, err := m.clientFactory.ForKind(schema.GroupVersionKind{Group: "management.cattle.io", Version: "v3", Kind: "Project"})
+	m.Require().NoError(err)
+	rtClient, err := m.clientFactory.ForKind(schema.GroupVersionKind{Group: "management.cattle.io", Version: "v3", Kind: "RoleTemplate"})
+	m.Require().NoError(err)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	defer cancel()
+	rt := &v3.RoleTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "test-project-creator-",
+		},
+		ProjectCreatorDefault: true,
+	}
+	err = rtClient.Create(ctx, "", rt, rt, metav1.CreateOptions{})
+	m.Require().NoError(err)
+	defer rtClient.Delete(ctx, "", rt.Name, metav1.DeleteOptions{})
+	validCreateObj := &v3.Project{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      randomName(),
+			Namespace: clusterName,
+		},
+	}
+	result := &v3.Project{}
+	err = projectClient.Create(ctx, validCreateObj.Namespace, validCreateObj, result, metav1.CreateOptions{})
+	m.Require().NoError(err)
+	m.Require().Contains(result.Annotations, "authz.management.cattle.io/creator-role-bindings")
+	annos := result.Annotations["authz.management.cattle.io/creator-role-bindings"]
+	annosMap := make(map[string]any)
+	err = json.Unmarshal([]byte(annos), &annosMap)
+	m.Require().NoError(err)
+	m.Require().Contains(annosMap, "required")
+	m.Require().Contains(annosMap["required"], rt.ObjectMeta.Name)
+	err = projectClient.Delete(ctx, validCreateObj.Namespace, validCreateObj.Name, metav1.DeleteOptions{})
+	m.Require().NoError(err)
+}
+
+var seededRand = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+func randomName() string {
+	const charset = "abcdefghijklmnopqrstuvwxyz"
+	b := make([]byte, 5)
+	for i := 0; i < 5; i++ {
+		b[i] = charset[seededRand.Intn(len(charset))]
+	}
+	return "p-test-" + string(b)
+}


### PR DESCRIPTION
# Add validation and mutation for Projects

New validations:
- prohibit deleting the system project
- check that quota fields are consistent with one another and sufficient
  for existing quota usage

New mutations:
- adds creator-role-bindings annotation

# Refactor project quota validator

Refactor code that was largely copied from the norman store in Rancher:

- rename variables and functions for clarity
- break up functions into logical units
- rename imports according to standard conventions and for clarity
- remove the ephemeral updates to the used quota object,
  quotav1.LessThanOrEqual already does not compare resources that aren't
  present in both objects[1]
- remove project mutex. Only one goroutine (the webhook) should be
  accessing the project and its namespaces. Callers (rancher/rancher)
  should implement their own lock before counting namespaces.

[1] https://github.com/kubernetes/apiserver/blob/d2172f30e1af3782a7124e21b8cb4676fc789acc/pkg/quota/v1/resources.go#L50-L62
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Projects are not validated or correctly annotated unless they are created through the norman API, so they must not be created through k8s or steve.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Port the norman validations and transformations to webhook validators and mutators.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

Automated tests:
* Added unit tests
* Added integration tests to webhook
* Existing integration tests in rancher/rancher

Manual tests:
* create projects and namespaces manually with kubectl, setting different quota values. Results should be the same as if they were created through the norman API/dashboard. Example manual tests: https://gist.github.com/cmurphy/3dd7555ec01bd2b6d1a3d885bb4c0c8e