### PR TITLE
Add check for roleTemplate context in CRTBs

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -59,8 +59,10 @@ Users cannot create ClusterRoleTemplateBindings which violate the following cons
 - Either a user subject (through `UserName` or `UserPrincipalName`) or a group subject (through `GroupName` or `GroupPrincipalName`) must be specified; both a user subject and a group subject cannot be specified
 - `ClusterName` must be specified
 - The roleTemplate indicated in `RoleTemplateName` must be:
-  - Valid (i.e. is an existing `roleTemplate` object in the `management.cattle.io/v3` API group)
+  - Provided as a non-empty value
+  - Valid (i.e. is an existing `roleTemplate` object of given name in the `management.cattle.io/v3` API group)
   - Not locked (i.e. `roleTemplate.Locked` must be `false`)
+  - Associated with its appropriate context (`roleTemplate.Context` must be equal to "cluster")
 
 #### Invalid Fields - Update
 

--- a/pkg/resources/management.cattle.io/v3/clusterroletemplatebinding/ClusterRoleTemplateBinding.md
+++ b/pkg/resources/management.cattle.io/v3/clusterroletemplatebinding/ClusterRoleTemplateBinding.md
@@ -10,8 +10,10 @@ Users cannot create ClusterRoleTemplateBindings which violate the following cons
 - Either a user subject (through `UserName` or `UserPrincipalName`) or a group subject (through `GroupName` or `GroupPrincipalName`) must be specified; both a user subject and a group subject cannot be specified
 - `ClusterName` must be specified
 - The roleTemplate indicated in `RoleTemplateName` must be:
-  - Valid (i.e. is an existing `roleTemplate` object in the `management.cattle.io/v3` API group)
+  - Provided as a non-empty value
+  - Valid (i.e. is an existing `roleTemplate` object of given name in the `management.cattle.io/v3` API group)
   - Not locked (i.e. `roleTemplate.Locked` must be `false`)
+  - Associated with its appropriate context (`roleTemplate.Context` must be equal to "cluster")
 
 ### Invalid Fields - Update
 

--- a/pkg/resources/management.cattle.io/v3/clusterroletemplatebinding/validator.go
+++ b/pkg/resources/management.cattle.io/v3/clusterroletemplatebinding/validator.go
@@ -174,5 +174,10 @@ func (a *admitter) validateCreateFields(newCRTB *apisv3.ClusterRoleTemplateBindi
 		return field.Forbidden(fieldPath.Child("roleTemplate"), fmt.Sprintf("referenced role %s is locked and cannot be assigned", roleTemplate.DisplayName))
 	}
 
+	const clusterContext = "cluster"
+	if roleTemplate.Context != clusterContext {
+		return field.NotSupported(fieldPath.Child("roleTemplate", "context"), roleTemplate.Context, []string{clusterContext})
+	}
+
 	return nil
 }

--- a/tests/integration/clusterRoleTemplateBinding_test.go
+++ b/tests/integration/clusterRoleTemplateBinding_test.go
@@ -57,6 +57,7 @@ func (m *IntegrationSuite) TestClusterRoleTemplateBinding() {
 				Resources: []string{"pods"},
 			},
 		},
+		Context: "cluster",
 	}
 	m.createObj(testRT, schema.GroupVersionKind{})
 	validateEndpoints(m.T(), endPoints, m.clientFactory)


### PR DESCRIPTION
## Problem
While migrating CRTB validation to the webhook, the check to ensure the `roleTemplate.Context` is `cluster` was missed. (From [here]( https://github.com/rancher/rancher/blob/4dc8b1808c17c7c19fe42a56b60b33b81dfa6452/pkg/api/norman/customization/roletemplatebinding/validator.go#L19))
 
## Solution
Added the check in the create validation to make sure the context is `cluster`. I also updated the docs to include this information. I kept it the same as [PRTB](https://github.com/rancher/webhook/blob/cfa7bcea894fa552499d49b28945b95a0867d0f1/pkg/resources/management.cattle.io/v3/projectroletemplatebinding/ProjectRoleTemplateBinding.md) for consistency.
 
## Testing
Tested this manually by creating a `roleTemplate` with `project` as the context and then attempting to create a CRTB using this `roleTemplate` using `kubectl`. Before the change this was possible. After the change I could no longer create the CRTB, as expected.

I also added a unit test for this scenario.