### PR TITLE
[0.3] Disallow changes to ServiceAccount field on PRTB update rather than its presence

### DIFF
--- a/pkg/resources/management.cattle.io/v3/projectroletemplatebinding/validator.go
+++ b/pkg/resources/management.cattle.io/v3/projectroletemplatebinding/validator.go
@@ -159,7 +159,7 @@ func validateUpdateFields(oldPRTB, newPRTB *apisv3.ProjectRoleTemplateBinding, f
 	case (newPRTB.GroupName != "" || oldPRTB.GroupPrincipalName != "") && (newPRTB.UserName != "" || oldPRTB.UserPrincipalName != ""):
 		return field.Forbidden(fieldPath,
 			"binding must target either a user [userName]/[userPrincipalName] OR a group [groupName]/[groupPrincipalName]")
-	case newPRTB.ServiceAccount != "":
+	case oldPRTB.ServiceAccount != newPRTB.ServiceAccount:
 		return field.Forbidden(fieldPath.Child("serviceAccount"), "update is not allowed")
 	default:
 		return nil

--- a/pkg/resources/management.cattle.io/v3/projectroletemplatebinding/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/projectroletemplatebinding/validator_test.go
@@ -409,6 +409,59 @@ func (p *ProjectRoleTemplateBindingSuite) TestValidationOnUpdate() {
 			allowed: false,
 		},
 		{
+			name: "update removing a previously set service account",
+			args: args{
+				username: adminUser,
+				oldPRTB: func() *apisv3.ProjectRoleTemplateBinding {
+					basePRTB := newBasePRTB()
+					basePRTB.UserName = ""
+					basePRTB.ServiceAccount = "p1:default"
+					return basePRTB
+				},
+				newPRTB: func() *apisv3.ProjectRoleTemplateBinding {
+					basePRTB := newBasePRTB()
+					basePRTB.UserName = ""
+					return basePRTB
+				},
+			},
+			allowed: false,
+		},
+		{
+			name: "update previously set service account",
+			args: args{
+				username: adminUser,
+				oldPRTB: func() *apisv3.ProjectRoleTemplateBinding {
+					basePRTB := newBasePRTB()
+					basePRTB.UserName = ""
+					basePRTB.ServiceAccount = "p1:default"
+					return basePRTB
+				},
+				newPRTB: func() *apisv3.ProjectRoleTemplateBinding {
+					basePRTB := newBasePRTB()
+					basePRTB.UserName = ""
+					basePRTB.ServiceAccount = "p1:another"
+					return basePRTB
+				},
+			},
+			allowed: false,
+		},
+		{
+			name: "set a previously unset service account with a user name already present",
+			args: args{
+				username: adminUser,
+				oldPRTB: func() *apisv3.ProjectRoleTemplateBinding {
+					basePRTB := newBasePRTB()
+					return basePRTB
+				},
+				newPRTB: func() *apisv3.ProjectRoleTemplateBinding {
+					basePRTB := newBasePRTB()
+					basePRTB.ServiceAccount = "p1:another"
+					return basePRTB
+				},
+			},
+			allowed: false,
+		},
+		{
 			name: "update previously unset user",
 			args: args{
 				username: adminUser,
@@ -462,25 +515,6 @@ func (p *ProjectRoleTemplateBindingSuite) TestValidationOnUpdate() {
 				},
 			},
 			allowed: false,
-		},
-		{
-			name: "update previously unset user principal",
-			args: args{
-				username: adminUser,
-				oldPRTB: func() *apisv3.ProjectRoleTemplateBinding {
-					basePRTB := newBasePRTB()
-					basePRTB.UserName = newUser
-					basePRTB.UserPrincipalName = ""
-					return basePRTB
-				},
-				newPRTB: func() *apisv3.ProjectRoleTemplateBinding {
-					basePRTB := newBasePRTB()
-					basePRTB.UserName = newUser
-					basePRTB.UserPrincipalName = newUserPrinc
-					return basePRTB
-				},
-			},
-			allowed: true,
 		},
 		{
 			name: "update previously set group",


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/42625
## Problem
The webhook rejects a request that updates any PRTB that already has ServiceAccount field **set**.

## Solution
Instead, it should reject attempts to **change** it. Adjust the logic accordingly.

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [x] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [ ] Docs