### PR TITLE
Adds the ability to set custom ports for Webhook.

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -3,12 +3,18 @@ FROM registry.suse.com/bci/golang:1.19
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
 
+ENV HELM_VERSION v3.12.1
+ENV HELM_UNITTEST_VERSION 0.3.2
+
 RUN zypper -n install git docker vim less file curl wget awk
+
+RUN curl -sL https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz | tar xvzf - -C /usr/local/bin --strip-components=1
+
 RUN if [ "${ARCH}" = "amd64" ]; then \
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.52.2; \
+        helm plugin install https://github.com/helm-unittest/helm-unittest.git --version ${HELM_UNITTEST_VERSION}>/out.txt 2>&1; \
     fi
-ENV HELM_VERSION v3.12.1
-RUN curl -sL https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz | tar xvzf - -C /usr/local/bin --strip-components=1
+
 RUN GOBIN=/usr/local/bin go install github.com/golang/mock/mockgen@v1.6.0
 
 ENV DAPPER_ENV REPO TAG DRONE_TAG CROSS

--- a/charts/rancher-webhook/charts/capi/templates/service.yaml
+++ b/charts/rancher-webhook/charts/capi/templates/service.yaml
@@ -8,6 +8,6 @@ spec:
   ports:
   - name: https
     port: 443
-    targetPort: 8777
+    targetPort: {{ .Values.port | default 8777 }}
   selector:
     app: rancher-webhook

--- a/charts/rancher-webhook/templates/deployment.yaml
+++ b/charts/rancher-webhook/templates/deployment.yaml
@@ -36,6 +36,10 @@ spec:
           value: "{{.Values.capi.enabled}}"
         - name: ENABLE_MCM
           value: "{{.Values.mcm.enabled}}"
+        - name: CATTLE_PORT
+          value: {{.Values.port | default 9443 | quote}}
+        - name: CATTLE_CAPI_PORT
+          value: {{.Values.capi.port | default 8777 | quote}}
         - name: NAMESPACE
           valueFrom:
             fieldRef:
@@ -45,9 +49,9 @@ spec:
         imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"
         ports:
         - name: https
-          containerPort: 9443
+          containerPort: {{ .Values.port | default 9443 }}
         - name: capi-https
-          containerPort: 8777
+          containerPort: {{ .Values.capi.port | default 8777}}
         startupProbe:
           httpGet:
             path: "/healthz"
@@ -66,7 +70,14 @@ spec:
         - name: tls
           mountPath: /tmp/k8s-webhook-server/serving-certs
         {{- end }}
+        {{- if .Values.capNetBindService }}
+        securityContext:
+          capabilities:
+            add:
+            - NET_BIND_SERVICE 
+        {{- end }}
       serviceAccountName: rancher-webhook
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{.Values.priorityClassName}}"
       {{- end }}
+      

--- a/charts/rancher-webhook/templates/service.yaml
+++ b/charts/rancher-webhook/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   ports:
   - port: 443
-    targetPort: 9443
+    targetPort: {{ .Values.port | default 9443 }}
     protocol: TCP
     name: https
   selector:

--- a/charts/rancher-webhook/tests/README.md
+++ b/charts/rancher-webhook/tests/README.md
@@ -1,0 +1,16 @@
+
+## local dev testing instructions
+
+Option 1: Full chart CI run with a live cluster
+
+```bash
+./scripts/charts/ci 
+```
+
+Option 2: Test runs against the chart only 
+
+```bash
+# install the helm plugin first - helm plugin install https://github.com/helm-unittest/helm-unittest.git
+bash dev-scripts/helm-unittest.sh
+```
+

--- a/charts/rancher-webhook/tests/capi-service_test.yaml
+++ b/charts/rancher-webhook/tests/capi-service_test.yaml
@@ -1,0 +1,20 @@
+suite: Test Service
+templates:
+  - charts/capi/templates/service.yaml
+tests:
+  - it: should set webhook default port values
+    set:
+      capi.enabled: true
+    asserts:
+      - equal:
+          path: spec.ports[0].targetPort
+          value: 8777
+
+  - it: should set updated target port
+    set:
+      capi.port: 2319
+      capi.enabled: true
+    asserts:
+      - equal:
+          path: spec.ports[0].targetPort
+          value: 2319

