### PR TITLE
Prevent CRTBs from being created with mismatching Namespace and ClusterName

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -57,7 +57,9 @@ Users can only create/update ClusterRoleTemplateBindings which grant permissions
 
 Users cannot create ClusterRoleTemplateBindings which violate the following constraints:
 - Either a user subject (through `UserName` or `UserPrincipalName`) or a group subject (through `GroupName` or `GroupPrincipalName`) must be specified; both a user subject and a group subject cannot be specified
-- `ClusterName` must be specified
+- `ClusterName` must:
+  - Be provided as a non-empty value
+  - Match the namespace of the ClusterRoleTemplateBinding
 - The roleTemplate indicated in `RoleTemplateName` must be:
   - Provided as a non-empty value
   - Valid (i.e. is an existing `roleTemplate` object of given name in the `management.cattle.io/v3` API group)

--- a/pkg/resources/management.cattle.io/v3/clusterroletemplatebinding/ClusterRoleTemplateBinding.md
+++ b/pkg/resources/management.cattle.io/v3/clusterroletemplatebinding/ClusterRoleTemplateBinding.md
@@ -8,7 +8,9 @@ Users can only create/update ClusterRoleTemplateBindings which grant permissions
 
 Users cannot create ClusterRoleTemplateBindings which violate the following constraints:
 - Either a user subject (through `UserName` or `UserPrincipalName`) or a group subject (through `GroupName` or `GroupPrincipalName`) must be specified; both a user subject and a group subject cannot be specified
-- `ClusterName` must be specified
+- `ClusterName` must:
+  - Be provided as a non-empty value
+  - Match the namespace of the ClusterRoleTemplateBinding
 - The roleTemplate indicated in `RoleTemplateName` must be:
   - Provided as a non-empty value
   - Valid (i.e. is an existing `roleTemplate` object of given name in the `management.cattle.io/v3` API group)

