### PR TITLE
Update minimum kube version to 1.23

### DIFF
--- a/charts/rancher-webhook/Chart.yaml
+++ b/charts/rancher-webhook/Chart.yaml
@@ -11,7 +11,7 @@ annotations:
   catalog.cattle.io/os: linux
   catalog.cattle.io/permits-os: linux,windows
   catalog.cattle.io/rancher-version: ">= 2.8.0-0 < 2.9.0-0"
-  catalog.cattle.io/kube-version: ">= 1.16.0-0 < 1.28.0-0"
+  catalog.cattle.io/kube-version: ">= 1.23.0-0 < 1.28.0-0"
 dependencies:
   - name: capi
     condition: capi.enabled


### PR DESCRIPTION
## Issue:

https://github.com/rancher/rancher/issues/42949 needed to complete https://github.com/rancher/rancher/issues/41789

## Problem

The minimum kube-version is not set to `1.23.0-0`.

## Solution

Increase the minimum kube-version to `1.23.0-0`

## CheckList
  