--- a/charts/rancher-webhook/tests/deployment_test.yaml
+++ b/charts/rancher-webhook/tests/deployment_test.yaml
@@ -1,0 +1,62 @@
+suite: Test Deployment
+templates:
+  - deployment.yaml
+
+tests:
+  - it: should set webhook default port values
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 9443
+      - equal:
+          path: spec.template.spec.containers[0].ports[1].containerPort
+          value: 8777
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CATTLE_PORT
+            value: "9443"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CATTLE_CAPI_PORT
+            value: "8777"
+
+  - it: should set updated webhook port
+    set:
+      port: 2319
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 2319
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CATTLE_PORT
+            value: "2319"
+
+  - it: should set updated capi port
+    set:
+      capi.port: 2319
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[1].containerPort
+          value: 2319
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CATTLE_CAPI_PORT
+            value: "2319"
+
+  - it: should not set capabilities by default.
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].securityContext
+
+  - it: should set net capabilities when capNetBindService is true.
+    set:
+      capNetBindService: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.add
+          content: NET_BIND_SERVICE

--- a/charts/rancher-webhook/tests/service_test.yaml
+++ b/charts/rancher-webhook/tests/service_test.yaml
@@ -1,0 +1,18 @@
+suite: Test Service
+templates:
+  - service.yaml
+
+tests:
+  - it: should set webhook default port values
+    asserts:
+      - equal:
+          path: spec.ports[0].targetPort
+          value: 9443
+
+  - it: should set updated target port
+    set:
+      port: 2319
+    asserts:
+      - equal:
+          path: spec.ports[0].targetPort
+          value: 2319

--- a/charts/rancher-webhook/values.yaml
+++ b/charts/rancher-webhook/values.yaml
@@ -10,6 +10,7 @@ global:
 
 capi:
   enabled: false
+  port: 8777
 
 mcm:
   enabled: true
@@ -20,3 +21,6 @@ nodeSelector: {}
 
 ## PriorityClassName assigned to deployment.
 priorityClassName: ""
+
+# port assigns which port to use when running rancher-webhook
+port: 9443

--- a/dev-scripts/helm-unittest.sh
+++ b/dev-scripts/helm-unittest.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cd $(dirname $0)/..
+./scripts/package-helm
+./scripts/test-helm

--- a/scripts/ci
+++ b/scripts/ci
@@ -8,3 +8,4 @@ cd $(dirname $0)
 ./validate
 ./validate-ci
 ./package
+./test-helm

--- a/scripts/integration-test
+++ b/scripts/integration-test
@@ -10,6 +10,7 @@ cd $(dirname $0)/../
 
 echo "Starting Rancher Server"
 entrypoint.sh >./rancher.log 2>&1 &
+RANCHER_PID=$!
 
 echo "Waiting for Rancher health check..."
 while ! curl -sf http://localhost:80/healthz >/dev/null 2>&1; do
@@ -27,9 +28,36 @@ while ! kubectl rollout status -w -n cattle-system deploy/rancher-webhook >/dev/
     echo "Waiting for rancher to deploy rancher-webhook..."
     sleep 2
 done
+echo "Webhook deployed"
 
 # After rancher deploys webhook kill the bash command running tail.
 kill ${TAIL_PID}
+
+# Wait for helm operation to complete and save rancher-webhook release info before we kill rancher and the cluster.
+while
+    pods=$(kubectl get pods -n cattle-system --field-selector=status.phase=Running -o jsonpath='{.items[?(@.metadata.generateName=="helm-operation-")].metadata.name}')
+    [[ -n "$pods" ]]
+do
+    echo "Waiting for helm operation to finish"
+    sleep 2
+done
+
+# Kill Rancher since we only need the CRDs and the initial webhook values.
+# We do not want Rancher to reconcile an older version of the webhook during test.
+kill ${RANCHER_PID}
+
+echo "Rancher has been stopped starting K3s."
+# Start Cluster without Rancher.
+k3s server --cluster-init --disable=traefik,servicelb,metrics-server,local-storage --node-name=local-node --log=./k3s.log >/dev/null 2>&1 &
+KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+
+# Wait for cluster to start.
+while ! kubectl version >/dev/null 2>&1; do
+    echo "Waiting for cluster to start"
+    sleep 5
+done
+
+echo "Uploading new webhook image"
 
 ###### Upload the newly created webhook image to containerd, then install the webhook chart using the new image
 IMAGE_FILE=./dist/rancher-webhook-image.tar
