### PR TITLE
Revert "Merge pull request #277"

### DIFF
--- a/pkg/resources/management.cattle.io/v3/nodedriver/validator.go
+++ b/pkg/resources/management.cattle.io/v3/nodedriver/validator.go
@@ -9,12 +9,8 @@ import (
 	"github.com/rancher/webhook/pkg/admission"
 	controllersv3 "github.com/rancher/webhook/pkg/generated/controllers/management.cattle.io/v3"
 	objectsv3 "github.com/rancher/webhook/pkg/generated/objects/management.cattle.io/v3"
-	"github.com/rancher/wrangler/pkg/generic"
-	"github.com/sirupsen/logrus"
 	admissionv1 "k8s.io/api/admission/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
-	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -44,7 +40,6 @@ type Validator struct {
 
 type admitter struct {
 	nodeCache controllersv3.NodeCache
-	crdCache  generic.NonNamespacedCacheInterface[*v1.CustomResourceDefinition]
 	dynamic   dynamicLister
 }
 
@@ -54,10 +49,9 @@ type dynamicLister interface {
 }
 
 // NewValidator returns a new Validator for NodeDriver resources
-func NewValidator(nodeCache controllersv3.NodeCache, dynamic *dynamic.Controller, crdCache generic.NonNamespacedCacheInterface[*v1.CustomResourceDefinition]) admission.ValidatingAdmissionHandler {
+func NewValidator(nodeCache controllersv3.NodeCache, dynamic *dynamic.Controller) admission.ValidatingAdmissionHandler {
 	return &Validator{admitter: admitter{
 		nodeCache: nodeCache,
-		crdCache:  crdCache,
 		dynamic:   dynamic,
 	}}
 }
@@ -129,7 +123,7 @@ func (a *admitter) rke1ResourcesDeleted(driver *v3.NodeDriver) (bool, error) {
 			continue
 		}
 
-		if node.Status.NodeTemplateSpec.Driver == driver.Name {
+		if node.Status.NodeTemplateSpec.Driver == driver.Spec.DisplayName {
 			return false, nil
 		}
 	}
@@ -139,30 +133,16 @@ func (a *admitter) rke1ResourcesDeleted(driver *v3.NodeDriver) (bool, error) {
 
 // // RKE2
 // this one is pretty weird since we have to get the name of the CR we're
-// looking from the Name of the driver.
+// looking from the displayName of the driver.
 func (a *admitter) rke2ResourcesDeleted(driver *v3.NodeDriver) (bool, error) {
 	gvk := schema.GroupVersionKind{
 		Group:   "rke-machine.cattle.io",
 		Version: "v1",
-		Kind:    driver.Name + "machine",
+		Kind:    driver.Spec.DisplayName + "machine",
 	}
-
-	_, err := a.crdCache.Get(fmt.Sprintf("%ss.%s", gvk.Kind, gvk.Group))
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			// in this case the CRD just isn't present for the NodeDriver itself or
-			// hasn't been created yet. If there isn't a CRD -> there can't be any
-			// machines so we authorize the request
-			logrus.Debugf("CRD Not found for %s when disabling NodeDriver, admitting request", gvk)
-			return true, nil
-		}
-
-		return false, fmt.Errorf("error fetching CRD from cache: %w", err)
-	}
-
 	machines, err := a.dynamic.List(gvk, "", labels.Everything())
 	if err != nil {
-		return false, fmt.Errorf("error listing %smachines: %w", driver.Name, err)
+		return false, fmt.Errorf("error listing %smachines: %w", driver.Spec.DisplayName, err)
 	}
 
 	if len(machines) != 0 {

--- a/pkg/resources/management.cattle.io/v3/nodedriver/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/nodedriver/validator_test.go
@@ -3,7 +3,6 @@ package nodedriver
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -12,8 +11,6 @@ import (
 	"github.com/rancher/wrangler/pkg/generic/fake"
 	"github.com/stretchr/testify/suite"
 	admissionv1 "k8s.io/api/admission/v1"
-	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -39,14 +36,11 @@ func (m *mockLister) List(_ schema.GroupVersionKind, _ string, _ labels.Selector
 
 func (suite *NodeDriverValidationSuite) TestHappyPath() {
 	ctrl := gomock.NewController(suite.T())
-	mockNodeCache := fake.NewMockCacheInterface[*v3.Node](ctrl)
-	mockNodeCache.EXPECT().List("", labels.Everything()).Return([]*v3.Node{}, nil)
-	mockCRDCache := fake.NewMockNonNamespacedCacheInterface[*apiextensions.CustomResourceDefinition](ctrl)
-	mockCRDCache.EXPECT().Get("testingmachines.rke-machine.cattle.io").Return(&apiextensions.CustomResourceDefinition{}, nil)
+	mockCache := fake.NewMockCacheInterface[*v3.Node](ctrl)
+	mockCache.EXPECT().List("", labels.Everything()).Return([]*v3.Node{}, nil)
 
 	a := admitter{
-		nodeCache: mockNodeCache,
-		crdCache:  mockCRDCache,
+		nodeCache: mockCache,
 		dynamic:   &mockLister{},
 	}
 
@@ -64,18 +58,15 @@ func (suite *NodeDriverValidationSuite) TestHappyPath() {
 
 func (suite *NodeDriverValidationSuite) TestRKE1NotDeleted() {
 	ctrl := gomock.NewController(suite.T())
-	mockNodeCache := fake.NewMockCacheInterface[*v3.Node](ctrl)
-	mockNodeCache.EXPECT().List("", labels.Everything()).Return([]*v3.Node{
+	mockCache := fake.NewMockCacheInterface[*v3.Node](ctrl)
+	mockCache.EXPECT().List("", labels.Everything()).Return([]*v3.Node{
 		{Status: v3.NodeStatus{NodeTemplateSpec: &v3.NodeTemplateSpec{
 			Driver: "testing",
 		}}},
 	}, nil)
-	mockCRDCache := fake.NewMockNonNamespacedCacheInterface[*apiextensions.CustomResourceDefinition](ctrl)
-	mockCRDCache.EXPECT().Get("testingmachines.rke-machine.cattle.io").Return(&apiextensions.CustomResourceDefinition{}, nil)
 
 	a := admitter{
-		nodeCache: mockNodeCache,
-		crdCache:  mockCRDCache,
+		nodeCache: mockCache,
 		dynamic:   &mockLister{},
 	}
 
@@ -93,14 +84,11 @@ func (suite *NodeDriverValidationSuite) TestRKE1NotDeleted() {
 
 func (suite *NodeDriverValidationSuite) TestRKE2NotDeleted() {
 	ctrl := gomock.NewController(suite.T())
-	mockNodeCache := fake.NewMockCacheInterface[*v3.Node](ctrl)
-	mockNodeCache.EXPECT().List("", labels.Everything()).Return([]*v3.Node{}, nil)
-	mockCRDCache := fake.NewMockNonNamespacedCacheInterface[*apiextensions.CustomResourceDefinition](ctrl)
-	mockCRDCache.EXPECT().Get("testingmachines.rke-machine.cattle.io").Return(&apiextensions.CustomResourceDefinition{}, nil)
+	mockCache := fake.NewMockCacheInterface[*v3.Node](ctrl)
+	mockCache.EXPECT().List("", labels.Everything()).Return([]*v3.Node{}, nil)
 
 	a := admitter{
-		nodeCache: mockNodeCache,
-		crdCache:  mockCRDCache,
+		nodeCache: mockCache,
 		dynamic:   &mockLister{toReturn: []runtime.Object{&runtime.Unknown{}}},
 	}
 
@@ -132,14 +120,11 @@ func (suite *NodeDriverValidationSuite) TestNotDisablingDriver() {
 
 func (suite *NodeDriverValidationSuite) TestDeleteGood() {
 	ctrl := gomock.NewController(suite.T())
-	mockNodeCache := fake.NewMockCacheInterface[*v3.Node](ctrl)
-	mockNodeCache.EXPECT().List("", labels.Everything()).Return([]*v3.Node{}, nil)
-	mockCRDCache := fake.NewMockNonNamespacedCacheInterface[*apiextensions.CustomResourceDefinition](ctrl)
-	mockCRDCache.EXPECT().Get("testingmachines.rke-machine.cattle.io").Return(&apiextensions.CustomResourceDefinition{}, nil)
+	mockCache := fake.NewMockCacheInterface[*v3.Node](ctrl)
+	mockCache.EXPECT().List("", labels.Everything()).Return([]*v3.Node{}, nil)
 
 	a := admitter{
-		nodeCache: mockNodeCache,
-		crdCache:  mockCRDCache,
+		nodeCache: mockCache,
 		dynamic:   &mockLister{},
 	}
 
@@ -162,12 +147,9 @@ func (suite *NodeDriverValidationSuite) TestDeleteRKE1Bad() {
 			Driver: "testing",
 		}}},
 	}, nil)
-	mockCRDCache := fake.NewMockNonNamespacedCacheInterface[*apiextensions.CustomResourceDefinition](ctrl)
-	mockCRDCache.EXPECT().Get("testingmachines.rke-machine.cattle.io").Return(&apiextensions.CustomResourceDefinition{}, nil)
 
 	a := admitter{
 		nodeCache: mockCache,
-		crdCache:  mockCRDCache,
 		dynamic:   &mockLister{},
 	}
 
@@ -186,12 +168,9 @@ func (suite *NodeDriverValidationSuite) TestDeleteRKE2Bad() {
 	ctrl := gomock.NewController(suite.T())
 	mockCache := fake.NewMockCacheInterface[*v3.Node](ctrl)
 	mockCache.EXPECT().List("", labels.Everything()).Return([]*v3.Node{}, nil)
-	mockCRDCache := fake.NewMockNonNamespacedCacheInterface[*apiextensions.CustomResourceDefinition](ctrl)
-	mockCRDCache.EXPECT().Get("testingmachines.rke-machine.cattle.io").Return(&apiextensions.CustomResourceDefinition{}, nil)
 
 	a := admitter{
 		nodeCache: mockCache,
-		crdCache:  mockCRDCache,
 		dynamic:   &mockLister{toReturn: []runtime.Object{&runtime.Unknown{}}},
 	}
 
@@ -206,55 +185,6 @@ func (suite *NodeDriverValidationSuite) TestDeleteRKE2Bad() {
 	suite.False(resp.Allowed, "admission request was allowed")
 }
 
-func (suite *NodeDriverValidationSuite) TestCRDNotCreated() {
-	ctrl := gomock.NewController(suite.T())
-	mockNodeCache := fake.NewMockCacheInterface[*v3.Node](ctrl)
-	mockNodeCache.EXPECT().List("", labels.Everything()).Return([]*v3.Node{}, nil)
-	mockCRDCache := fake.NewMockNonNamespacedCacheInterface[*apiextensions.CustomResourceDefinition](ctrl)
-	mockCRDCache.EXPECT().Get("testingmachines.rke-machine.cattle.io").Return(nil, apierrors.NewNotFound(schema.GroupResource{}, "foobar"))
-
-	a := admitter{
-		nodeCache: mockNodeCache,
-		crdCache:  mockCRDCache,
-		dynamic:   &mockLister{},
-	}
-
-	resp, err := a.Admit(&admission.Request{
-		Context: context.Background(),
-		AdmissionRequest: admissionv1.AdmissionRequest{
-			Operation: admissionv1.Update,
-			OldObject: runtime.RawExtension{Raw: newNodeDriver(true, nil)},
-			Object:    runtime.RawExtension{Raw: newNodeDriver(false, nil)},
-		}})
-
-	suite.Nil(err)
-	suite.True(resp.Allowed, "admission request was denied")
-}
-
-func (suite *NodeDriverValidationSuite) TestErrorFetchingCRD() {
-	ctrl := gomock.NewController(suite.T())
-	mockNodeCache := fake.NewMockCacheInterface[*v3.Node](ctrl)
-	mockNodeCache.EXPECT().List("", labels.Everything()).Return([]*v3.Node{}, nil)
-	mockCRDCache := fake.NewMockNonNamespacedCacheInterface[*apiextensions.CustomResourceDefinition](ctrl)
-	mockCRDCache.EXPECT().Get("testingmachines.rke-machine.cattle.io").Return(nil, errors.New("boom"))
-
-	a := admitter{
-		nodeCache: mockNodeCache,
-		crdCache:  mockCRDCache,
-		dynamic:   &mockLister{},
-	}
-
-	_, err := a.Admit(&admission.Request{
-		Context: context.Background(),
-		AdmissionRequest: admissionv1.AdmissionRequest{
-			Operation: admissionv1.Update,
-			OldObject: runtime.RawExtension{Raw: newNodeDriver(true, nil)},
-			Object:    runtime.RawExtension{Raw: newNodeDriver(false, nil)},
-		}})
-
-	suite.Error(err)
-}
-
 func newNodeDriver(active bool, annotations map[string]string) []byte {
 	if annotations == nil {
 		annotations = map[string]string{}
@@ -263,10 +193,10 @@ func newNodeDriver(active bool, annotations map[string]string) []byte {
 	driver := v3.NodeDriver{
 		ObjectMeta: v1.ObjectMeta{
 			Annotations: annotations,
-			Name:        "testing",
 		},
 		Spec: v3.NodeDriverSpec{
-			Active: active,
+			DisplayName: "testing",
+			Active:      active,
 		},
 	}
 

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -42,7 +42,7 @@ func Validation(clients *clients.Clients) ([]admission.ValidatingAdmissionHandle
 		crtbs := clusterroletemplatebinding.NewValidator(crtbResolver, clients.DefaultResolver, clients.RoleTemplateResolver, clients.Management.GlobalRoleBinding().Cache(), clients.Management.Cluster().Cache())
 		roleTemplates := roletemplate.NewValidator(clients.DefaultResolver, clients.RoleTemplateResolver, clients.K8s.AuthorizationV1().SubjectAccessReviews(), clients.Management.GlobalRole().Cache())
 		secrets := secret.NewValidator(clients.RBAC.Role().Cache(), clients.RBAC.RoleBinding().Cache())
-		nodeDriver := nodedriver.NewValidator(clients.Management.Node().Cache(), clients.Dynamic, clients.CRD.CustomResourceDefinition().Cache())
+		nodeDriver := nodedriver.NewValidator(clients.Management.Node().Cache(), clients.Dynamic)
 		projects := project.NewValidator(clients.Management.Cluster().Cache())
 
 		handlers = append(handlers, psact, globalRoles, globalRoleBindings, prtbs, crtbs, roleTemplates, secrets, nodeDriver, projects)


### PR DESCRIPTION
This reverts commit 3ed3c681186d02d5d414869126ad6a9fdd38698f, reversing changes made to ddb05820d48f7fcc0774e7d2fbfad54d66af7232 as part of https://github.com/rancher/rancher/issues/42378.

## Issue: <!-- link the issue or issues this PR resolves here --> https://github.com/rancher/rancher/issues/43623
<!-- If your PR depends on changes from other PRs, link them here and describe why they are needed for your solution section. -->
## Problem
<!-- Describe the root cause of the issue you are resolving. 
This may include what behavior is observed and why it is not desirable. If this is a new feature, describe why we need it and how it will be used. -->

Custom out-of-tree (not builtin) node drivers are still using the `nd-xxxxx` autogenerated name for creation.

## Solution
<!-- Describe what you changed to fix the issue. 
Relate your changes to the original bug/feature and explain why this addresses the issue. -->

Revert #277 

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [x] Test (Ran unit tests manually)
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [x] Docs (N/A)