### PR TITLE
Adds Support for Escalate and Bind verb to GRs/GRBs

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -122,8 +122,6 @@ On create or update, the following checks take place:
 
 Users can only change GlobalRoles with rights less than or equal to those they currently possess. This is to prevent privilege escalation. This includes the rules in the RoleTemplates referred to in `inheritedClusterRoles`. 
 
-This escalation checking currently prevents service accounts from modifying GlobalRoles which include permissions on downstream clusters (such as Admin, Restricted Admin, or GlobalRoles which use the `inheritedClusterRoles` field).
-
 #### Builtin Validation
 
 The `globalroles.builtin` field is immutable, and new builtIn GlobalRoles cannot be created.
@@ -139,8 +137,6 @@ Note: all checks are bypassed if the GlobalRoleBinding is being deleted, or if o
 #### Escalation Prevention
 
 Users can only create/update GlobalRoleBindings with rights less than or equal to those they currently possess. This is to prevent privilege escalation. 
-
-This escalation checking currently prevents service accounts from modifying GlobalRoleBindings which give access to GlobalRoles which include permissions on downstream clusters (such as Admin, Restricted Admin, or GlobalRoles which use the `inheritedClusterRoles` field).
 
 #### Valid Global Role Reference
 

--- a/docs.md
+++ b/docs.md
@@ -122,6 +122,8 @@ On create or update, the following checks take place:
 
 Users can only change GlobalRoles with rights less than or equal to those they currently possess. This is to prevent privilege escalation. This includes the rules in the RoleTemplates referred to in `inheritedClusterRoles`. 
 
+This escalation check is bypassed if a user has the `escalate` verb on the GlobalRole that they are attempting to update. This can also be given through a wildcard permission (i.e. the `*` verb also gives `escalate`).
+
 #### Builtin Validation
 
 The `globalroles.builtin` field is immutable, and new builtIn GlobalRoles cannot be created.

--- a/docs.md
+++ b/docs.md
@@ -144,6 +144,8 @@ Users can only create/update GlobalRoleBindings with rights less than or equal t
 
 GlobalRoleBindings must refer to a valid global role (i.e. an existing `GlobalRole` object in the `management.cattle.io/v3` apiGroup).
 
+This escalation check is bypassed if a user has the `bind` verb on the GlobalRole that they are trying to bind to (through creating or updating a GlobalRoleBinding to that GlobalRole). This can also be given through a wildcard permission (i.e. the `*` verb also gives `bind`).
+
 #### Invalid Fields - Update
 Users cannot update the following fields after creation:
 - `userName`

--- a/pkg/auth/escalation.go
+++ b/pkg/auth/escalation.go
@@ -24,8 +24,8 @@ const (
 	CreatorIDAnn = "field.cattle.io/creatorId"
 )
 
