### PR TITLE
[DNM 0.4] Add validation to project-scoped secrets

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -24,6 +24,23 @@ The following labels are considered relevant for PSA enforcement:
 - pod-security.kubernetes.io/warn
 - pod-security.kubernetes.io/warn-version
 
+## ProjectScopedSecret 
+
+### Validation Checks
+
+The webhook selects secrets with a special label and validates them on create and update.
+The label is `cattle.io/project-scoped` with a value of `original`.
+
+#### On create
+
+The webhook ensures the secret has an annotation `field.cattle.io/projectId` with a non-empty value. This value should
+be the cluster ID.
+
+#### On update
+
+On update, the webhook ensures that neither the annotation nor the special label `cattle.io/project-scoped` have been
+changed.
+
 ## Secret 
 
 ### Validation Checks

--- a/pkg/admission/admission.go
+++ b/pkg/admission/admission.go
@@ -162,12 +162,21 @@ func defaultWebhookInfo(handler WebhookHandler, clientConfig v1.WebhookClientCon
 	}
 }
 
+type Pather interface {
+	Path() string
+}
+
 // Path returns the path of the webhook joined with the given basePath.
 func Path(basePath string, handler WebhookHandler) string {
-	gvr := handler.GVR()
-	newPath, err := url.JoinPath(basePath, SubPath(gvr))
+	var resource string
+	if pather, ok := handler.(Pather); ok {
+		resource = pather.Path()
+	} else {
+		resource = SubPath(handler.GVR())
+	}
+	newPath, err := url.JoinPath(basePath, resource)
 	if err != nil {
-		return path.Join(basePath, SubPath(gvr))
+		return path.Join(basePath, resource)
 	}
 	return newPath
 }

--- a/pkg/resources/core/v1/secret/ProjectScopedSecret.md
+++ b/pkg/resources/core/v1/secret/ProjectScopedSecret.md
@@ -1,0 +1,14 @@
+## Validation Checks
+
+The webhook selects secrets with a special label and validates them on create and update.
+The label is `cattle.io/project-scoped` with a value of `original`.
+
+### On create
+
+The webhook ensures the secret has an annotation `field.cattle.io/projectId` with a non-empty value. This value should
+be the cluster ID.
+
+### On update
+
+On update, the webhook ensures that neither the annotation nor the special label `cattle.io/project-scoped` have been
+changed.

