### PR TITLE
Prevent builtIn roleTemplates from being created or updated

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -177,7 +177,9 @@ If the `roletemplates.administrative` is set to true the context must equal `"cl
 
 #### Builtin Validation
 
-The `roletemplates.builtin` field is immutable. If `roletemplates.builtin` is true then all fields are immutable except:
+The `roletemplates.builtin` field is immutable, and new builtIn RoleTemplates cannot be created.
+
+If `roletemplates.builtin` is true then all fields are immutable except:
 - `metadata` 
 - `clusterCreatorDefault` 
 - `projectCreatorDefault`

--- a/pkg/resources/management.cattle.io/v3/roletemplate/RoleTemplate.md
+++ b/pkg/resources/management.cattle.io/v3/roletemplate/RoleTemplate.md
@@ -21,7 +21,9 @@ If the `roletemplates.administrative` is set to true the context must equal `"cl
 
 ### Builtin Validation
 
-The `roletemplates.builtin` field is immutable. If `roletemplates.builtin` is true then all fields are immutable except:
+The `roletemplates.builtin` field is immutable, and new builtIn RoleTemplates cannot be created.
+
+If `roletemplates.builtin` is true then all fields are immutable except:
 - `metadata` 
 - `clusterCreatorDefault` 
 - `projectCreatorDefault`

--- a/pkg/resources/management.cattle.io/v3/roletemplate/validator.go
+++ b/pkg/resources/management.cattle.io/v3/roletemplate/validator.go
@@ -152,8 +152,11 @@ func (a *admitter) validateUpdateFields(oldRole, newRole *v3.RoleTemplate, fldPa
 		return err
 	}
 
-	// if this is not a built in role no further validation is needed
+	// if this is not a built in role, prevent it from becoming one. Otherwise, no further validation is needed
 	if !oldRole.Builtin {
+		if newRole.Builtin {
+			return field.Forbidden(fldPath, fmt.Sprintf("cannot update non-builtIn RoleTemplate %s to be builtIn", oldRole.Name))
+		}
 		return nil
 	}
 
@@ -174,6 +177,9 @@ func (a *admitter) validateUpdateFields(oldRole, newRole *v3.RoleTemplate, fldPa
 
 // validateCreateFields checks if all required fields are present and valid.
 func validateCreateFields(newRole *v3.RoleTemplate, fldPath *field.Path) *field.Error {
+	if newRole.Builtin {
+		return field.Forbidden(fldPath, "creating new builtIn RoleTemplates is forbidden")
+	}
 	return validateContextValue(newRole, fldPath)
 }
 

--- a/pkg/resources/management.cattle.io/v3/roletemplate/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/roletemplate/validator_test.go
@@ -342,7 +342,7 @@ func (r *RoleTemplateSuite) Test_UpdateValidation() {
 			allowed: true,
 		},
 		{
-			name: "update Builtin field",
+			name: "update Builtin field from true to false",
 			args: args{
 				username: testUser,
 				oldRT: func() *v3.RoleTemplate {
@@ -353,6 +353,23 @@ func (r *RoleTemplateSuite) Test_UpdateValidation() {
 				newRT: func() *v3.RoleTemplate {
 					baseRT := newDefaultRT()
 					baseRT.Builtin = false
+					return baseRT
+				},
+			},
+			allowed: false,
+		},
+		{
+			name: "update Builtin field from false to true",
+			args: args{
+				username: testUser,
+				oldRT: func() *v3.RoleTemplate {
+					baseRT := newDefaultRT()
+					baseRT.Builtin = false
+					return baseRT
+				},
+				newRT: func() *v3.RoleTemplate {
+					baseRT := newDefaultRT()
+					baseRT.Builtin = true
 					return baseRT
 				},
 			},
@@ -535,6 +552,21 @@ func (r *RoleTemplateSuite) Test_Create() {
 					baseRT.Rules = r.manageNodeRole.Rules
 					baseRT.Administrative = true
 					baseRT.Context = "namespace"
+					return baseRT
+				},
+			},
+			allowed: false,
+		},
+		{
+			name: "create new builtIn RoleTemplate",
+			args: args{
+				username: adminUser,
+				oldRT: func() *v3.RoleTemplate {
+					return nil
+				},
+				newRT: func() *v3.RoleTemplate {
+					baseRT := newDefaultRT()
+					baseRT.Builtin = true
 					return baseRT
 				},
 			},


### PR DESCRIPTION
## Issue: 
 
## Problem
The `builtin` field can be updated from `false` to `true`, which we do not want. It is also possible to create a new builtin RoleTemplate.
 
## Solution
This adds 2 checks to the webhook:
- Prevent the creation of new RoleTemplates with `builtin` set to `true`
- Prevent existing, non-builtin RoleTemplates from being updated with `builtin` set to `true`
 
## Testing
Added unit tests to cover these scenarios
