### PR TITLE
Make project.spec.ClusterName immutable

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -175,7 +175,7 @@ This admission webhook prevents the disabling or deletion of a NodeDriver if the
 
 #### ClusterName validation
 
-ClusterName must be equal to the namespace, and must refer to an existing management.cattle.io/v3.Cluster object.
+ClusterName must be equal to the namespace, and must refer to an existing management.cattle.io/v3.Cluster object. In addition, users cannot update the field after creation. 
 
 #### Protects system project
 

--- a/pkg/resources/management.cattle.io/v3/project/Project.md
+++ b/pkg/resources/management.cattle.io/v3/project/Project.md
@@ -2,7 +2,7 @@
 
 ### ClusterName validation
 
-ClusterName must be equal to the namespace, and must refer to an existing management.cattle.io/v3.Cluster object.
+ClusterName must be equal to the namespace, and must refer to an existing management.cattle.io/v3.Cluster object. In addition, users cannot update the field after creation. 
 
 ### Protects system project
 

--- a/pkg/resources/management.cattle.io/v3/project/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/project/validator_test.go
@@ -426,13 +426,6 @@ func TestProjectValidation(t *testing.T) {
 					ClusterName: "testcluster",
 				},
 			},
-			stateSetup: func(state *testState) {
-				state.clusterCache.EXPECT().Get("testcluster").Return(&v3.Cluster{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "testcluster",
-					},
-				}, nil)
-			},
 			wantAllowed: true,
 		},
 		{
@@ -468,13 +461,6 @@ func TestProjectValidation(t *testing.T) {
 					NamespaceDefaultResourceQuota: nil,
 				},
 			},
-			stateSetup: func(state *testState) {
-				state.clusterCache.EXPECT().Get("testcluster").Return(&v3.Cluster{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "testcluster",
-					},
-				}, nil)
-			},
 			wantAllowed: true,
 		},
 		{
@@ -508,13 +494,6 @@ func TestProjectValidation(t *testing.T) {
 					},
 				},
 			},
-			stateSetup: func(state *testState) {
-				state.clusterCache.EXPECT().Get("testcluster").Return(&v3.Cluster{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "testcluster",
-					},
-				}, nil)
-			},
 			wantAllowed: true,
 		},
 		{
@@ -543,13 +522,6 @@ func TestProjectValidation(t *testing.T) {
 					},
 				},
 			},
-			stateSetup: func(state *testState) {
-				state.clusterCache.EXPECT().Get("testcluster").Return(&v3.Cluster{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "testcluster",
-					},
-				}, nil)
-			},
 			wantAllowed: false,
 		},
 		{
@@ -577,13 +549,6 @@ func TestProjectValidation(t *testing.T) {
 						},
 					},
 				},
-			},
-			stateSetup: func(state *testState) {
-				state.clusterCache.EXPECT().Get("testcluster").Return(&v3.Cluster{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "testcluster",
-					},
-				}, nil)
 			},
 			wantAllowed: false,
 		},
@@ -619,13 +584,6 @@ func TestProjectValidation(t *testing.T) {
 					},
 				},
 			},
-			stateSetup: func(state *testState) {
-				state.clusterCache.EXPECT().Get("testcluster").Return(&v3.Cluster{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "testcluster",
-					},
-				}, nil)
-			},
 			wantAllowed: false,
 		},
 		{
@@ -659,13 +617,6 @@ func TestProjectValidation(t *testing.T) {
 						},
 					},
 				},
-			},
-			stateSetup: func(state *testState) {
-				state.clusterCache.EXPECT().Get("testcluster").Return(&v3.Cluster{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "testcluster",
-					},
-				}, nil)
 			},
 			wantAllowed: false,
 		},
@@ -702,13 +653,6 @@ func TestProjectValidation(t *testing.T) {
 					},
 				},
 			},
-			stateSetup: func(state *testState) {
-				state.clusterCache.EXPECT().Get("testcluster").Return(&v3.Cluster{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "testcluster",
-					},
-				}, nil)
-			},
 			wantAllowed: false,
 		},
 		{
@@ -741,13 +685,6 @@ func TestProjectValidation(t *testing.T) {
 						},
 					},
 				},
-			},
-			stateSetup: func(state *testState) {
-				state.clusterCache.EXPECT().Get("testcluster").Return(&v3.Cluster{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "testcluster",
-					},
-				}, nil)
 			},
 			wantAllowed: false,
 		},
@@ -798,13 +735,6 @@ func TestProjectValidation(t *testing.T) {
 					},
 				},
 			},
-			stateSetup: func(state *testState) {
-				state.clusterCache.EXPECT().Get("testcluster").Return(&v3.Cluster{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "testcluster",
-					},
-				}, nil)
-			},
 			wantAllowed: false,
 		},
 		{
@@ -853,13 +783,6 @@ func TestProjectValidation(t *testing.T) {
 						},
 					},
 				},
-			},
-			stateSetup: func(state *testState) {
-				state.clusterCache.EXPECT().Get("testcluster").Return(&v3.Cluster{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "testcluster",
-					},
-				}, nil)
 			},
 			wantAllowed: true,
 		},
@@ -929,14 +852,54 @@ func TestProjectValidation(t *testing.T) {
 					},
 				},
 			},
-			stateSetup: func(state *testState) {
-				state.clusterCache.EXPECT().Get("testcluster").Return(&v3.Cluster{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "testcluster",
-					},
-				}, nil)
+			wantAllowed: false,
+		},
+		{
+			name:      "update changing clusterName",
+			operation: admissionv1.Update,
+			oldProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+				Spec: v3.ProjectSpec{
+					ClusterName: "testcluster",
+				},
+			},
+			newProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testothercluster",
+				},
+				Spec: v3.ProjectSpec{
+					ClusterName: "testothercluster",
+				},
 			},
 			wantAllowed: false,
+		},
+		{
+			name:      "invalid operation",
+			operation: admissionv1.Connect,
+			oldProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+				Spec: v3.ProjectSpec{
+					ClusterName: "testcluster",
+				},
+			},
+			newProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+				Spec: v3.ProjectSpec{
+					ClusterName: "testcluster",
+				},
+			},
+			wantAllowed: false,
+			wantErr:     true,
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
The clusterName field of projects was already immutable in effect since it needed to match the namespace, which is immutable. This makes it explcitly immutable, and changes the check for cluster existence to only occur on create requests

## Issue: <!-- link the issue or issues this PR resolves here -->
rancher/rancher#42999

## Problem
On both create and update, the webhook validates that the ClusterName field refers to a valid cluster. This causes issues when a cluster is deleted - a controller then needs to remove a finalizer added to a project to allow the project to be deleted. Since the cluster no longer exists, the finalizer can't be removed, and the project is indefinitely locked in a deleting state.


## Solution
Now, the clusterName integrity check (validating that the `management.cattle.io/Cluster` object specified by `ClusterName` exists) only runs on create. Additionally, update calls enforce immutability of the `ClusterName` field (since the field needed to match the namespace previously, and the namespace was immutable, this was already enforced). 

Since the integrity check is now done only on create, the finalizers can be removed as desired.

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [x] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [x] Docs