--- a/pkg/resources/core/v1/secret/project_scoped.go
+++ b/pkg/resources/core/v1/secret/project_scoped.go
@@ -1,0 +1,113 @@
+package secret
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/rancher/webhook/pkg/admission"
+	v1 "github.com/rancher/webhook/pkg/generated/objects/core/v1"
+	admissionv1 "k8s.io/api/admission/v1"
+	admissionregistration "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const (
+	projectScopedLabel  = "cattle.io/project-scoped"
+	projectIDAnnotation = "field.cattle.io/projectId"
+)
+
+func NewProjectScopedValidator() *ProjectScopedValidator {
+	return &ProjectScopedValidator{
+		admitter: projectScopedAdmitter{},
+	}
+}
+
+type ProjectScopedValidator struct {
+	admitter projectScopedAdmitter
+}
+
+func (v *ProjectScopedValidator) GVR() schema.GroupVersionResource {
+	return gvr
+}
+
+func (v *ProjectScopedValidator) Operations() []admissionregistrationv1.OperationType {
+	return []admissionregistrationv1.OperationType{admissionregistrationv1.Create, admissionregistrationv1.Update}
+}
+
+func (v *ProjectScopedValidator) ValidatingWebhook(clientConfig admissionregistrationv1.WebhookClientConfig) []admissionregistrationv1.ValidatingWebhook {
+	webhook := admission.NewDefaultValidatingWebhook(v, clientConfig, admissionregistration.NamespacedScope, v.Operations())
+	webhook.Name = admission.CreateWebhookName(v, "project-scoped")
+	webhook.SideEffects = admission.Ptr(admissionregistrationv1.SideEffectClassNone)
+	webhook.ObjectSelector = &metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      projectScopedLabel,
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{"original"},
+			},
+		},
+	}
+
+	return []admissionregistrationv1.ValidatingWebhook{*webhook}
+}
+
+func (v *ProjectScopedValidator) Admitters() []admission.Admitter {
+	return []admission.Admitter{&v.admitter}
+}
+
+func (v *ProjectScopedValidator) Path() string {
+	return "project-scoped-secrets"
+}
+
+type projectScopedAdmitter struct {
+}
+
+func (a *projectScopedAdmitter) validateUpdate(oldSecret, newSecret *corev1.Secret) error {
+	if newSecret.Annotations[projectIDAnnotation] != oldSecret.Annotations[projectIDAnnotation] {
+		return fmt.Errorf("annotation %s must be immutable", projectIDAnnotation)
+	}
+	if newSecret.Labels[projectScopedLabel] != oldSecret.Labels[projectScopedLabel] {
+		return fmt.Errorf("label %s must be immutable", projectScopedLabel)
+	}
+	return nil
+}
+
+func (a *projectScopedAdmitter) Admit(request *admission.Request) (*admissionv1.AdmissionResponse, error) {
+	if request.Operation == admissionv1.Update {
+		oldSecret, newSecret, err := v1.SecretOldAndNewFromRequest(&request.AdmissionRequest)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read the existing and updated secrets from the request: %w", err)
+		}
+		if err := a.validateUpdate(oldSecret, newSecret); err != nil {
+			return admission.ResponseBadRequest(err.Error()), nil
+		}
+		return admission.ResponseAllowed(), nil
+	}
+	secret, err := v1.SecretFromRequest(&request.AdmissionRequest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read the secret from the request: %w", err)
+	}
+	if err := a.validateCreate(secret); err != nil {
+		return admission.ResponseBadRequest(err.Error()), nil
+	}
+	return admission.ResponseAllowed(), nil
+}
+
+func (a *projectScopedAdmitter) validateCreate(secret *corev1.Secret) error {
+	id := clusterID(secret.Annotations[projectIDAnnotation])
+	if id == "" {
+		return fmt.Errorf("cluster ID is missing in the %s annotation", projectIDAnnotation)
+	}
+	return nil
+}
+
+func clusterID(s string) string {
+	parts := strings.Split(strings.TrimSpace(s), ":")
+	if len(parts) == 0 {
+		return ""
+	}
+	return parts[0]
+}

