### PR TITLE
Adding SA exceptions to gr escalation

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -121,6 +121,8 @@ On create or update, the following checks take place:
 
 Users can only change GlobalRoles with rights less than or equal to those they currently possess. This is to prevent privilege escalation. This includes the rules in the RoleTemplates referred to in `inheritedClusterRoles`. 
 
+This escalation checking currently prevents service accounts from modifying GlobalRoles which include permissions on downstream clusters (such as Admin, Restricted Admin, or GlobalRoles which use the `inheritedClusterRoles` field).
+
 #### Builtin Validation
 
 The `globalroles.builtin` field is immutable, and new builtIn GlobalRoles cannot be created.
@@ -136,6 +138,8 @@ Note: all checks are bypassed if the GlobalRoleBinding is being deleted, or if o
 #### Escalation Prevention
 
 Users can only create/update GlobalRoleBindings with rights less than or equal to those they currently possess. This is to prevent privilege escalation. 
+
+This escalation checking currently prevents service accounts from modifying GlobalRoleBindings which give access to GlobalRoles which include permissions on downstream clusters (such as Admin, Restricted Admin, or GlobalRoles which use the `inheritedClusterRoles` field).
 
 #### Valid Global Role Reference
 

--- a/pkg/resolvers/resolvers_test.go
+++ b/pkg/resolvers/resolvers_test.go
@@ -54,6 +54,9 @@ func NewUserInfo(username string, groups ...string) *user.DefaultInfo {
 	return &user.DefaultInfo{
 		Name:   username,
 		Groups: groups,
+		Extra: map[string][]string{
+			"test": {"test"},
+		},
 	}
 }
 

--- a/pkg/resources/management.cattle.io/v3/globalrole/GlobalRole.md
+++ b/pkg/resources/management.cattle.io/v3/globalrole/GlobalRole.md
@@ -12,6 +12,8 @@ On create or update, the following checks take place:
 
 Users can only change GlobalRoles with rights less than or equal to those they currently possess. This is to prevent privilege escalation. This includes the rules in the RoleTemplates referred to in `inheritedClusterRoles`. 
 
+This escalation checking currently prevents service accounts from modifying GlobalRoles which include permissions on downstream clusters (such as Admin, Restricted Admin, or GlobalRoles which use the `inheritedClusterRoles` field).
+
 ### Builtin Validation
 
 The `globalroles.builtin` field is immutable, and new builtIn GlobalRoles cannot be created.

