### PR TITLE
Disallows the updating GlobalRoles to be builtin.

### DIFF
--- a/pkg/resources/management.cattle.io/v3/globalrole/validator.go
+++ b/pkg/resources/management.cattle.io/v3/globalrole/validator.go
@@ -213,6 +213,9 @@ func (a *admitter) validateInheritedClusterRoles(oldGR *v3.GlobalRole, newGR *v3
 // validUpdateFields checks if the fields being changed are valid update fields.
 func (a *admitter) validateUpdateFields(oldRole, newRole *v3.GlobalRole, fldPath *field.Path) *field.Error {
 	if !oldRole.Builtin {
+		if newRole.Builtin {
+			return field.Forbidden(fldPath, fmt.Sprintf("cannot update non-builtIn GlobalRole %s to be builtIn", oldRole.Name))
+		}
 		return nil
 	}
 

--- a/pkg/resources/management.cattle.io/v3/globalrole/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/globalrole/validator_test.go
@@ -365,7 +365,7 @@ func TestAdmit(t *testing.T) {
 			allowed: true,
 		},
 		{
-			name: "update Builtin field",
+			name: "update Builtin field to false",
 			args: args{
 				oldGR: func() *v3.GlobalRole {
 					baseGR := newDefaultGR()
@@ -375,6 +375,22 @@ func TestAdmit(t *testing.T) {
 				newGR: func() *v3.GlobalRole {
 					baseGR := newDefaultGR()
 					baseGR.Builtin = false
+					return baseGR
+				},
+			},
+			allowed: false,
+		},
+		{
+			name: "update Builtin field to true",
+			args: args{
+				oldGR: func() *v3.GlobalRole {
+					baseGR := newDefaultGR()
+					baseGR.Builtin = false
+					return baseGR
+				},
+				newGR: func() *v3.GlobalRole {
+					baseGR := newDefaultGR()
+					baseGR.Builtin = true
 					return baseGR
 				},
 			},


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from other PRs, link them here and describe why they are needed for your solution section. -->
## Problem
<!-- Describe the root cause of the issue you are resolving. 
This may include what behavior is observed and why it is not desirable. If this is a new feature, describe why we need it and how it will be used. -->
Users could update a globalRole that was not a builtIn to be a builtin role.

## Solution
<!-- Describe what you changed to fix the issue. 
Relate your changes to the original bug/feature and explain why this addresses the issue. -->
When a previously non-builtIn role is updated we check if it is being changed to a builtIn role.

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [x] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [ ] Docs __No docs change needed__