### PR TITLE
Api version bump

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/rancher/dynamiclistener v0.3.5
 	github.com/rancher/lasso v0.0.0-20230629200414-8a54b32e6792
 	github.com/rancher/lasso/controller-runtime v0.0.0-20221206162308-10123d5719ad
-	github.com/rancher/rancher/pkg/apis v0.0.0-20230901132600-5e1ee2611616
+	github.com/rancher/rancher/pkg/apis v0.0.0-20230907072751-b6d3cfeb7cce
 	github.com/rancher/rke v1.5.0-rc2
 	github.com/rancher/wrangler v1.1.1
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -541,8 +541,8 @@ github.com/rancher/lasso/controller-runtime v0.0.0-20221206162308-10123d5719ad h
 github.com/rancher/lasso/controller-runtime v0.0.0-20221206162308-10123d5719ad/go.mod h1:TLtLcyLAqTV0hynU5zIY3vD66uuX/rnIl+t+NRGpMbQ=
 github.com/rancher/norman v0.0.0-20230426211126-d3552b018687 h1:9Bf4fZBIdkidKTqHFsJXMlnzflxx3h4ZAEH/n6HMuyI=
 github.com/rancher/norman v0.0.0-20230426211126-d3552b018687/go.mod h1:7MyWxfCmPl6N/UFLu4neLH6nwTFgQQF5rxtUGyZvPFE=
-github.com/rancher/rancher/pkg/apis v0.0.0-20230901132600-5e1ee2611616 h1:jMNvKWFg5XEtzJijQS6IgbpVlT1H7WIoLlXAbiM2Jas=
-github.com/rancher/rancher/pkg/apis v0.0.0-20230901132600-5e1ee2611616/go.mod h1:faAHE0MFFEB+fZQMfjfylYuzuVOn5yxKi7JFRsEfFOE=
+github.com/rancher/rancher/pkg/apis v0.0.0-20230907072751-b6d3cfeb7cce h1:bJD0Xgxs1aBBAXwBajUGuJ+xtE7VPNPbLKqrfndRdIw=
+github.com/rancher/rancher/pkg/apis v0.0.0-20230907072751-b6d3cfeb7cce/go.mod h1:faAHE0MFFEB+fZQMfjfylYuzuVOn5yxKi7JFRsEfFOE=
 github.com/rancher/rke v1.5.0-rc2 h1:gec//2jkyEimO/fZLMMRVAJF8GpKqDf3voe+k3jrhGg=
 github.com/rancher/rke v1.5.0-rc2/go.mod h1:wUwsm6dXyzzxWlVwmPPR5XMWX6ICjAdWJ+l45ZqV+P0=
 github.com/rancher/wrangler v1.1.1-0.20230705223603-201b4da5bdaf h1:XKUtcI795sLmX+joUkvSoX0EbbpAVk1SO6nCPA16xZk=

--- a/scripts/integration-test
+++ b/scripts/integration-test
@@ -5,6 +5,9 @@ export CATTLE_DEV_MODE=yes
 export CATTLE_SERVER_URL="https://$(ip route get 8.8.8.8 | awk '{print $7}'):443"
 export CATTLE_BOOTSTRAP_PASSWORD="admin"
 export CATTLE_FEATURES="harvester=false"
+export CATTLE_CHART_DEFAULT_BRANCH="dev-v2.8"
+export CATTLE_SYSTEM_CHART_DEFAULT_BRANCH="dev-v2.8"
+export CATTLE_RANCHER_WEBHOOK_VERSION="103.0.0+up0.4.0-rc3"
 
 cd $(dirname $0)/../
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
CI in rancher which uses the new webhook is currently failing. This updates the Rancher/pkg/apis import to use new types to resolve the CI failures, and adds a temporary ci change to allow CI in the webhook to pass.