### PR TITLE
Fix NodeDriver validation to ensure uniqueness + prevent race condition of CRD creation

### DIFF
--- a/pkg/resources/management.cattle.io/v3/nodedriver/validator.go
+++ b/pkg/resources/management.cattle.io/v3/nodedriver/validator.go
@@ -123,7 +123,7 @@ func (a *admitter) rke1ResourcesDeleted(driver *v3.NodeDriver) (bool, error) {
 			continue
 		}
 
-		if node.Status.NodeTemplateSpec.Driver == driver.Spec.DisplayName {
+		if node.Status.NodeTemplateSpec.Driver == driver.Name {
 			return false, nil
 		}
 	}
@@ -133,16 +133,16 @@ func (a *admitter) rke1ResourcesDeleted(driver *v3.NodeDriver) (bool, error) {
 
 // // RKE2
 // this one is pretty weird since we have to get the name of the CR we're
-// looking from the displayName of the driver.
+// looking from the Name of the driver.
 func (a *admitter) rke2ResourcesDeleted(driver *v3.NodeDriver) (bool, error) {
 	gvk := schema.GroupVersionKind{
 		Group:   "rke-machine.cattle.io",
 		Version: "v1",
-		Kind:    driver.Spec.DisplayName + "machine",
+		Kind:    driver.Name + "machine",
 	}
 	machines, err := a.dynamic.List(gvk, "", labels.Everything())
 	if err != nil {
-		return false, fmt.Errorf("error listing %smachines: %w", driver.Spec.DisplayName, err)
+		return false, fmt.Errorf("error listing %smachines: %w", driver.Name, err)
 	}
 
 	if len(machines) != 0 {

--- a/pkg/resources/management.cattle.io/v3/nodedriver/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/nodedriver/validator_test.go
@@ -193,10 +193,10 @@ func newNodeDriver(active bool, annotations map[string]string) []byte {
 	driver := v3.NodeDriver{
 		ObjectMeta: v1.ObjectMeta{
 			Annotations: annotations,
+			Name:        "testing",
 		},
 		Spec: v3.NodeDriverSpec{
-			DisplayName: "testing",
-			Active:      active,
+			Active: active,
 		},
 	}
 

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -41,7 +41,7 @@ func Validation(clients *clients.Clients) ([]admission.ValidatingAdmissionHandle
 		crtbs := clusterroletemplatebinding.NewValidator(crtbResolver, clients.DefaultResolver, clients.RoleTemplateResolver)
 		roleTemplates := roletemplate.NewValidator(clients.DefaultResolver, clients.RoleTemplateResolver, clients.K8s.AuthorizationV1().SubjectAccessReviews())
 		secrets := secret.NewValidator(clients.RBAC.Role().Cache(), clients.RBAC.RoleBinding().Cache())
-		nodeDriver := nodedriver.NewValidator(clients.Management.Node().Cache(), clients.Dynamic)
+		nodeDriver := nodedriver.NewValidator(clients.Management.Node().Cache(), clients.Dynamic, clients.CRD.CustomResourceDefinition().Cache())
 		projects := project.NewValidator()
 
 		handlers = append(handlers, psact, globalRoles, globalRoleBindings, prtbs, crtbs, roleTemplates, secrets, nodeDriver, projects)


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/42378 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
When two Node Drivers share the same name deleting/disabling them goes through the rancher-webhook, which will admit the request if no nodes are using them and subsequently delete the CRDs associated with one or the other, which may end up removing the wrong CRDs and put the cluster in a weird state. The only way to fix this would be to wait for the reconciler to run again and recreate them.

Another side effect here is that if the CRDs are not present (like it takes a bit for the items to download) the request is not admitted which is a race condition.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
The first part will be switching the check to go off of the `.spec.DisplayName` instead to `.objectMeta.Name`, that way the check will be globally unique.

The second part will just be fixiable by adding a check to see if the CRD exists before listing the resources, if the CRD doesn't exist then just admit the request. 
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

First part:
1. Create a custom node driver (or rename 2 to have the same display name)
2. Delete one of them, notice the wrong CRDs may be deleted (one of them most likely, so might take trying it in a certain order)
3. Pre-patch, weird state will be observed. Post-patch it will delete only the right CRDs since we are keying off of the name.

Second part:
1. Open 2 browser tabs
2. In the UI, enable a NodeDriver that has an external dependency (takes more time)
3. `kubectl delete nodedriver <name>` where name is the one that was just enabled
4. Pre-patch, the delete will fail since it can't list the items (no CRDs). Post-patch it will admit the request just fine since the webhook will test and see if the CRD exists and just admit the request. 