--- a/pkg/resources/core/v1/secret/project_scoped_test.go
+++ b/pkg/resources/core/v1/secret/project_scoped_test.go
@@ -1,0 +1,182 @@
+package secret
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/rancher/webhook/pkg/admission"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	v1authentication "k8s.io/api/authentication/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestAdmitValidatesProjectScopedSecrets(t *testing.T) {
+	t.Parallel()
+	validSecret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mystery",
+			Namespace: "p-abcde",
+			Labels: map[string]string{
+				projectScopedLabel: "original",
+			},
+			Annotations: map[string]string{
+				projectIDAnnotation: "c-abcde:p-abcde",
+			},
+		},
+	}
+	validSecretUpdate := validSecret.DeepCopy()
+	validSecretUpdate.StringData = map[string]string{"hello": "world"}
+	validator := NewProjectScopedValidator()
+
+	tests := []struct {
+		name      string
+		operation admissionv1.Operation
+		secret    *v1.Secret
+		update    *v1.Secret
+		wantAdmit bool
+	}{
+		{
+			name:      "create a regular project scoped secret",
+			operation: admissionv1.Create,
+			secret:    validSecret,
+			wantAdmit: true,
+		},
+		{
+			name:      "update a regular project scoped secret",
+			operation: admissionv1.Update,
+			secret:    validSecret,
+			update:    validSecretUpdate,
+			wantAdmit: true,
+		},
+		{
+			name:      "fail to create a project scoped secret with no cluster id in annotation",
+			operation: admissionv1.Create,
+			secret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mystery",
+					Namespace: "p-abcde",
+					Labels: map[string]string{
+						projectScopedLabel: "original",
+					},
+					Annotations: map[string]string{
+						projectIDAnnotation: "  ",
+					},
+				},
+			},
+			wantAdmit: false,
+		},
+		{
+			name:      "fail to update the project-scoped label",
+			operation: admissionv1.Update,
+			secret:    validSecret,
+			update: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mystery",
+					Namespace: "p-abcde",
+					Labels:    map[string]string{}, // now missing
+					Annotations: map[string]string{
+						projectIDAnnotation: "c-abcde:p-abcde",
+					},
+				},
+			},
+			wantAdmit: false,
+		},
+		{
+			name:      "fail to update the project-scoped annotation",
+			operation: admissionv1.Update,
+			secret:    validSecret,
+			update: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mystery",
+					Namespace: "p-abcde",
+					Labels: map[string]string{
+						projectScopedLabel: "original",
+					},
+					Annotations: map[string]string{}, // now missing
+				},
+			},
+			wantAdmit: false,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			secretGVR := metav1.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}
+			secretGVK := metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"}
+			req := admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UID:             "2",
+					Kind:            secretGVK,
+					Resource:        secretGVR,
+					RequestKind:     &secretGVK,
+					RequestResource: &secretGVR,
+					Name:            "mystery",
+					Namespace:       test.secret.Namespace,
+					Operation:       test.operation,
+					UserInfo:        v1authentication.UserInfo{Username: "test-user", UID: ""},
+					Object:          runtime.RawExtension{},
+					OldObject:       runtime.RawExtension{},
+				},
+			}
+
+			var err error
+			req.Object.Raw, err = json.Marshal(test.secret)
+			require.NoError(t, err)
+
+			if test.update != nil {
+				req.OldObject.Raw, err = json.Marshal(test.update)
+				require.NoError(t, err)
+			}
+
+			admitters := validator.Admitters()
+			assert.Len(t, admitters, 1)
+			response, err := admitters[0].Admit(&req)
+			require.NoError(t, err)
+			require.Equal(t, test.wantAdmit, response.Allowed)
+		})
+	}
+}
+
+func TestAdmitFailsWhenProjectScopedSecretRequestsAreBad(t *testing.T) {
+	t.Parallel()
+	validator := NewProjectScopedValidator()
+
+	tests := []struct {
+		name      string
+		operation admissionv1.Operation
+		wantError bool
+	}{
+		{
+			name:      "create request",
+			operation: admissionv1.Create,
+			wantError: true,
+		},
+		{
+			name:      "update request",
+			operation: admissionv1.Update,
+			wantError: true,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			// The request contains too little information.
+			request := admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: test.operation,
+				},
+			}
+			admitters := validator.Admitters()
+			assert.Len(t, admitters, 1)
+			response, err := admitters[0].Admit(&request)
+			require.Error(t, err)
+			require.Nil(t, response)
+		})
+	}
+}

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -42,10 +42,11 @@ func Validation(clients *clients.Clients) ([]admission.ValidatingAdmissionHandle
 		crtbs := clusterroletemplatebinding.NewValidator(crtbResolver, clients.DefaultResolver, clients.RoleTemplateResolver, clients.Management.GlobalRoleBinding().Cache(), clients.Management.Cluster().Cache())
 		roleTemplates := roletemplate.NewValidator(clients.DefaultResolver, clients.RoleTemplateResolver, clients.K8s.AuthorizationV1().SubjectAccessReviews(), clients.Management.GlobalRole().Cache())
 		secrets := secret.NewValidator(clients.RBAC.Role().Cache(), clients.RBAC.RoleBinding().Cache())
+		projectScopedSecrets := secret.NewProjectScopedValidator()
 		nodeDriver := nodedriver.NewValidator(clients.Management.Node().Cache(), clients.Dynamic)
 		projects := project.NewValidator(clients.Management.Cluster().Cache())
 
-		handlers = append(handlers, psact, globalRoles, globalRoleBindings, prtbs, crtbs, roleTemplates, secrets, nodeDriver, projects)
+		handlers = append(handlers, psact, globalRoles, globalRoleBindings, prtbs, crtbs, roleTemplates, secrets, projectScopedSecrets, nodeDriver, projects)
 	}
 	return handlers, nil
 }


### PR DESCRIPTION
## Issue

## Problem

The webhook currently has no validation of project-scoped secrets.

## Solution

Add validation to secrets, but not all.
The webhook will select secrets with a special label and inspects them on create and update.
On create, it ensures the secret has an annotation `field.cattle.io/projectId` with a non-empty value. This value should be the clusterID.
On update, it ensures that neither the annotation nor the special label `cattle.io/project-scoped` have been changed.

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [x] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [x] Docs