--- a/pkg/resources/management.cattle.io/v3/globalrole/setup_test.go
+++ b/pkg/resources/management.cattle.io/v3/globalrole/setup_test.go
@@ -274,5 +274,5 @@ func newDefaultState(t *testing.T) testState {
 
 func (m *testState) createBaseGRBResolver() *resolvers.GRBClusterRuleResolver {
 	grResolver := auth.NewGlobalRoleResolver(auth.NewRoleTemplateResolver(m.rtCacheMock, nil), m.grCacheMock)
-	return resolvers.NewGRBClusterRuleResolver(m.grbCacheMock, grResolver)
+	return resolvers.NewGRBClusterRuleResolver(m.grbCacheMock, grResolver, nil)
 }

--- a/pkg/resources/management.cattle.io/v3/globalrolebinding/GlobalRoleBinding.md
+++ b/pkg/resources/management.cattle.io/v3/globalrolebinding/GlobalRoleBinding.md
@@ -6,6 +6,8 @@ Note: all checks are bypassed if the GlobalRoleBinding is being deleted, or if o
 
 Users can only create/update GlobalRoleBindings with rights less than or equal to those they currently possess. This is to prevent privilege escalation. 
 
+This escalation checking currently prevents service accounts from modifying GlobalRoleBindings which give access to GlobalRoles which include permissions on downstream clusters (such as Admin, Restricted Admin, or GlobalRoles which use the `inheritedClusterRoles` field).
+
 ### Valid Global Role Reference
 
 GlobalRoleBindings must refer to a valid global role (i.e. an existing `GlobalRole` object in the `management.cattle.io/v3` apiGroup).

--- a/pkg/resources/management.cattle.io/v3/globalrolebinding/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/globalrolebinding/validator_test.go
@@ -546,7 +546,7 @@ func TestAdmit(t *testing.T) {
 				test.args.stateSetup(state)
 			}
 			grResolver := auth.NewGlobalRoleResolver(auth.NewRoleTemplateResolver(state.rtCacheMock, nil), state.grCacheMock)
-			grbResolver := resolvers.NewGRBClusterRuleResolver(state.grbCacheMock, grResolver)
+			grbResolver := resolvers.NewGRBClusterRuleResolver(state.grbCacheMock, grResolver, nil)
 			admitters := globalrolebinding.NewValidator(state.resolver, grbResolver).Admitters()
 			require.Len(t, admitters, 1)
 
@@ -567,7 +567,7 @@ func Test_UnexpectedErrors(t *testing.T) {
 	t.Parallel()
 	state := newDefaultState(t)
 	grResolver := auth.NewGlobalRoleResolver(auth.NewRoleTemplateResolver(state.rtCacheMock, nil), state.grCacheMock)
-	grbResolver := resolvers.NewGRBClusterRuleResolver(state.grbCacheMock, grResolver)
+	grbResolver := resolvers.NewGRBClusterRuleResolver(state.grbCacheMock, grResolver, nil)
 	validator := globalrolebinding.NewValidator(state.resolver, grbResolver)
 	admitters := validator.Admitters()
 	require.Len(t, admitters, 1, "wanted only one admitter")

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -34,7 +34,7 @@ func Validation(clients *clients.Clients) ([]admission.ValidatingAdmissionHandle
 	if clients.MultiClusterManagement {
 		crtbResolver := resolvers.NewCRTBRuleResolver(clients.Management.ClusterRoleTemplateBinding().Cache(), clients.RoleTemplateResolver)
 		prtbResolver := resolvers.NewPRTBRuleResolver(clients.Management.ProjectRoleTemplateBinding().Cache(), clients.RoleTemplateResolver)
-		grbResolver := resolvers.NewGRBClusterRuleResolver(clients.Management.GlobalRoleBinding().Cache(), clients.GlobalRoleResolver)
+		grbResolver := resolvers.NewGRBClusterRuleResolver(clients.Management.GlobalRoleBinding().Cache(), clients.GlobalRoleResolver, clients.K8s.AuthorizationV1().SubjectAccessReviews())
 		psact := podsecurityadmissionconfigurationtemplate.NewValidator(clients.Management.Cluster().Cache(), clients.Provisioning.Cluster().Cache())
 		globalRoles := globalrole.NewValidator(clients.DefaultResolver, grbResolver)
 		globalRoleBindings := globalrolebinding.NewValidator(clients.DefaultResolver, grbResolver)


### PR DESCRIPTION
## Overview

Adds an exception for the fleet/backup-restore service accounts for the `inheritedClusterRoles` escalation check

## Issue Detail
The escalation check for the `inheritedClusterRoles` field currently only allows users to grant permissions through this field (either by modifying the globalRole or any associated binding) if one of two items is true:
- The user possess rules that they are trying to give, specifically through the `inheritedClusterRoles` field. 
  - This means that a user can only give out (for example) `clusterOwner` if they have been assigned `clusterOwner` in the `inheritedClusterRoles` field of a globalRole.
- The user is an admin/restricted admin
  - The code treats the global roles (with these names) as having `clusterOwner` in the `inheritedClusterRoles` field.

This behavior caused issues with service accounts (namely fleet and backup-restore) which were unable to pass these escalation checks, since GRBs can't be made to service accounts (meaning they never pass one of the two above conditions). This resulted in fleet/backup-restore not being able to create GlobalRoles (or bindings to those roles) which use this field, or are the `admin` or `restricted-admin` roles. 

## Fix

The current approach is to allow usage of this field for service accounts that meet all of the following requirements:
- First, they need to be service accounts (in the `system:serviceaccounts` group)
- Second, they need to be one of the two hardcoded service accounts that we allow this exception for (fleet/backup-restore)
  - This part may need to change, it hasn't been confirmed yet that these two service accounts are always in the respective namespaces defined in this PR
- Third, they need to pass a SAR check for `*` verbs on `*` resources in `*` api groups at the cluster scope.
  - This is to prevent users from bypassing this check in the case of rancher setups which aren't using fleet/backup-restore
  - Because of this check, such a user would still need to make the SA an admin through other means, which would present a security risk on it's own (even absent this check)
  - Credit to @KevinJoiner for suggesting the inclusion of this check alongside the others.  

Tests have also been added for the various cases defined in this PR.