### PR TITLE
Add cert-based API server authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,9 @@ export CATTLE_WEBHOOK_URL="https://<NGROK_URL>.ngrok.io"
 ./bin/webhook
 ```
 After 15 seconds the webhook will update the `ValidatingWebhookConfiguration` and `MutatingWebhookConfiguration` in the Kubernetes cluster to point at the locally running instance.
+
+> :warning: Kubernetes API server authentication will not work with ngrok.
+
 ## License
 Copyright (c) 2019-2021 [Rancher Labs, Inc.](http://rancher.com)
 

--- a/charts/rancher-webhook/templates/deployment.yaml
+++ b/charts/rancher-webhook/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $auth := .Values.auth | default dict }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -11,11 +12,18 @@ spec:
       labels:
         app: rancher-webhook
     spec:
-      {{- if .Values.capi.enabled }}
+      {{- if or .Values.capi.enabled $auth.clientCA }}
       volumes:
+      {{- end }}
+      {{- if .Values.capi.enabled }}
       - name: tls
         secret:
           secretName: rancher-webhook-tls
+      {{- end }}
+      {{- if $auth.clientCA }}
+      - name: client-ca
+        secret:
+          secretName: client-ca
       {{- end }}
       {{- if .Values.global.hostNetwork }}
       hostNetwork: true
@@ -44,6 +52,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- if $auth.allowedCNs }}
+        - name: ALLOWED_CNS
+          value: '{{ join "," $auth.allowedCNs }}'
+        {{- end }}
         image: '{{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}'
         name: rancher-webhook
         imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"
@@ -65,19 +77,26 @@ spec:
             port: "https"
             scheme: "HTTPS"
           periodSeconds: 5
-        {{- if .Values.capi.enabled }}
+        {{- if or .Values.capi.enabled $auth.clientCA }}
         volumeMounts:
+        {{- end }}
+        {{- if .Values.capi.enabled }}
         - name: tls
           mountPath: /tmp/k8s-webhook-server/serving-certs
+          readOnly: true
+        {{- end }}
+        {{- if $auth.clientCA }}
+        - name: client-ca
+          mountPath: /tmp/k8s-webhook-server/client-ca
+          readOnly: true
         {{- end }}
         {{- if .Values.capNetBindService }}
         securityContext:
           capabilities:
             add:
-            - NET_BIND_SERVICE 
+            - NET_BIND_SERVICE
         {{- end }}
       serviceAccountName: rancher-webhook
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{.Values.priorityClassName}}"
       {{- end }}
-      

--- a/charts/rancher-webhook/templates/secret.yaml
+++ b/charts/rancher-webhook/templates/secret.yaml
@@ -1,0 +1,11 @@
+{{- $auth := .Values.auth | default dict }}
+{{- if $auth.clientCA }}
+apiVersion: v1
+data:
+  ca.crt: {{ $auth.clientCA }}
+kind: Secret
+metadata:
+  name: client-ca
+  namespace: cattle-system
+type: Opaque
+{{- end }}

--- a/charts/rancher-webhook/tests/deployment_test.yaml
+++ b/charts/rancher-webhook/tests/deployment_test.yaml
@@ -60,3 +60,35 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].securityContext.capabilities.add
           content: NET_BIND_SERVICE
+
+  - it: should not set volumes or volumeMounts by default
+    asserts:
+      - isNull:
+          path: spec.template.spec.volumes
+      - isNull:
+          path: spec.template.spec.volumeMounts
+
+  - it: should set CA fields when CA options are set
+    set:
+      auth.clientCA: base64-encoded-cert
+      auth.allowedCNs:
+        - kube-apiserver
+        - joe
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: client-ca
+            secret:
+              secretName: client-ca
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: client-ca
+            mountPath: /tmp/k8s-webhook-server/client-ca
+            readOnly: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ALLOWED_CNS
+            value: kube-apiserver,joe

--- a/charts/rancher-webhook/values.yaml
+++ b/charts/rancher-webhook/values.yaml
@@ -24,3 +24,11 @@ priorityClassName: ""
 
 # port assigns which port to use when running rancher-webhook
 port: 9443
+
+# Parameters for authenticating the kube-apiserver.
+auth:
+  # CA for authenticating kube-apiserver client certs. If empty, client connections will not be authenticated.
+  # Must be base64-encoded.
+  clientCA: ""
+  # Allowlist of CNs for kube-apiserver client certs. If empty, any cert signed by the CA provided in clientCA will be accepted.
+  allowedCNs: []

--- a/main.go
+++ b/main.go
@@ -30,6 +30,9 @@ func run() error {
 	if os.Getenv("CATTLE_DEBUG") == "true" || os.Getenv("RANCHER_DEBUG") == "true" {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
+	if os.Getenv("CATTLE_TRACE") == "true" {
+		logrus.SetLevel(logrus.TraceLevel)
+	}
 
 	logrus.Infof("Rancher-webhook version %s is starting", fmt.Sprintf("%s (%s)", Version, GitCommit))
 


### PR DESCRIPTION
Add the ability to authenticate incoming requests, verifying that all requests originate from the Kubernetes API server and no where else.

Authenticating the API server requires manual steps to configure both the API server and the webhook. Follow the Kubernetes webhook documentation[1] to create an admission configuration and kubeconfig for the API server, and update the kube-apiserver flags to use them. Only cert-based authentication is supported, basic auth and token authentication will not be recognized. Then, set auth.clientCA in the webhook chart's values.yaml to the base64-encoded CA for the certs, and set auth.allowedCNs to the CN for the client cert the apiserver will present.

[1] https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#authenticate-apiservers

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
The webhook accepts and processes any request from any client. This does not expose any secrets, but could lead to a DDOS attack.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Offer the ability to harden the webhook by having it require authentication from the kube-apiserver.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
Adds unit tests for helm chart values.

See linked issue for reproduction steps and documentation that can be used for manual testing.