--- a/pkg/resources/management.cattle.io/v3/clusterroletemplatebinding/validator.go
+++ b/pkg/resources/management.cattle.io/v3/clusterroletemplatebinding/validator.go
@@ -168,7 +168,7 @@ func (a *admitter) validateCreateFields(newCRTB *apisv3.ClusterRoleTemplateBindi
 	hasGroupTarget := newCRTB.GroupName != "" || newCRTB.GroupPrincipalName != ""
 
 	if (hasUserTarget && hasGroupTarget) || (!hasUserTarget && !hasGroupTarget) {
-		return field.Forbidden(fieldPath, "binding must target either a user [userId]/[userPrincipalId] OR a group [groupId]/[groupPrincipalId]")
+		return field.Forbidden(fieldPath, "binding must target either a user [userName]/[userPrincipalName] OR a group [groupName]/[groupPrincipalName]")
 	}
 
 	if newCRTB.ClusterName == "" {

--- a/pkg/resources/management.cattle.io/v3/clusterroletemplatebinding/validator.go
+++ b/pkg/resources/management.cattle.io/v3/clusterroletemplatebinding/validator.go
@@ -81,7 +81,6 @@ func (a *admitter) Admit(request *admission.Request) (*admissionv1.AdmissionResp
 	defer listTrace.LogIfLong(admission.SlowTraceDuration)
 
 	fieldPath := field.NewPath("clusterroletemplatebinding")
-	var warnings []string
 
 	if request.Operation == admissionv1.Update {
 		oldCRTB, newCRTB, err := objectsv3.ClusterRoleTemplateBindingOldAndNewFromRequest(&request.AdmissionRequest)
@@ -91,10 +90,6 @@ func (a *admitter) Admit(request *admission.Request) (*admissionv1.AdmissionResp
 
 		if err := validateUpdateFields(oldCRTB, newCRTB, fieldPath); err != nil {
 			return admission.ResponseBadRequest(err.Error()), nil
-		}
-
-		if newCRTB.ClusterName != newCRTB.Namespace {
-			warnings = append(warnings, "Using CRTBs with namespaces and clusterNames that differ is not supported")
 		}
 	}
 
@@ -128,9 +123,6 @@ func (a *admitter) Admit(request *admission.Request) (*admissionv1.AdmissionResp
 	response := &admissionv1.AdmissionResponse{}
 	auth.SetEscalationResponse(response, auth.ConfirmNoEscalation(request, rules, crtb.ClusterName, a.resolver))
 
-	if warnings != nil {
-		response.Warnings = warnings
-	}
 	return response, nil
 }
 

--- a/pkg/resources/management.cattle.io/v3/clusterroletemplatebinding/validator.go
+++ b/pkg/resources/management.cattle.io/v3/clusterroletemplatebinding/validator.go
@@ -81,6 +81,7 @@ func (a *admitter) Admit(request *admission.Request) (*admissionv1.AdmissionResp
 	defer listTrace.LogIfLong(admission.SlowTraceDuration)
 
 	fieldPath := field.NewPath("clusterroletemplatebinding")
+	var warnings []string
 
 	if request.Operation == admissionv1.Update {
 		oldCRTB, newCRTB, err := objectsv3.ClusterRoleTemplateBindingOldAndNewFromRequest(&request.AdmissionRequest)
@@ -90,6 +91,10 @@ func (a *admitter) Admit(request *admission.Request) (*admissionv1.AdmissionResp
 
 		if err := validateUpdateFields(oldCRTB, newCRTB, fieldPath); err != nil {
 			return admission.ResponseBadRequest(err.Error()), nil
+		}
+
+		if newCRTB.ClusterName != newCRTB.Namespace {
+			warnings = append(warnings, "Using CRTBs with namespaces and clusterNames that differ is not supported")
 		}
 	}
 
@@ -123,6 +128,9 @@ func (a *admitter) Admit(request *admission.Request) (*admissionv1.AdmissionResp
 	response := &admissionv1.AdmissionResponse{}
 	auth.SetEscalationResponse(response, auth.ConfirmNoEscalation(request, rules, crtb.ClusterName, a.resolver))
 
+	if warnings != nil {
+		response.Warnings = warnings
+	}
 	return response, nil
 }
 
@@ -165,6 +173,10 @@ func (a *admitter) validateCreateFields(newCRTB *apisv3.ClusterRoleTemplateBindi
 
 	if newCRTB.ClusterName == "" {
 		return field.Required(fieldPath.Child("clusterName"), reason)
+	}
+
+	if newCRTB.ClusterName != newCRTB.Namespace {
+		return field.Forbidden(fieldPath, "clusterName and namespace must be the same value")
 	}
 
 	if newCRTB.RoleTemplateName == "" {

--- a/pkg/resources/management.cattle.io/v3/clusterroletemplatebinding/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/clusterroletemplatebinding/validator_test.go
@@ -41,7 +41,7 @@ type ClusterRoleTemplateBindingSuite struct {
 }
 
 func TestClusterRoleTemplateBindings(t *testing.T) {
-	//t.Parallel()
+	t.Parallel()
 	suite.Run(t, new(ClusterRoleTemplateBindingSuite))
 }
 

--- a/pkg/resources/management.cattle.io/v3/clusterroletemplatebinding/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/clusterroletemplatebinding/validator_test.go
@@ -668,11 +668,10 @@ func (c *ClusterRoleTemplateBindingSuite) Test_Create() {
 		username string
 	}
 	tests := []struct {
-		name     string
-		args     args
-		wantErr  bool
-		allowed  bool
-		warnings []string
+		name    string
+		args    args
+		wantErr bool
+		allowed bool
 	}{
 		{
 			name: "base test valid CRTB",
@@ -889,24 +888,6 @@ func (c *ClusterRoleTemplateBindingSuite) Test_Create() {
 			},
 			allowed: false,
 		},
-		{
-			name: "update mismatched clusterName and namespace",
-			args: args{
-				username: adminUser,
-				oldCRTB: func() *apisv3.ClusterRoleTemplateBinding {
-					baseCRTB := newDefaultCRTB()
-					baseCRTB.ClusterName = "c-mismatch"
-					return baseCRTB
-				},
-				newCRTB: func() *apisv3.ClusterRoleTemplateBinding {
-					baseCRTB := newDefaultCRTB()
-					baseCRTB.ClusterName = "c-mismatch"
-					return baseCRTB
-				},
-			},
-			allowed:  true,
-			warnings: []string{"Using CRTBs with namespaces and clusterNames that differ is not supported"},
-		},
 	}
 
 	for i := range tests {
@@ -923,15 +904,6 @@ func (c *ClusterRoleTemplateBindingSuite) Test_Create() {
 				c.NoError(err, "Admit failed")
 				if resp.Allowed != test.allowed {
 					c.Failf("Response was incorrectly validated", "Wanted response.Allowed = '%v' got '%v': result=%+v", test.name, test.allowed, resp.Allowed, resp.Result)
-				}
-				// check warnings
-				if test.warnings != nil {
-					if len(test.warnings) != len(resp.Warnings) {
-						c.Failf("Number of warnings in response different from expected", "Wanted response.Warnings: '%v' got '%v'", test.warnings, resp.Warnings)
-					}
-					for w := range test.warnings {
-						assert.Equal(c.T(), test.warnings[w], resp.Warnings[w])
-					}
 				}
 			}
 		})

--- a/tests/integration/clusterRoleTemplateBinding_test.go
+++ b/tests/integration/clusterRoleTemplateBinding_test.go
@@ -17,7 +17,7 @@ func (m *IntegrationSuite) TestClusterRoleTemplateBinding() {
 		},
 		UserName:         "bruce-wayne",
 		RoleTemplateName: rtName,
-		ClusterName:      "gotham",
+		ClusterName:      testNamespace,
 	}
 	invalidCreate := func() *v3.ClusterRoleTemplateBinding {
 		invalidCreate := validCreateObj.DeepCopy()


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/42754 

## Problem
Users can create CRTBs that have different namespaces and ClusterNames. That causes their deletion to fail when the cluster is deleted. It also doesn't appear in the UI as intended.

## Solution
- Added a check on CREATE to ensure that the namespace and custerName are the same. Deny the request if they are mismatched
- Added the same check on UPDATE, but just provide a warning to the user and allow it.

I also fixed the wording of one of the error messages to be more clear.

## CheckList
- [X] Test
- [X] Docs