### PR TITLE
Add validation to Toleration and Affinitys Keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .idea
 .vscode
 /webhook
+/vendor

--- a/docs.md
+++ b/docs.md
@@ -276,3 +276,23 @@ If `roletemplates.builtin` is true then all fields are immutable except:
  ### Deletion check
 
 RoleTemplate can not be deleted if they are referenced by other RoleTemplates via `roletemplates.roleTemplateNames` or by GlobalRoles via `globalRoles.inheritedClusterRoles`
+
+# provisioning.cattle.io/v1 
+
+## Cluster 
+
+### Validation Checks
+
+#### cluster.spec.clusterAgentDeploymentCustomization and cluster.spec.fleetAgentDeploymentCustomization
+
+`Key rule`: The keys are being validated to match the kubernetes requirement. 63 Characteres maximum, Regex:
+`([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]` it also accepts a "/"
+
+`appendTolerations`:  is being validated with the  `{Key Rule}`
+
+`affinity.nodeAffinity`:  The nodeSelectorTerms  (`requiredDuringSchedulingIgnoredDuringExecution` and 
+`preferredDuringSchedulingIgnoredDuringExecution.preference`) are being validated with the `{Key Rule}`. 
+
+`affinity.podAffinity and affinity.podAntiAffinity`:  The labelSelectors 
+(`requiredDuringSchedulingIgnoredDuringExecution` and `preferredDuringSchedulingIgnoredDuringExecution.podAffinityTerm``)
+are being validated using the k8s apimachinery rules. The `{Key Rule}` is part of it. 

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/Cluster.md
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/Cluster.md
@@ -1,0 +1,15 @@
+## Validation Checks
+
+### cluster.spec.clusterAgentDeploymentCustomization and cluster.spec.fleetAgentDeploymentCustomization
+
+`Key rule`: The keys are being validated to match the kubernetes requirement. 63 Characteres maximum, Regex:
+`([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]` it also accepts a "/"
+
+`appendTolerations`:  is being validated with the  `{Key Rule}`
+
+`affinity.nodeAffinity`:  The nodeSelectorTerms  (`requiredDuringSchedulingIgnoredDuringExecution` and 
+`preferredDuringSchedulingIgnoredDuringExecution.preference`) are being validated with the `{Key Rule}`. 
+
+`affinity.podAffinity and affinity.podAntiAffinity`:  The labelSelectors 
+(`requiredDuringSchedulingIgnoredDuringExecution` and `preferredDuringSchedulingIgnoredDuringExecution.podAffinityTerm``)
+are being validated using the k8s apimachinery rules. The `{Key Rule}` is part of it. 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> [#41606](https://github.com/rancher/rancher/issues/41606)
<!-- If your PR depends on changes from other PRs, link them here and describe why they are needed for your solution section. -->
## Problem:
<!-- Describe the root cause of the issue you are resolving. 
This may include what behavior is observed and why it is not desirable. If this is a new feature, describe why we need it and how it will be used. -->
We do not validate Tolerations nor Affinity rules, If a user passes a wrong key it just break the cluster with no error. 

## Solution
<!-- Describe what you changed to fix the issue. 
Relate your changes to the original bug/feature and explain why this addresses the issue. -->
For toleration I added validations to the key as I didn't find any upstream validations for the object. 
For Affinity I found an upstream function to validate LabelSelector so I'm using it. 

## Problems /  Points to consider: 
* As the upstream validations work with "arrays" I tried to keep it taking all errors, it make the UI kinda strange if we have a lot of errors (but all of them can be fixed on 1 request). 
![image](https://github.com/rancher/webhook/assets/66074971/bf04df10-696b-4668-afd6-6396d34ddd0f)


* The path pointers are not being checked, it can panic if the parent path is not passed by, this only can happen if someone changes the code, and this is done in the apimachinery too.  If needed I can add validations to create a empty path. 


## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [ X ] Test

  Also  did some manual tests on the fields.

  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [X ] Docs:  I'm not sure if they are good nor I have an idea of how to make them better.