### PR TITLE
Don't allow PRTB namespace and the project ID of projectName to differ

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -182,10 +182,13 @@ This is to prevent privilege escalation.
 
 Users cannot create ProjectRoleTemplateBindings that violate the following constraints:
 
+- The `ProjectName` field must be:
+    - Provided as a non-empty value
+    - Specified using the format of `cluster-id:project-id`
+    - `project-id`, in particular, must match the namespace of the ProjectRoleTemplateBinding
 - Either a user subject (through `UserName` or `UserPrincipalName`), or a group subject (through `GroupName`
   or `GroupPrincipalName`), or a service account subject (through `ServiceAccount`) must be specified. Exactly one
   subject type of the three must be provided.
-- `ProjectName` must be specified
 - The roleTemplate indicated in `RoleTemplateName` must be:
     - Provided as a non-empty value
     - Valid (there must exist a `roleTemplate` object of given name in the `management.cattle.io/v3` API group)

--- a/pkg/resources/management.cattle.io/v3/projectroletemplatebinding/ProjectRoleTemplateBinding.md
+++ b/pkg/resources/management.cattle.io/v3/projectroletemplatebinding/ProjectRoleTemplateBinding.md
@@ -9,10 +9,13 @@ This is to prevent privilege escalation.
 
 Users cannot create ProjectRoleTemplateBindings that violate the following constraints:
 
+- The `ProjectName` field must be:
+    - Provided as a non-empty value
+    - Specified using the format of `cluster-id:project-id`
+    - `project-id`, in particular, must match the namespace of the ProjectRoleTemplateBinding
 - Either a user subject (through `UserName` or `UserPrincipalName`), or a group subject (through `GroupName`
   or `GroupPrincipalName`), or a service account subject (through `ServiceAccount`) must be specified. Exactly one
   subject type of the three must be provided.
-- `ProjectName` must be specified
 - The roleTemplate indicated in `RoleTemplateName` must be:
     - Provided as a non-empty value
     - Valid (there must exist a `roleTemplate` object of given name in the `management.cattle.io/v3` API group)

--- a/pkg/resources/management.cattle.io/v3/projectroletemplatebinding/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/projectroletemplatebinding/validator_test.go
@@ -849,7 +849,7 @@ func (p *ProjectRoleTemplateBindingSuite) TestValidationOnCreate() {
 			allowed: false,
 		},
 		{
-			name: "create with unset project name",
+			name: "unset project name",
 			args: args{
 				username: adminUser,
 				oldPRTB: func() *apisv3.ProjectRoleTemplateBinding {
@@ -863,11 +863,28 @@ func (p *ProjectRoleTemplateBindingSuite) TestValidationOnCreate() {
 			},
 			allowed: false,
 		},
+		{
+			name: "namespace and the project id part of the project name differ",
+			args: args{
+				username: adminUser,
+				oldPRTB: func() *apisv3.ProjectRoleTemplateBinding {
+					return nil
+				},
+				newPRTB: func() *apisv3.ProjectRoleTemplateBinding {
+					basePRTB := newBasePRTB()
+					basePRTB.ObjectMeta.Namespace = "default"
+					basePRTB.ProjectName = fmt.Sprintf("%s:%s", clusterID, "p-cgtq4")
+					return basePRTB
+				},
+			},
+			allowed: false,
+		},
 	}
 
 	for i := range tests {
 		test := tests[i]
 		p.Run(test.name, func() {
+			p.T().Parallel()
 			req := createPRTBRequest(p.T(), test.args.oldPRTB(), test.args.newPRTB(), test.args.username)
 			admitters := validator.Admitters()
 			p.Len(admitters, 1)
@@ -926,7 +943,7 @@ func newBasePRTB() *apisv3.ProjectRoleTemplateBinding {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              "PRTB-new",
 			GenerateName:      "PRTB-",
-			Namespace:         "p-namespace",
+			Namespace:         projectID,
 			UID:               "6534e4ef-f07b-4c61-b88d-95a92cce4852",
 			ResourceVersion:   "1",
 			Generation:        1,

--- a/tests/integration/projectRoleTemplateBinding_test.go
+++ b/tests/integration/projectRoleTemplateBinding_test.go
@@ -1,6 +1,8 @@
 package integration_test
 
 import (
+	"fmt"
+
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	rbacv1 "k8s.io/api/rbac/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,7 +19,7 @@ func (m *IntegrationSuite) TestProjectRoleTemplateBinding() {
 		},
 		UserName:         "bruce-wayne",
 		RoleTemplateName: rtName,
-		ProjectName:      "gotham:city",
+		ProjectName:      fmt.Sprintf("%s:%s", "gotham", testNamespace),
 	}
 	invalidCreate := func() *v3.ProjectRoleTemplateBinding {
 		invalidCreate := validCreateObj.DeepCopy()


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/42754

## Problem
Users aren't forbidden to create a badly configured PRTB where the namespace and the project ID part of `projectName` don't match.

For example:
```yaml
apiVersion: management.cattle.io/v3
kind: ProjectRoleTemplateBinding
metadata:
  name: test
  namespace: p-cgtq4
projectName: c-some-cluster:foobar
roleTemplateName: configmaps-manage
userName: u-tgws8
```

A valid PRTB example would have a namespace `p-cgtq4` and projectName `c-some-cluster:p-cgtq4`.

If users are allowed to specify the project ID and namespace different, there are two problems:
1. A Rancher controller will continuously fail to sync the RBAC objects to the cluster
2. If a namespace exists but doesn't equal the project ID, then the PRTB will never be cleaned up when the actual project (for which the binding was intended) gets deleted

## Solution
Extract the cluster name and project ID from `projectName` (split on colon). Ensure the project ID equals the namespace.

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [x] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [x] Docs