### PR TITLE
[v0.5] `go generate` to update copyright year

### DIFF
--- a/pkg/generated/controllers/management.cattle.io/factory.go
+++ b/pkg/generated/controllers/management.cattle.io/factory.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Rancher Labs, Inc.
+Copyright 2024 Rancher Labs, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/generated/controllers/management.cattle.io/interface.go
+++ b/pkg/generated/controllers/management.cattle.io/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Rancher Labs, Inc.
+Copyright 2024 Rancher Labs, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/generated/controllers/management.cattle.io/v3/cluster.go
+++ b/pkg/generated/controllers/management.cattle.io/v3/cluster.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Rancher Labs, Inc.
+Copyright 2024 Rancher Labs, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/generated/controllers/management.cattle.io/v3/clusterroletemplatebinding.go
+++ b/pkg/generated/controllers/management.cattle.io/v3/clusterroletemplatebinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Rancher Labs, Inc.
+Copyright 2024 Rancher Labs, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/generated/controllers/management.cattle.io/v3/globalrole.go
+++ b/pkg/generated/controllers/management.cattle.io/v3/globalrole.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Rancher Labs, Inc.
+Copyright 2024 Rancher Labs, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/generated/controllers/management.cattle.io/v3/globalrolebinding.go
+++ b/pkg/generated/controllers/management.cattle.io/v3/globalrolebinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Rancher Labs, Inc.
+Copyright 2024 Rancher Labs, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/generated/controllers/management.cattle.io/v3/interface.go
+++ b/pkg/generated/controllers/management.cattle.io/v3/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Rancher Labs, Inc.
+Copyright 2024 Rancher Labs, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/generated/controllers/management.cattle.io/v3/node.go
+++ b/pkg/generated/controllers/management.cattle.io/v3/node.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Rancher Labs, Inc.
+Copyright 2024 Rancher Labs, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/generated/controllers/management.cattle.io/v3/podsecurityadmissionconfigurationtemplate.go
+++ b/pkg/generated/controllers/management.cattle.io/v3/podsecurityadmissionconfigurationtemplate.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Rancher Labs, Inc.
+Copyright 2024 Rancher Labs, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/generated/controllers/management.cattle.io/v3/project.go
+++ b/pkg/generated/controllers/management.cattle.io/v3/project.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Rancher Labs, Inc.
+Copyright 2024 Rancher Labs, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/generated/controllers/management.cattle.io/v3/projectroletemplatebinding.go
+++ b/pkg/generated/controllers/management.cattle.io/v3/projectroletemplatebinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Rancher Labs, Inc.
+Copyright 2024 Rancher Labs, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/generated/controllers/management.cattle.io/v3/roletemplate.go
+++ b/pkg/generated/controllers/management.cattle.io/v3/roletemplate.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Rancher Labs, Inc.
+Copyright 2024 Rancher Labs, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/generated/controllers/provisioning.cattle.io/factory.go
+++ b/pkg/generated/controllers/provisioning.cattle.io/factory.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Rancher Labs, Inc.
+Copyright 2024 Rancher Labs, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/generated/controllers/provisioning.cattle.io/interface.go
+++ b/pkg/generated/controllers/provisioning.cattle.io/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Rancher Labs, Inc.
+Copyright 2024 Rancher Labs, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/generated/controllers/provisioning.cattle.io/v1/cluster.go
+++ b/pkg/generated/controllers/provisioning.cattle.io/v1/cluster.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Rancher Labs, Inc.
+Copyright 2024 Rancher Labs, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/generated/controllers/provisioning.cattle.io/v1/interface.go
+++ b/pkg/generated/controllers/provisioning.cattle.io/v1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Rancher Labs, Inc.
+Copyright 2024 Rancher Labs, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Was running into this with the other PR - so will need to be merged for the new year.