-// EscalationAuthorized checks if the user associated with the context is explicitly authorized to escalate the given GVR.
-func EscalationAuthorized(request *admission.Request, gvr schema.GroupVersionResource, sar authorizationv1.SubjectAccessReviewInterface, namespace string) (bool, error) {
+// RequestUserHasVerb checks if the user associated with the context has a given verb on a given gvr for a specified name/namespace
+func RequestUserHasVerb(request *admission.Request, gvr schema.GroupVersionResource, sar authorizationv1.SubjectAccessReviewInterface, verb, name, namespace string) (bool, error) {
 	extras := map[string]v1.ExtraValue{}
 	for k, v := range request.UserInfo.Extra {
 		extras[k] = v1.ExtraValue(v)
@@ -34,11 +34,12 @@ func EscalationAuthorized(request *admission.Request, gvr schema.GroupVersionRes
 	resp, err := sar.Create(request.Context, &v1.SubjectAccessReview{
 		Spec: v1.SubjectAccessReviewSpec{
 			ResourceAttributes: &v1.ResourceAttributes{
-				Verb:      "escalate",
+				Verb:      verb,
 				Namespace: namespace,
 				Version:   gvr.Version,
 				Resource:  gvr.Resource,
 				Group:     gvr.Group,
+				Name:      name,
 			},
 			User:   request.UserInfo.Username,
 			Groups: request.UserInfo.Groups,

--- a/pkg/auth/escalation_test.go
+++ b/pkg/auth/escalation_test.go
@@ -166,7 +166,7 @@ func (e *EscalationSuite) TestConfirmNoEscalation() {
 	}
 }
 
-func (e *EscalationSuite) TestEscalationAuthorized() {
+func (e *EscalationSuite) TestRequestUserHasVerb() {
 	gvr := schema.GroupVersionResource{
 		Group:    "management.cattle.io",
 		Version:  "v3",
@@ -194,7 +194,8 @@ func (e *EscalationSuite) TestEscalationAuthorized() {
 			spec.ResourceAttributes.Group == gvr.Group &&
 			spec.ResourceAttributes.Resource == gvr.Resource &&
 			spec.ResourceAttributes.Namespace == namespace &&
-			spec.ResourceAttributes.Verb == "escalate"
+			spec.ResourceAttributes.Verb == "escalate" &&
+			spec.ResourceAttributes.Name == "test-resource"
 		return true, review, nil
 	})
 	tests := []struct {
@@ -225,7 +226,7 @@ func (e *EscalationSuite) TestEscalationAuthorized() {
 	for i := range tests {
 		test := tests[i]
 		e.Run(test.name, func() {
-			got, err := auth.EscalationAuthorized(test.request, gvr, fakeSAR, namespace)
+			got, err := auth.RequestUserHasVerb(test.request, gvr, fakeSAR, "escalate", "test-resource", namespace)
 			if test.wantErr {
 				e.Error(err, "expected tests to have error.")
 			} else {

--- a/pkg/auth/globalrole.go
+++ b/pkg/auth/globalrole.go
@@ -16,7 +16,7 @@ type GlobalRoleResolver struct {
 
 const ownerRT = "cluster-owner"
 
-var adminRoles = []string{"admin", "restricted-admin"}
+var adminRoles = []string{"restricted-admin"}
 
 // NewRoleTemplateResolver creates a newly allocated RoleTemplateResolver from the provided caches
 func NewGlobalRoleResolver(roleTemplateResolver *RoleTemplateResolver, grCache controllerv3.GlobalRoleCache) *GlobalRoleResolver {
@@ -46,8 +46,8 @@ func (g *GlobalRoleResolver) ClusterRulesFromRole(gr *v3.GlobalRole) ([]rbacv1.P
 	if gr == nil {
 		return nil, nil
 	}
-	// admin and restricted admin are treated like they are owners of all downstream clusters
-	// but they don't get the same field because this would duplicate legacy logic
+	// restricted admin is treated like it is owner of all downstream clusters
+	// but it doesn't get the same field because this would duplicate legacy logic
 	for _, name := range adminRoles {
 		if gr.Name == name {
 			templateRules, err := g.roleTemplateResolver.RulesFromTemplateName(ownerRT)

--- a/pkg/auth/globalrole_test.go
+++ b/pkg/auth/globalrole_test.go
@@ -216,20 +216,6 @@ func TestClusterRulesFromRole(t *testing.T) {
 			wantRules: append(append(noInheritRules, firstRTRules...), secondRTRules...),
 		},
 		{
-			name: "test admin gr",
-			globalRole: &v3.GlobalRole{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "admin",
-				},
-				Rules:                 globalRules,
-				InheritedClusterRoles: []string{},
-			},
-			stateSetup: func(state testState) {
-				state.rtCacheMock.EXPECT().Get("cluster-owner").Return(adminRT, nil)
-			},
-			wantRules: adminRTRules,
-		},
-		{
 			name: "test restricted admin gr",
 			globalRole: &v3.GlobalRole{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/resolvers/grbClusterResolver.go
+++ b/pkg/resolvers/grbClusterResolver.go
@@ -1,19 +1,13 @@
 package resolvers
 
 import (
-	"context"
 	"fmt"
-	"time"
 
 	apisv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/webhook/pkg/auth"
 	v3 "github.com/rancher/webhook/pkg/generated/controllers/management.cattle.io/v3"
-	v1 "k8s.io/api/authorization/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apiserver/pkg/authentication/serviceaccount"
 	"k8s.io/apiserver/pkg/authentication/user"
-	authorizationv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
 )
 
 const (
@@ -21,37 +15,20 @@ const (
 	localCluster    = "local"
 )
 
-var (
-	exceptionServiceAccounts = []string{"rancher-backup", "fleet-agent"}
-	adminRules               = []rbacv1.PolicyRule{
-		{
-			APIGroups: []string{rbacv1.APIGroupAll},
-			Resources: []string{rbacv1.ResourceAll},
-			Verbs:     []string{rbacv1.VerbAll},
-		},
-		{
-			NonResourceURLs: []string{rbacv1.NonResourceAll},
-			Verbs:           []string{rbacv1.VerbAll},
-		},
-	}
-)
-
 // GRBClusterRuleResolver implements the rbacv1.AuthorizationRuleResolver interface. Provides rule resolution
 // for the permissions a GRB gives that apply in a given cluster (or all clusters).
 type GRBClusterRuleResolver struct {
 	GlobalRoleBindings v3.GlobalRoleBindingCache
 	GlobalRoleResolver *auth.GlobalRoleResolver
-	sar                authorizationv1.SubjectAccessReviewInterface
 }
 
 // New NewGRBClusterRuleResolver returns a new resolver for resolving rules given through GlobalRoleBindings
 // which apply to cluster(s). This function can only be called once for each unique instance of grbCache.
-func NewGRBClusterRuleResolver(grbCache v3.GlobalRoleBindingCache, grResolver *auth.GlobalRoleResolver, sar authorizationv1.SubjectAccessReviewInterface) *GRBClusterRuleResolver {
+func NewGRBClusterRuleResolver(grbCache v3.GlobalRoleBindingCache, grResolver *auth.GlobalRoleResolver) *GRBClusterRuleResolver {
 	grbCache.AddIndexer(grbSubjectIndex, grbBySubject)
 	return &GRBClusterRuleResolver{
 		GlobalRoleBindings: grbCache,
 		GlobalRoleResolver: grResolver,
-		sar:                sar,
 	}
 }
 
@@ -109,77 +86,6 @@ func (g *GRBClusterRuleResolver) VisitRulesFor(user user.Info, namespace string,
 			return
 		}
 	}
-	// if we aren't an exception service account, no need to check sa-specific permissions
-	if !isExceptionServiceAccount(user) {
-		return
-	}
-	isAdmin, err := g.hasAdminPermissions(user)
-	if err != nil {
-		visitor(nil, nil, err)
-		return
-	}
-	if isAdmin {
-		// exception service accounts are considered to have full permissions for the purposes of the clusterRules
-		if !visitRules(nil, adminRules, nil, visitor) {
-			return
-		}
-	}
-}
-
-// hasAdminPermissions checks if a given user is an admin
-func (g *GRBClusterRuleResolver) hasAdminPermissions(user user.Info) (bool, error) {
-	extras := map[string]v1.ExtraValue{}
-	for extraKey, extraValue := range user.GetExtra() {
-		extras[extraKey] = v1.ExtraValue(extraValue)
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-	defer cancel()
-	resourceResponse, err := g.sar.Create(ctx, &v1.SubjectAccessReview{
-		Spec: v1.SubjectAccessReviewSpec{
-			ResourceAttributes: &v1.ResourceAttributes{
-				Verb:     rbacv1.VerbAll,
-				Group:    rbacv1.APIGroupAll,
-				Version:  rbacv1.APIGroupAll,
-				Resource: rbacv1.ResourceAll,
-			},
-			User:   user.GetName(),
-			Groups: user.GetGroups(),
-			UID:    user.GetUID(),
-			Extra:  extras,
-		}}, metav1.CreateOptions{})
-	if err != nil {
-		return false, fmt.Errorf("unable to create sar for user %s: %w", user.GetName(), err)
-	}
-	if resourceResponse == nil {
-		return false, fmt.Errorf("no sar returned from create request for user %s", user.GetName())
-	}
-	return resourceResponse.Status.Allowed, nil
-}
-
-// isExceptionServiceAccount checks if the specified user is one of the rancher service accounts which need to interact
-// with globalRoles but don't themselves have grb permissions
-func isExceptionServiceAccount(user user.Info) bool {
-	isExceptionUser := false
-	_, saName, err := serviceaccount.SplitUsername(user.GetName())
-	if err != nil {
-		// an error indicates that this wasn't a service account, so we can return early
-		return false
-	}
-	for _, exceptionUsername := range exceptionServiceAccounts {
-		if saName == exceptionUsername {
-			isExceptionUser = true
-			break
-		}
-	}
-	if !isExceptionUser {
-		return false
-	}
-	for _, group := range user.GetGroups() {
-		if group == serviceaccount.AllServiceAccountsGroup {
-			return true
-		}
-	}
-	return false
 }
 
 // grbBySubject indexes a GRB using the subject as the key.

--- a/pkg/resolvers/grbClusterResolver_test.go
+++ b/pkg/resolvers/grbClusterResolver_test.go
@@ -9,30 +9,22 @@ import (
 	"github.com/rancher/webhook/pkg/auth"
 	"github.com/rancher/wrangler/pkg/generic/fake"
 	"github.com/stretchr/testify/suite"
-	v1 "k8s.io/api/authorization/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/authentication/user"
-	k8fake "k8s.io/client-go/kubernetes/typed/authorization/v1/fake"
-	k8testing "k8s.io/client-go/testing"
 )
 
 type GRBClusterRuleResolverSuite struct {
 	suite.Suite
-	userInfo           user.Info
-	broUserInfo        user.Info
-	broDefaultUserInfo user.Info
-	fleetUserInfo      user.Info
-	otherSAUserInfo    user.Info
-	groupGRB           *v3.GlobalRoleBinding
-	errorGroupGRB      *v3.GlobalRoleBinding
-	userGRB            *v3.GlobalRoleBinding
-	errorUserGRB       *v3.GlobalRoleBinding
-	globalUserRules    []rbacv1.PolicyRule
-	globalGroupRules   []rbacv1.PolicyRule
-	userClusterRules   []rbacv1.PolicyRule
-	groupClusterRules  []rbacv1.PolicyRule
+	userInfo          user.Info
+	groupGRB          *v3.GlobalRoleBinding
+	errorGroupGRB     *v3.GlobalRoleBinding
+	userGRB           *v3.GlobalRoleBinding
+	errorUserGRB      *v3.GlobalRoleBinding
+	globalUserRules   []rbacv1.PolicyRule
+	globalGroupRules  []rbacv1.PolicyRule
+	userClusterRules  []rbacv1.PolicyRule
+	groupClusterRules []rbacv1.PolicyRule
 }
 
 func TestGRBClusterRuleResolver(t *testing.T) {
@@ -42,10 +34,6 @@ func TestGRBClusterRuleResolver(t *testing.T) {
 
 func (g *GRBClusterRuleResolverSuite) SetupSuite() {
 	g.userInfo = NewUserInfo("test-user", "test-group")
-	g.broUserInfo = NewUserInfo("system:serviceaccount:cattle-resources-system:rancher-backup", "system:serviceaccounts")
-	g.broDefaultUserInfo = NewUserInfo("system:serviceaccount:default:rancher-backup", "system:serviceaccounts")
-	g.fleetUserInfo = NewUserInfo("system:serviceaccount:cattle-fleet-local-system:fleet-agent", "system:serviceaccounts")
-	g.otherSAUserInfo = NewUserInfo("system:serviceaccount:default:default", "system:serviceaccounts")
 	g.groupGRB = &v3.GlobalRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "group-grb",
@@ -110,12 +98,10 @@ func (g *GRBClusterRuleResolverSuite) TestGRBClusterRuleResolver() {
 		grCache  *fake.MockNonNamespacedCacheInterface[*v3.GlobalRole]
 		grbCache *fake.MockNonNamespacedCacheInterface[*v3.GlobalRoleBinding]
 		rtCache  *fake.MockNonNamespacedCacheInterface[*v3.RoleTemplate]
-		sar      *k8fake.FakeSubjectAccessReviews
 	}
 
 	tests := []struct {
 		name      string
-		userInfo  user.Info
 		setup     func(state testState)
 		namespace string
 		wantRules []rbacv1.PolicyRule
@@ -124,7 +110,6 @@ func (g *GRBClusterRuleResolverSuite) TestGRBClusterRuleResolver() {
 		{
 			name:      "test rule resolution, valid + invalid user/group bindings",
 			namespace: "",
-			userInfo:  g.userInfo,
 			setup: func(state testState) {
 				state.grbCache.EXPECT().GetByIndex(grbSubjectIndex, GetUserKey(g.userInfo.GetName(), "")).Return([]*v3.GlobalRoleBinding{g.userGRB, g.errorUserGRB}, nil)
 				state.grbCache.EXPECT().GetByIndex(grbSubjectIndex, GetGroupKey(g.userInfo.GetGroups()[0], "")).Return([]*v3.GlobalRoleBinding{g.groupGRB, g.errorGroupGRB}, nil)
@@ -164,7 +149,6 @@ func (g *GRBClusterRuleResolverSuite) TestGRBClusterRuleResolver() {
 		{
 			name:      "test state resolution group indexer error",
 			namespace: "",
-			userInfo:  g.userInfo,
 			setup: func(state testState) {
 				state.grbCache.EXPECT().GetByIndex(grbSubjectIndex, GetUserKey(g.userInfo.GetName(), "")).Return([]*v3.GlobalRoleBinding{g.userGRB, g.errorUserGRB}, nil)
 				state.grbCache.EXPECT().GetByIndex(grbSubjectIndex, GetGroupKey(g.userInfo.GetGroups()[0], "")).Return(nil, fmt.Errorf("server unavailable"))
@@ -190,7 +174,6 @@ func (g *GRBClusterRuleResolverSuite) TestGRBClusterRuleResolver() {
 		{
 			name:      "test state resolution user indexer error",
 			namespace: "",
-			userInfo:  g.userInfo,
 			setup: func(state testState) {
 				state.grbCache.EXPECT().GetByIndex(grbSubjectIndex, GetUserKey(g.userInfo.GetName(), "")).Return(nil, fmt.Errorf("server unavailable"))
 				state.grbCache.EXPECT().GetByIndex(grbSubjectIndex, GetGroupKey(g.userInfo.GetGroups()[0], "")).Return([]*v3.GlobalRoleBinding{g.groupGRB, g.errorGroupGRB}, nil)
@@ -217,7 +200,6 @@ func (g *GRBClusterRuleResolverSuite) TestGRBClusterRuleResolver() {
 		{
 			name:      "test state resolution local cluster",
 			namespace: "local",
-			userInfo:  g.userInfo,
 			setup: func(state testState) {
 				state.grbCache.EXPECT().GetByIndex(grbSubjectIndex, GetUserKey(g.userInfo.GetName(), "")).Return([]*v3.GlobalRoleBinding{g.userGRB, g.errorUserGRB}, nil)
 				state.grbCache.EXPECT().GetByIndex(grbSubjectIndex, GetGroupKey(g.userInfo.GetGroups()[0], "")).Return([]*v3.GlobalRoleBinding{g.groupGRB, g.errorGroupGRB}, nil)
@@ -246,7 +228,6 @@ func (g *GRBClusterRuleResolverSuite) TestGRBClusterRuleResolver() {
 		{
 			name:      "test state resolution non-local cluster",
 			namespace: "not-local",
-			userInfo:  g.userInfo,
 			setup: func(state testState) {
 				state.grbCache.EXPECT().GetByIndex(grbSubjectIndex, GetUserKey(g.userInfo.GetName(), "")).Return([]*v3.GlobalRoleBinding{g.userGRB}, nil)
 				state.grbCache.EXPECT().GetByIndex(grbSubjectIndex, GetGroupKey(g.userInfo.GetGroups()[0], "")).Return([]*v3.GlobalRoleBinding{g.groupGRB}, nil)
@@ -286,7 +267,6 @@ func (g *GRBClusterRuleResolverSuite) TestGRBClusterRuleResolver() {
 		{
 			name:      "test state resolution no error, no namespace",
 			namespace: "",
-			userInfo:  g.userInfo,
 			setup: func(state testState) {
 				state.grbCache.EXPECT().GetByIndex(grbSubjectIndex, GetUserKey(g.userInfo.GetName(), "")).Return([]*v3.GlobalRoleBinding{g.userGRB}, nil)
 				state.grbCache.EXPECT().GetByIndex(grbSubjectIndex, GetGroupKey(g.userInfo.GetGroups()[0], "")).Return([]*v3.GlobalRoleBinding{g.groupGRB}, nil)
@@ -323,276 +303,6 @@ func (g *GRBClusterRuleResolverSuite) TestGRBClusterRuleResolver() {
 			wantRules: append(g.userClusterRules, g.groupClusterRules...),
 			wantError: false,
 		},
-		{
-			name:      "test backup-restore service account",
-			namespace: "",
-			userInfo:  g.broUserInfo,
-			setup: func(state testState) {
-				state.grbCache.EXPECT().GetByIndex(grbSubjectIndex, GetUserKey(g.broUserInfo.GetName(), "")).Return([]*v3.GlobalRoleBinding{}, nil)
-				state.grbCache.EXPECT().GetByIndex(grbSubjectIndex, GetGroupKey(g.broUserInfo.GetGroups()[0], "")).Return([]*v3.GlobalRoleBinding{}, nil)
-				state.sar.Fake.AddReactor("create", "subjectaccessreviews", func(action k8testing.Action) (handled bool, ret runtime.Object, err error) {
-					createAction := action.(k8testing.CreateActionImpl)
-					review := createAction.GetObject().(*v1.SubjectAccessReview)
-					spec := review.Spec
-					attributes := spec.ResourceAttributes
-					isAdminPerm := attributes != nil && attributes.Group == rbacv1.APIGroupAll &&
-						attributes.Resource == rbacv1.ResourceAll && attributes.Verb == rbacv1.VerbAll &&
-						attributes.Version == rbacv1.APIGroupAll
-					if isAdminPerm && spec.User == g.broUserInfo.GetName() && len(spec.Groups) == 1 && spec.Groups[0] == g.broUserInfo.GetGroups()[0] {
-						review.Status.Allowed = true
-						return true, review, nil
-					}
-					return false, nil, nil
-				})
-
-			},
-
-			wantRules: adminRules,
-			wantError: false,
-		},
-		{
-			name:      "test backup-restore service account, non-admin",
-			namespace: "",
-			userInfo:  g.broUserInfo,
-			setup: func(state testState) {
-				state.grbCache.EXPECT().GetByIndex(grbSubjectIndex, GetUserKey(g.broUserInfo.GetName(), "")).Return([]*v3.GlobalRoleBinding{}, nil)
-				state.grbCache.EXPECT().GetByIndex(grbSubjectIndex, GetGroupKey(g.broUserInfo.GetGroups()[0], "")).Return([]*v3.GlobalRoleBinding{}, nil)
-				state.sar.Fake.AddReactor("create", "subjectaccessreviews", func(action k8testing.Action) (handled bool, ret runtime.Object, err error) {
-					createAction := action.(k8testing.CreateActionImpl)
-					review := createAction.GetObject().(*v1.SubjectAccessReview)
-					spec := review.Spec
-					attributes := spec.ResourceAttributes
-					isAdminPerm := attributes != nil && attributes.Group == rbacv1.APIGroupAll &&
-						attributes.Resource == rbacv1.ResourceAll && attributes.Verb == rbacv1.VerbAll &&
-						attributes.Version == rbacv1.APIGroupAll
-					if isAdminPerm && spec.User == g.broUserInfo.GetName() && len(spec.Groups) == 1 && spec.Groups[0] == g.broUserInfo.GetGroups()[0] {
-						review.Status.Allowed = false
-						return true, review, nil
-					}
-					return false, nil, nil
-				})
-
-			},
-
-			wantRules: []rbacv1.PolicyRule{},
-			wantError: false,
-		},
-		{
-			name:      "test backup-restore service account, error when evaluting SAR",
-			namespace: "",
-			userInfo:  g.broUserInfo,
-			setup: func(state testState) {
-				state.grbCache.EXPECT().GetByIndex(grbSubjectIndex, GetUserKey(g.broUserInfo.GetName(), "")).Return([]*v3.GlobalRoleBinding{}, nil)
-				state.grbCache.EXPECT().GetByIndex(grbSubjectIndex, GetGroupKey(g.broUserInfo.GetGroups()[0], "")).Return([]*v3.GlobalRoleBinding{}, nil)
-				state.sar.Fake.AddReactor("create", "subjectaccessreviews", func(action k8testing.Action) (handled bool, ret runtime.Object, err error) {
-					createAction := action.(k8testing.CreateActionImpl)
-					review := createAction.GetObject().(*v1.SubjectAccessReview)
-					spec := review.Spec
-					attributes := spec.ResourceAttributes
-					isAdminPerm := attributes != nil && attributes.Group == rbacv1.APIGroupAll &&
-						attributes.Resource == rbacv1.ResourceAll && attributes.Verb == rbacv1.VerbAll &&
-						attributes.Version == rbacv1.APIGroupAll
-					if isAdminPerm && spec.User == g.broUserInfo.GetName() && len(spec.Groups) == 1 && spec.Groups[0] == g.broUserInfo.GetGroups()[0] {
-						return true, review, fmt.Errorf("unable to process request")
-					}
-					return false, nil, nil
-				})
-
-			},
-			wantRules: []rbacv1.PolicyRule{},
-			wantError: true,
-		},
-		{
-			name:      "test backup-restore service account, nil SAR result",
-			namespace: "",
-			userInfo:  g.broUserInfo,
-			setup: func(state testState) {
-				state.grbCache.EXPECT().GetByIndex(grbSubjectIndex, GetUserKey(g.broUserInfo.GetName(), "")).Return([]*v3.GlobalRoleBinding{}, nil)
-				state.grbCache.EXPECT().GetByIndex(grbSubjectIndex, GetGroupKey(g.broUserInfo.GetGroups()[0], "")).Return([]*v3.GlobalRoleBinding{}, nil)
-				state.sar.Fake.AddReactor("create", "subjectaccessreviews", func(action k8testing.Action) (handled bool, ret runtime.Object, err error) {
-					createAction := action.(k8testing.CreateActionImpl)
-					review := createAction.GetObject().(*v1.SubjectAccessReview)
-					spec := review.Spec
-					attributes := spec.ResourceAttributes
-					isAdminPerm := attributes != nil && attributes.Group == rbacv1.APIGroupAll &&
-						attributes.Resource == rbacv1.ResourceAll && attributes.Verb == rbacv1.VerbAll &&
-						attributes.Version == rbacv1.APIGroupAll
-					if isAdminPerm && spec.User == g.broUserInfo.GetName() && len(spec.Groups) == 1 && spec.Groups[0] == g.broUserInfo.GetGroups()[0] {
-						return true, nil, nil
-					}
-					return false, nil, nil
-				})
-
-			},
-			wantRules: []rbacv1.PolicyRule{},
-			wantError: true,
-		},
-		{
-			name:      "test fleet service account",
-			namespace: "",
-			userInfo:  g.fleetUserInfo,
-			setup: func(state testState) {
-				state.grbCache.EXPECT().GetByIndex(grbSubjectIndex, GetUserKey(g.fleetUserInfo.GetName(), "")).Return([]*v3.GlobalRoleBinding{}, nil)
-				state.grbCache.EXPECT().GetByIndex(grbSubjectIndex, GetGroupKey(g.fleetUserInfo.GetGroups()[0], "")).Return([]*v3.GlobalRoleBinding{}, nil)
-				state.sar.Fake.AddReactor("create", "subjectaccessreviews", func(action k8testing.Action) (handled bool, ret runtime.Object, err error) {
-					createAction := action.(k8testing.CreateActionImpl)
-					review := createAction.GetObject().(*v1.SubjectAccessReview)
-					spec := review.Spec
-					attributes := spec.ResourceAttributes
-					isAdminPerm := attributes != nil && attributes.Group == rbacv1.APIGroupAll &&
-						attributes.Resource == rbacv1.ResourceAll && attributes.Verb == rbacv1.VerbAll &&
-						attributes.Version == rbacv1.APIGroupAll
-					if isAdminPerm && spec.User == g.fleetUserInfo.GetName() && len(spec.Groups) == 1 && spec.Groups[0] == g.fleetUserInfo.GetGroups()[0] {
-						review.Status.Allowed = true
-						return true, review, nil
-					}
-					return false, nil, nil
-				})
-
-			},
-
-			wantRules: adminRules,
-			wantError: false,
-		},
-		{
-			name:      "test fleet service account, non-admin permissions",
-			namespace: "",
-			userInfo:  g.fleetUserInfo,
-			setup: func(state testState) {
-				state.grbCache.EXPECT().GetByIndex(grbSubjectIndex, GetUserKey(g.fleetUserInfo.GetName(), "")).Return([]*v3.GlobalRoleBinding{}, nil)
-				state.grbCache.EXPECT().GetByIndex(grbSubjectIndex, GetGroupKey(g.fleetUserInfo.GetGroups()[0], "")).Return([]*v3.GlobalRoleBinding{}, nil)
-				state.sar.Fake.AddReactor("create", "subjectaccessreviews", func(action k8testing.Action) (handled bool, ret runtime.Object, err error) {
-					createAction := action.(k8testing.CreateActionImpl)
-					review := createAction.GetObject().(*v1.SubjectAccessReview)
-					spec := review.Spec
-					attributes := spec.ResourceAttributes
-					isAdminPerm := attributes != nil && attributes.Group == rbacv1.APIGroupAll &&
-						attributes.Resource == rbacv1.ResourceAll && attributes.Verb == rbacv1.VerbAll &&
-						attributes.Version == rbacv1.APIGroupAll
-					if isAdminPerm && spec.User == g.fleetUserInfo.GetName() && len(spec.Groups) == 1 && spec.Groups[0] == g.fleetUserInfo.GetGroups()[0] {
-						review.Status.Allowed = false
-						return true, review, nil
-					}
-					return false, nil, nil
-				})
-
-			},
-
-			wantRules: []rbacv1.PolicyRule{},
-			wantError: false,
-		},
-		{
-			name:      "test fleet service account, error when processing SAR",
-			namespace: "",
-			userInfo:  g.fleetUserInfo,
-			setup: func(state testState) {
-				state.grbCache.EXPECT().GetByIndex(grbSubjectIndex, GetUserKey(g.fleetUserInfo.GetName(), "")).Return([]*v3.GlobalRoleBinding{}, nil)
-				state.grbCache.EXPECT().GetByIndex(grbSubjectIndex, GetGroupKey(g.fleetUserInfo.GetGroups()[0], "")).Return([]*v3.GlobalRoleBinding{}, nil)
-				state.sar.Fake.AddReactor("create", "subjectaccessreviews", func(action k8testing.Action) (handled bool, ret runtime.Object, err error) {
-					createAction := action.(k8testing.CreateActionImpl)
-					review := createAction.GetObject().(*v1.SubjectAccessReview)
-					spec := review.Spec
-					attributes := spec.ResourceAttributes
-					isAdminPerm := attributes != nil && attributes.Group == rbacv1.APIGroupAll &&
-						attributes.Resource == rbacv1.ResourceAll && attributes.Verb == rbacv1.VerbAll &&
-						attributes.Version == rbacv1.APIGroupAll
-					if isAdminPerm && spec.User == g.fleetUserInfo.GetName() && len(spec.Groups) == 1 && spec.Groups[0] == g.fleetUserInfo.GetGroups()[0] {
-						return true, review, fmt.Errorf("unable to process sar")
-					}
-					return false, nil, nil
-				})
-
-			},
-
-			wantRules: []rbacv1.PolicyRule{},
-			wantError: true,
-		},
-		{
-			name:      "test fleet service account, nil SAR result",
-			namespace: "",
-			userInfo:  g.fleetUserInfo,
-			setup: func(state testState) {
-				state.grbCache.EXPECT().GetByIndex(grbSubjectIndex, GetUserKey(g.fleetUserInfo.GetName(), "")).Return([]*v3.GlobalRoleBinding{}, nil)
-				state.grbCache.EXPECT().GetByIndex(grbSubjectIndex, GetGroupKey(g.fleetUserInfo.GetGroups()[0], "")).Return([]*v3.GlobalRoleBinding{}, nil)
-				state.sar.Fake.AddReactor("create", "subjectaccessreviews", func(action k8testing.Action) (handled bool, ret runtime.Object, err error) {
-					createAction := action.(k8testing.CreateActionImpl)
-					review := createAction.GetObject().(*v1.SubjectAccessReview)
-					spec := review.Spec
-					attributes := spec.ResourceAttributes
-					isAdminPerm := attributes != nil && attributes.Group == rbacv1.APIGroupAll &&
-						attributes.Resource == rbacv1.ResourceAll && attributes.Verb == rbacv1.VerbAll &&
-						attributes.Version == rbacv1.APIGroupAll
-					if isAdminPerm && spec.User == g.fleetUserInfo.GetName() && len(spec.Groups) == 1 && spec.Groups[0] == g.fleetUserInfo.GetGroups()[0] {
-						return true, nil, nil
-					}
-					return false, nil, nil
-				})
-
-			},
-
-			wantRules: []rbacv1.PolicyRule{},
-			wantError: true,
-		},
-
-		{
-			name:      "test bro default service account",
-			namespace: "",
-			userInfo:  g.broDefaultUserInfo,
-			setup: func(state testState) {
-				state.grbCache.EXPECT().GetByIndex(grbSubjectIndex, GetUserKey(g.broDefaultUserInfo.GetName(), "")).Return([]*v3.GlobalRoleBinding{}, nil)
-				state.grbCache.EXPECT().GetByIndex(grbSubjectIndex, GetGroupKey(g.broDefaultUserInfo.GetGroups()[0], "")).Return([]*v3.GlobalRoleBinding{}, nil)
-				state.sar.Fake.AddReactor("create", "subjectaccessreviews", func(action k8testing.Action) (handled bool, ret runtime.Object, err error) {
-					createAction := action.(k8testing.CreateActionImpl)
-					review := createAction.GetObject().(*v1.SubjectAccessReview)
-					spec := review.Spec
-					attributes := spec.ResourceAttributes
-					isAdminPerm := attributes != nil && attributes.Group == rbacv1.APIGroupAll &&
-						attributes.Resource == rbacv1.ResourceAll && attributes.Verb == rbacv1.VerbAll &&
-						attributes.Version == rbacv1.APIGroupAll
-					if isAdminPerm && spec.User == g.broDefaultUserInfo.GetName() && len(spec.Groups) == 1 && spec.Groups[0] == g.broDefaultUserInfo.GetGroups()[0] {
-						review.Status.Allowed = true
-						return true, review, nil
-					}
-					return false, nil, nil
-				})
-
-			},
-
-			wantRules: adminRules,
-			wantError: false,
-		},
-
-		{
-			name:      "test other service account",
-			namespace: "",
-			userInfo:  g.otherSAUserInfo,
-			setup: func(state testState) {
-				state.grbCache.EXPECT().GetByIndex(grbSubjectIndex, GetUserKey(g.otherSAUserInfo.GetName(), "")).Return([]*v3.GlobalRoleBinding{}, nil)
-				state.grbCache.EXPECT().GetByIndex(grbSubjectIndex, GetGroupKey(g.otherSAUserInfo.GetGroups()[0], "")).Return([]*v3.GlobalRoleBinding{}, nil)
-			},
-			wantRules: []rbacv1.PolicyRule{},
-			wantError: false,
-		},
-		{
-			name:      "test backup-restore not in sa group",
-			namespace: "",
-			userInfo:  NewUserInfo(g.broUserInfo.GetName()),
-			setup: func(state testState) {
-				state.grbCache.EXPECT().GetByIndex(grbSubjectIndex, GetUserKey(g.broUserInfo.GetName(), "")).Return([]*v3.GlobalRoleBinding{}, nil)
-			},
-			wantRules: []rbacv1.PolicyRule{},
-			wantError: false,
-		},
-		{
-			name:      "test fleet not in sa group",
-			namespace: "",
-			userInfo:  NewUserInfo(g.fleetUserInfo.GetName()),
-			setup: func(state testState) {
-				state.grbCache.EXPECT().GetByIndex(grbSubjectIndex, GetUserKey(g.fleetUserInfo.GetName(), "")).Return([]*v3.GlobalRoleBinding{}, nil)
-			},
-			wantRules: []rbacv1.PolicyRule{},
-			wantError: false,
-		},
 	}
 
 	for _, test := range tests {
@@ -604,14 +314,10 @@ func (g *GRBClusterRuleResolverSuite) TestGRBClusterRuleResolver() {
 
 			rtCache := fake.NewMockNonNamespacedCacheInterface[*v3.RoleTemplate](ctrl)
 			grCache := fake.NewMockNonNamespacedCacheInterface[*v3.GlobalRole](ctrl)
-			k8Fake := &k8testing.Fake{}
-			fakeSAR := &k8fake.FakeSubjectAccessReviews{Fake: &k8fake.FakeAuthorizationV1{Fake: k8Fake}}
-
 			state := testState{
 				grCache:  grCache,
 				grbCache: grbCache,
 				rtCache:  rtCache,
-				sar:      fakeSAR,
 			}
 
 			if test.setup != nil {
@@ -619,9 +325,9 @@ func (g *GRBClusterRuleResolverSuite) TestGRBClusterRuleResolver() {
 			}
 
 			grResolver := auth.NewGlobalRoleResolver(auth.NewRoleTemplateResolver(state.rtCache, nil), state.grCache)
-			grbResolver := NewGRBClusterRuleResolver(state.grbCache, grResolver, state.sar)
+			grbResolver := NewGRBClusterRuleResolver(state.grbCache, grResolver)
 
-			rules, err := grbResolver.RulesFor(test.userInfo, test.namespace)
+			rules, err := grbResolver.RulesFor(g.userInfo, test.namespace)
 			g.Require().Len(rules, len(test.wantRules))
 			for _, rule := range test.wantRules {
 				g.Require().Contains(rules, rule)

--- a/pkg/resolvers/resolvers_test.go
+++ b/pkg/resolvers/resolvers_test.go
@@ -54,9 +54,6 @@ func NewUserInfo(username string, groups ...string) *user.DefaultInfo {
 	return &user.DefaultInfo{
 		Name:   username,
 		Groups: groups,
-		Extra: map[string][]string{
-			"test": {"test"},
-		},
 	}
 }
 

--- a/pkg/resources/management.cattle.io/v3/globalrole/GlobalRole.md
+++ b/pkg/resources/management.cattle.io/v3/globalrole/GlobalRole.md
@@ -12,8 +12,6 @@ On create or update, the following checks take place:
 
 Users can only change GlobalRoles with rights less than or equal to those they currently possess. This is to prevent privilege escalation. This includes the rules in the RoleTemplates referred to in `inheritedClusterRoles`. 
 
-This escalation checking currently prevents service accounts from modifying GlobalRoles which include permissions on downstream clusters (such as Admin, Restricted Admin, or GlobalRoles which use the `inheritedClusterRoles` field).
-
 ### Builtin Validation
 
 The `globalroles.builtin` field is immutable, and new builtIn GlobalRoles cannot be created.

--- a/pkg/resources/management.cattle.io/v3/globalrole/GlobalRole.md
+++ b/pkg/resources/management.cattle.io/v3/globalrole/GlobalRole.md
@@ -12,6 +12,8 @@ On create or update, the following checks take place:
 
 Users can only change GlobalRoles with rights less than or equal to those they currently possess. This is to prevent privilege escalation. This includes the rules in the RoleTemplates referred to in `inheritedClusterRoles`. 
 
+This escalation check is bypassed if a user has the `escalate` verb on the GlobalRole that they are attempting to update. This can also be given through a wildcard permission (i.e. the `*` verb also gives `escalate`).
+
 ### Builtin Validation
 
 The `globalroles.builtin` field is immutable, and new builtIn GlobalRoles cannot be created.

--- a/pkg/resources/management.cattle.io/v3/globalrole/setup_test.go
+++ b/pkg/resources/management.cattle.io/v3/globalrole/setup_test.go
@@ -274,5 +274,5 @@ func newDefaultState(t *testing.T) testState {
 
 func (m *testState) createBaseGRBResolver() *resolvers.GRBClusterRuleResolver {
 	grResolver := auth.NewGlobalRoleResolver(auth.NewRoleTemplateResolver(m.rtCacheMock, nil), m.grCacheMock)
-	return resolvers.NewGRBClusterRuleResolver(m.grbCacheMock, grResolver, nil)
+	return resolvers.NewGRBClusterRuleResolver(m.grbCacheMock, grResolver)
 }

--- a/pkg/resources/management.cattle.io/v3/globalrole/setup_test.go
+++ b/pkg/resources/management.cattle.io/v3/globalrole/setup_test.go
@@ -18,6 +18,8 @@ import (
 	v1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	k8fake "k8s.io/client-go/kubernetes/typed/authorization/v1/fake"
+	k8testing "k8s.io/client-go/testing"
 	"k8s.io/kubernetes/pkg/registry/rbac/validation"
 )
 
@@ -170,6 +172,7 @@ type testState struct {
 	rtCacheMock  *fake.MockNonNamespacedCacheInterface[*v3.RoleTemplate]
 	grCacheMock  *fake.MockNonNamespacedCacheInterface[*v3.GlobalRole]
 	grbCacheMock *fake.MockNonNamespacedCacheInterface[*v3.GlobalRoleBinding]
+	sarMock      *k8fake.FakeSubjectAccessReviews
 	resolver     validation.AuthorizationRuleResolver
 }
 
@@ -194,7 +197,7 @@ func createGRRequest(t *testing.T, test testCase) *admission.Request {
 			RequestKind:     &gvk,
 			RequestResource: &gvr,
 			Operation:       admissionv1.Create,
-			UserInfo:        v1authentication.UserInfo{Username: username, UID: ""},
+			UserInfo:        v1authentication.UserInfo{Username: username, UID: "", Extra: map[string]v1authentication.ExtraValue{"test": []string{"test"}}},
 			Object:          runtime.RawExtension{},
 			OldObject:       runtime.RawExtension{},
 		},
@@ -262,12 +265,15 @@ func newDefaultState(t *testing.T) testState {
 	grbCacheMock.EXPECT().AddIndexer(gomock.Any(), gomock.Any()).AnyTimes()
 	grCacheMock.EXPECT().Get(baseGR.Name).Return(&baseGR, nil).AnyTimes()
 	rtCacheMock.EXPECT().Get(baseRT.Name).Return(&baseRT, nil).AnyTimes()
+	k8Fake := &k8testing.Fake{}
+	fakeSAR := &k8fake.FakeSubjectAccessReviews{Fake: &k8fake.FakeAuthorizationV1{Fake: k8Fake}}
 
 	resolver, _ := validation.NewTestRuleResolver(nil, nil, clusterRoles, clusterRoleBindings)
 	return testState{
 		rtCacheMock:  rtCacheMock,
 		grCacheMock:  grCacheMock,
 		grbCacheMock: grbCacheMock,
+		sarMock:      fakeSAR,
 		resolver:     resolver,
 	}
 }

--- a/pkg/resources/management.cattle.io/v3/globalrolebinding/GlobalRoleBinding.md
+++ b/pkg/resources/management.cattle.io/v3/globalrolebinding/GlobalRoleBinding.md
@@ -10,6 +10,8 @@ Users can only create/update GlobalRoleBindings with rights less than or equal t
 
 GlobalRoleBindings must refer to a valid global role (i.e. an existing `GlobalRole` object in the `management.cattle.io/v3` apiGroup).
 
+This escalation check is bypassed if a user has the `bind` verb on the GlobalRole that they are trying to bind to (through creating or updating a GlobalRoleBinding to that GlobalRole). This can also be given through a wildcard permission (i.e. the `*` verb also gives `bind`).
+
 ### Invalid Fields - Update
 Users cannot update the following fields after creation:
 - `userName`

--- a/pkg/resources/management.cattle.io/v3/globalrolebinding/GlobalRoleBinding.md
+++ b/pkg/resources/management.cattle.io/v3/globalrolebinding/GlobalRoleBinding.md
@@ -6,8 +6,6 @@ Note: all checks are bypassed if the GlobalRoleBinding is being deleted, or if o
 
 Users can only create/update GlobalRoleBindings with rights less than or equal to those they currently possess. This is to prevent privilege escalation. 
 
-This escalation checking currently prevents service accounts from modifying GlobalRoleBindings which give access to GlobalRoles which include permissions on downstream clusters (such as Admin, Restricted Admin, or GlobalRoles which use the `inheritedClusterRoles` field).
-
 ### Valid Global Role Reference
 
 GlobalRoleBindings must refer to a valid global role (i.e. an existing `GlobalRole` object in the `management.cattle.io/v3` apiGroup).

--- a/pkg/resources/management.cattle.io/v3/globalrolebinding/setup_test.go
+++ b/pkg/resources/management.cattle.io/v3/globalrolebinding/setup_test.go
@@ -19,6 +19,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8fake "k8s.io/client-go/kubernetes/typed/authorization/v1/fake"
+	k8testing "k8s.io/client-go/testing"
 	"k8s.io/kubernetes/pkg/registry/rbac/validation"
 )
 
@@ -45,6 +47,7 @@ type testState struct {
 	rtCacheMock  *fake.MockNonNamespacedCacheInterface[*v3.RoleTemplate]
 	grCacheMock  *fake.MockNonNamespacedCacheInterface[*v3.GlobalRole]
 	grbCacheMock *fake.MockNonNamespacedCacheInterface[*v3.GlobalRoleBinding]
+	sarMock      *k8fake.FakeSubjectAccessReviews
 	resolver     validation.AuthorizationRuleResolver
 }
 
@@ -256,7 +259,7 @@ func createGRBRequest(t *testing.T, test testCase) *admission.Request {
 			RequestKind:     &gvk,
 			RequestResource: &gvr,
 			Operation:       v1.Create,
-			UserInfo:        v1authentication.UserInfo{Username: username, UID: ""},
+			UserInfo:        v1authentication.UserInfo{Username: username, UID: "", Extra: map[string]v1authentication.ExtraValue{"test": []string{"test"}}},
 			Object:          runtime.RawExtension{},
 			OldObject:       runtime.RawExtension{},
 		},
@@ -306,11 +309,15 @@ func newDefaultState(t *testing.T) testState {
 	grCacheMock.EXPECT().Get(notFoundName).Return(nil, newNotFound(notFoundName)).AnyTimes()
 	grCacheMock.EXPECT().Get("").Return(nil, newNotFound("")).AnyTimes()
 	rtCacheMock.EXPECT().Get(baseRT.Name).Return(&baseRT, nil).AnyTimes()
+	k8Fake := &k8testing.Fake{}
+	fakeSAR := &k8fake.FakeSubjectAccessReviews{Fake: &k8fake.FakeAuthorizationV1{Fake: k8Fake}}
+
 	resolver, _ := validation.NewTestRuleResolver(nil, nil, clusterRoles, clusterRoleBindings)
 	return testState{
 		rtCacheMock:  rtCacheMock,
 		grCacheMock:  grCacheMock,
 		grbCacheMock: grbCacheMock,
+		sarMock:      fakeSAR,
 		resolver:     resolver,
 	}
 }

--- a/pkg/resources/management.cattle.io/v3/globalrolebinding/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/globalrolebinding/validator_test.go
@@ -546,7 +546,7 @@ func TestAdmit(t *testing.T) {
 				test.args.stateSetup(state)
 			}
 			grResolver := auth.NewGlobalRoleResolver(auth.NewRoleTemplateResolver(state.rtCacheMock, nil), state.grCacheMock)
-			grbResolver := resolvers.NewGRBClusterRuleResolver(state.grbCacheMock, grResolver, nil)
+			grbResolver := resolvers.NewGRBClusterRuleResolver(state.grbCacheMock, grResolver)
 			admitters := globalrolebinding.NewValidator(state.resolver, grbResolver).Admitters()
 			require.Len(t, admitters, 1)
 
@@ -567,7 +567,7 @@ func Test_UnexpectedErrors(t *testing.T) {
 	t.Parallel()
 	state := newDefaultState(t)
 	grResolver := auth.NewGlobalRoleResolver(auth.NewRoleTemplateResolver(state.rtCacheMock, nil), state.grCacheMock)
-	grbResolver := resolvers.NewGRBClusterRuleResolver(state.grbCacheMock, grResolver, nil)
+	grbResolver := resolvers.NewGRBClusterRuleResolver(state.grbCacheMock, grResolver)
 	validator := globalrolebinding.NewValidator(state.resolver, grbResolver)
 	admitters := validator.Admitters()
 	require.Len(t, admitters, 1, "wanted only one admitter")

--- a/pkg/resources/management.cattle.io/v3/roletemplate/validator.go
+++ b/pkg/resources/management.cattle.io/v3/roletemplate/validator.go
@@ -28,6 +28,7 @@ const (
 	emptyContext     = ""
 	rtRefIndex       = "management.cattle.io/rt-by-reference"
 	rtGlobalRefIndex = "management.cattle.io/rt-by-ref-grb"
+	escalateVerb     = "escalate"
 )
 
 var gvr = schema.GroupVersionResource{
@@ -136,7 +137,7 @@ func (a *admitter) Admit(request *admission.Request) (*admissionv1.AdmissionResp
 		return admission.ResponseBadRequest(err.Error()), nil
 	}
 
-	allowed, err := auth.EscalationAuthorized(request, gvr, a.sar, "")
+	allowed, err := auth.RequestUserHasVerb(request, gvr, a.sar, escalateVerb, "", "")
 	if err != nil {
 		logrus.Warnf("Failed to check for the 'escalate' verb on RoleTemplates: %v", err)
 	} else if allowed {

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -36,7 +36,7 @@ func Validation(clients *clients.Clients) ([]admission.ValidatingAdmissionHandle
 		prtbResolver := resolvers.NewPRTBRuleResolver(clients.Management.ProjectRoleTemplateBinding().Cache(), clients.RoleTemplateResolver)
 		grbResolver := resolvers.NewGRBClusterRuleResolver(clients.Management.GlobalRoleBinding().Cache(), clients.GlobalRoleResolver)
 		psact := podsecurityadmissionconfigurationtemplate.NewValidator(clients.Management.Cluster().Cache(), clients.Provisioning.Cluster().Cache())
-		globalRoles := globalrole.NewValidator(clients.DefaultResolver, grbResolver)
+		globalRoles := globalrole.NewValidator(clients.DefaultResolver, grbResolver, clients.K8s.AuthorizationV1().SubjectAccessReviews())
 		globalRoleBindings := globalrolebinding.NewValidator(clients.DefaultResolver, grbResolver)
 		prtbs := projectroletemplatebinding.NewValidator(prtbResolver, crtbResolver, clients.DefaultResolver, clients.RoleTemplateResolver, clients.Management.Cluster().Cache(), clients.Management.Project().Cache())
 		crtbs := clusterroletemplatebinding.NewValidator(crtbResolver, clients.DefaultResolver, clients.RoleTemplateResolver, clients.Management.GlobalRoleBinding().Cache(), clients.Management.Cluster().Cache())

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -34,7 +34,7 @@ func Validation(clients *clients.Clients) ([]admission.ValidatingAdmissionHandle
 	if clients.MultiClusterManagement {
 		crtbResolver := resolvers.NewCRTBRuleResolver(clients.Management.ClusterRoleTemplateBinding().Cache(), clients.RoleTemplateResolver)
 		prtbResolver := resolvers.NewPRTBRuleResolver(clients.Management.ProjectRoleTemplateBinding().Cache(), clients.RoleTemplateResolver)
-		grbResolver := resolvers.NewGRBClusterRuleResolver(clients.Management.GlobalRoleBinding().Cache(), clients.GlobalRoleResolver, clients.K8s.AuthorizationV1().SubjectAccessReviews())
+		grbResolver := resolvers.NewGRBClusterRuleResolver(clients.Management.GlobalRoleBinding().Cache(), clients.GlobalRoleResolver)
 		psact := podsecurityadmissionconfigurationtemplate.NewValidator(clients.Management.Cluster().Cache(), clients.Provisioning.Cluster().Cache())
 		globalRoles := globalrole.NewValidator(clients.DefaultResolver, grbResolver)
 		globalRoleBindings := globalrolebinding.NewValidator(clients.DefaultResolver, grbResolver)

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -37,7 +37,7 @@ func Validation(clients *clients.Clients) ([]admission.ValidatingAdmissionHandle
 		grbResolver := resolvers.NewGRBClusterRuleResolver(clients.Management.GlobalRoleBinding().Cache(), clients.GlobalRoleResolver)
 		psact := podsecurityadmissionconfigurationtemplate.NewValidator(clients.Management.Cluster().Cache(), clients.Provisioning.Cluster().Cache())
 		globalRoles := globalrole.NewValidator(clients.DefaultResolver, grbResolver, clients.K8s.AuthorizationV1().SubjectAccessReviews())
-		globalRoleBindings := globalrolebinding.NewValidator(clients.DefaultResolver, grbResolver)
+		globalRoleBindings := globalrolebinding.NewValidator(clients.DefaultResolver, grbResolver, clients.K8s.AuthorizationV1().SubjectAccessReviews())
 		prtbs := projectroletemplatebinding.NewValidator(prtbResolver, crtbResolver, clients.DefaultResolver, clients.RoleTemplateResolver, clients.Management.Cluster().Cache(), clients.Management.Project().Cache())
 		crtbs := clusterroletemplatebinding.NewValidator(crtbResolver, clients.DefaultResolver, clients.RoleTemplateResolver, clients.Management.GlobalRoleBinding().Cache(), clients.Management.Cluster().Cache())
 		roleTemplates := roletemplate.NewValidator(clients.DefaultResolver, clients.RoleTemplateResolver, clients.K8s.AuthorizationV1().SubjectAccessReviews(), clients.Management.GlobalRole().Cache())


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

Aims to resolve several issues with creating/updating GRs/GRBs

## Problem
GlobalRoles and GlobalRoleBindings can only be created/updated by users with equivalent permissions. This created issues for things like service accounts, which were unable to gain permissions in specific fields (such as inherited cluster roles).

## Solution
This PR adds support for two new verbs (both on GlobalRoles):
- escalate
  - Users with this verb can create GlobalRoles that have permissions higher than the permissions they possess
- bind
  - Users with this verb can create GlobalRoleBindings to GlobalRoles that have permissions higher than the permissions that they possess
  - Note that the permissions here must be on the GlobalRole that the binding is made to, not the binding crd

Upstream docs on this field can be found here: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#restrictions-on-role-binding-creation-or-update.

In addition, this PR also reverts:
- fc3f4d171c685754a76c7b0c73905eac7ad37457 (this is no longer necessary since the above will allow service accounts to function properly in this context)
- Parts of the 51930f5f52ac64bde1fe7284b008ace9fdff645c which allow for changes to metadata without the required permissions

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [x] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [ ] Docs