@@ -40,15 +68,28 @@ WEBHOOK_REPO=$(ctr image import ${IMAGE_FILE} | cut -d ' ' -f 2 | cut -d ':' -f 
 source ./dist/tags
 
 # Install the webhook chart we just built.
-helm upgrade rancher-webhook ./dist/artifacts/rancher-webhook-${HELM_VERSION}.tgz -n cattle-system --set image.repository=${WEBHOOK_REPO} --set image.tag=${TAG} --reuse-values
-
-while ! kubectl rollout status -w -n cattle-system deploy/rancher-webhook; do
+# This command can fail since it is so close to the cluster start so we will give it 3 retires.
+RETRIES=0
+while ! helm upgrade rancher-webhook ./dist/artifacts/rancher-webhook-${HELM_VERSION}.tgz -n cattle-system \
+    --wait --set image.repository=${WEBHOOK_REPO} --set image.tag=${TAG} --reuse-values; do
+    if [ "$RETRIES" -ge 3 ]; then
+        exit 1
+    fi
+    RETRIES=$((RETRIES + 1))
     sleep 2
 done
 
 ./bin/rancher-webhook-integration.test -test.v -test.run IntegrationTest
 
-# Scale down rancher-webhook so that we can run tests on the FailurePolicy
+# Install the webhook chart with new ports.
+helm upgrade rancher-webhook ./dist/artifacts/rancher-webhook-${HELM_VERSION}.tgz -n cattle-system \
+    --wait --reuse-values --set port=443 --set capi.port=2319
+
+# Test that the ports are set as expected and run a single integration test to verify the webhook is still accessible.
+./bin/rancher-webhook-integration.test -test.v -test.run PortTest
+./bin/rancher-webhook-integration.test -test.v -test.run IntegrationTest -testify.m TestGlobalRole
+
+# Scale down rancher-webhook so that we can run tests on the FailurePolicy.
 kubectl scale deploy rancher-webhook -n cattle-system --replicas=0
 kubectl wait pods -l app=rancher-webhook --for=delete -n cattle-system
 ./bin/rancher-webhook-integration.test -test.v -test.run FailurePolicyTest

--- a/scripts/package-helm
+++ b/scripts/package-helm
@@ -12,13 +12,16 @@ rm -rf build/charts
 mkdir -p build dist/artifacts
 cp -rf charts build/
 
-sed -i \
+# must use sed -i'<backup_extension>'` for GNU and OSX compatibility
+sed -i'.bkp' \
     -e 's/^version:.*/version: '${HELM_VERSION}'/' \
     -e 's/appVersion:.*/appVersion: '${HELM_VERSION}'/' \
     build/charts/rancher-webhook/Chart.yaml
 
-sed -i \
+sed -i'.bkb' \
     -e 's/tag: latest/tag: '${HELM_TAG}'/' \
     build/charts/rancher-webhook/values.yaml
+
+rm build/charts/rancher-webhook/Chart.yaml.bkp build/charts/rancher-webhook/values.yaml.bkb
 
 helm package -d ./dist/artifacts ./build/charts/rancher-webhook

--- a/scripts/test-helm
+++ b/scripts/test-helm
@@ -1,0 +1,15 @@
+#! /bin/bash
+set -e
+cd $(dirname $0)/..
+
+./scripts/package-helm
+echo Running helm lint
+helm lint ./charts/rancher-webhook
+# Check for unittest plugin
+if helm unittest --help >/dev/null 2>&1; then
+    helm unittest build/charts/rancher-webhook
+else
+    echo "skipping helm unittest"
+    echo "helm plugin unittest not found."
+    echo "Run to install plugin: helm plugin install https://github.com/helm-unittest/helm-unittest.git"
+fi

--- a/scripts/validate-ci
+++ b/scripts/validate-ci
@@ -16,9 +16,6 @@ go mod verify
 
 source ./scripts/version
 
-echo Running helm lint
-helm lint ./charts/rancher-webhook
-
 if [ -n "$DIRTY" ]; then
     echo Git is dirty
     git status

--- a/tests/integration/port_test.go
+++ b/tests/integration/port_test.go
@@ -1,0 +1,81 @@
+package integration_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/rancher/lasso/pkg/client"
+	"github.com/rancher/wrangler/pkg/kubeconfig"
+	"github.com/rancher/wrangler/pkg/schemes"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const (
+	testWebhookPort = 443
+	testCapiPort    = 2319
+)
+
+type PortSuite struct {
+	suite.Suite
+	clientFactory client.SharedClientFactory
+}
+
+// TestPortTest should be run only when the webhook is not running.
+func TestPortTest(t *testing.T) {
+	suite.Run(t, new(PortSuite))
+}
+
+func (m *PortSuite) SetupSuite() {
+	logrus.SetLevel(logrus.DebugLevel)
+	kubeconfigPath := os.Getenv("KUBECONFIG")
+	restCfg, err := kubeconfig.GetNonInteractiveClientConfig(kubeconfigPath).ClientConfig()
+	m.Require().NoError(err, "Failed to clientFactory config")
+	m.clientFactory, err = client.NewSharedClientFactoryForConfig(restCfg)
+	m.Require().NoError(err, "Failed to create clientFactory Interface")
+
+	schemes.Register(corev1.AddToScheme)
+}
+
+func (m *PortSuite) TestWebhookPortChanged() {
+	podGVK := schema.GroupVersionKind{
+		Group:   "",
+		Version: "v1",
+		Kind:    "Pod",
+	}
+
+	podClient, err := m.clientFactory.ForKind(podGVK)
+	m.Require().NoError(err, "Failed to create client")
+	listOpts := v1.ListOptions{
+		LabelSelector: "app=rancher-webhook",
+	}
+	pods := corev1.PodList{}
+	podClient.List(context.Background(), "cattle-system", &pods, listOpts)
+	var webhookPod *corev1.Pod
+	for _, pod := range pods.Items {
+		if pod.Status.Phase == corev1.PodRunning {
+			if webhookPod != nil {
+				m.Require().FailNow("more then one rancher-webhook pod is running")
+			}
+			webhookPod = &pod
+		}
+	}
+	if webhookPod == nil {
+		m.Require().FailNow("running webhook pod not found")
+	}
+	m.Require().Equal(corev1.PodRunning, webhookPod.Status.Phase, "Rancher-webhook pod is not running Phase=%s", webhookPod.Status.Phase)
+	m.Require().Len(webhookPod.Spec.Containers, 1, "Rancher-webhook pod has the incorrect number of containers")
+	m.Require().Len(webhookPod.Spec.Containers[0].Ports, 2, "Rancher-webhook container has the incorrect number of ports")
+	havePort1 := webhookPod.Spec.Containers[0].Ports[0].ContainerPort
+	havePort2 := webhookPod.Spec.Containers[0].Ports[1].ContainerPort
+	if havePort1 != testWebhookPort && havePort2 != testWebhookPort {
+		m.Require().FailNowf("expected webhook port not found", "wanted '%d' was not found instead have '%d' and '%d'", testWebhookPort, havePort1, havePort2)
+	}
+	if havePort1 != testCapiPort && havePort2 != testCapiPort {
+		m.Require().FailNowf("expected capi port not found", "wanted '%d' was not found instead have '%d' and '%d'", testCapiPort, havePort1, havePort2)
+	}
+}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/41142 & https://github.com/rancher/webhook/issues/211

First Commit: 
Adds the ability to customize the ports used by the webhook via helm values. 
Integration tests were updated to stop the running Rancher instance from downgrading the webhook during the tests.
To fix this, the test run rancher for the initial webhook installation. Then Rancher is stopped, and K3s is manually started.


