### PR TITLE
Revert "Temporarily modifying integration tests"

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -18,6 +18,7 @@ steps:
 
   - name: integration-test
     image: rancher/rancher:v2.8-head
+    pull: always
     privileged: true
     commands:
       - zypper -n install helm

--- a/scripts/integration-test
+++ b/scripts/integration-test
@@ -5,9 +5,6 @@ export CATTLE_DEV_MODE=yes
 export CATTLE_SERVER_URL="https://$(ip route get 8.8.8.8 | awk '{print $7}'):443"
 export CATTLE_BOOTSTRAP_PASSWORD="admin"
 export CATTLE_FEATURES="harvester=false"
-export CATTLE_CHART_DEFAULT_BRANCH="dev-v2.8"
-export CATTLE_SYSTEM_CHART_DEFAULT_BRANCH="dev-v2.8"
-export CATTLE_RANCHER_WEBHOOK_VERSION="103.0.0+up0.4.0-rc3"
 
 cd $(dirname $0)/../
 


### PR DESCRIPTION
This reverts commit dd7b7b1897a51dde8374554fa3ec332ea7566264.

Previously, the integration tests were failing due to an issue with an invalid version on 2.8-head. Now that a valid version has been pushed, we can revert these modifications.