### PR TITLE
Modify `fleetNameRegex` to better conform to RFC 1123

### DIFF
--- a/pkg/resources/provisioning.cattle.io/v1/cluster/validator.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/validator.go
@@ -29,7 +29,7 @@ import (
 const globalNamespace = "cattle-global-data"
 
 var mgmtNameRegex = regexp.MustCompile("^c-[a-z0-9]{5}$")
-var fleetNameRegex = regexp.MustCompile("^[a-z0-9]+(?:-[a-z0-9]+)*$")
+var fleetNameRegex = regexp.MustCompile("^[^-][-a-z0-9]*$")
 
 // NewProvisioningClusterValidator returns a new validator for provisioning clusters
 func NewProvisioningClusterValidator(client *clients.Clients) *ProvisioningClusterValidator {

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/validator.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/validator.go
@@ -29,7 +29,7 @@ import (
 const globalNamespace = "cattle-global-data"
 
 var mgmtNameRegex = regexp.MustCompile("^c-[a-z0-9]{5}$")
-var fleetNameRegex = regexp.MustCompile("^[^-][-a-z0-9]*$")
+var fleetNameRegex = regexp.MustCompile("^[a-z0-9]+(?:-[a-z0-9]+)*$")
 
 // NewProvisioningClusterValidator returns a new validator for provisioning clusters
 func NewProvisioningClusterValidator(client *clients.Clients) *ProvisioningClusterValidator {

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/validator.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/validator.go
@@ -29,7 +29,7 @@ import (
 const globalNamespace = "cattle-global-data"
 
 var mgmtNameRegex = regexp.MustCompile("^c-[a-z0-9]{5}$")
-var fleetNameRegex = regexp.MustCompile("^[^-][-a-z0-9]+$")
+var fleetNameRegex = regexp.MustCompile("^[^-][-a-z0-9]*$")
 
 // NewProvisioningClusterValidator returns a new validator for provisioning clusters
 func NewProvisioningClusterValidator(client *clients.Clients) *ProvisioningClusterValidator {

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/validator.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/validator.go
@@ -29,7 +29,7 @@ import (
 const globalNamespace = "cattle-global-data"
 
 var mgmtNameRegex = regexp.MustCompile("^c-[a-z0-9]{5}$")
-var fleetNameRegex = regexp.MustCompile("^[^-][-a-z0-9]*$")
+var fleetNameRegex = regexp.MustCompile("^[a-z0-9][-a-z0-9]*$")
 
 // NewProvisioningClusterValidator returns a new validator for provisioning clusters
 func NewProvisioningClusterValidator(client *clients.Clients) *ProvisioningClusterValidator {

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/validator_test.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/validator_test.go
@@ -128,11 +128,18 @@ func Test_isValidName(t *testing.T) {
 			want:             false,
 		},
 		{
-			name: "name length is 1 character",
-			clusterName: "a",
+			name:             "name length is 1 character",
+			clusterName:      "a",
 			clusterNamespace: "fleet-default",
-			clusterExists: false,
-			want: true,
+			clusterExists:    false,
+			want:             true,
+		},
+		{
+			name:             "name length is 0 characters",
+			clusterName:      "",
+			clusterNamespace: "fleet-default",
+			clusterExists:    false,
+			want:             false,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/validator_test.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/validator_test.go
@@ -115,7 +115,14 @@ func Test_isValidName(t *testing.T) {
 		},
 		{
 			name:             "name cannot begin with hyphen",
-			clusterName:      "-CLUSTER-NAME",
+			clusterName:      "-cluster-name",
+			clusterNamespace: "fleet-default",
+			clusterExists:    true,
+			want:             false,
+		},
+		{
+			name:             "name cannot end with hyphen",
+			clusterName:      "cluster-name-",
 			clusterNamespace: "fleet-default",
 			clusterExists:    true,
 			want:             false,

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/validator_test.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/validator_test.go
@@ -127,6 +127,13 @@ func Test_isValidName(t *testing.T) {
 			clusterExists:    false,
 			want:             false,
 		},
+		{
+			name: "name length is 1 character",
+			clusterName: "a",
+			clusterNamespace: "fleet-default",
+			clusterExists: false,
+			want: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/validator_test.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/validator_test.go
@@ -121,13 +121,6 @@ func Test_isValidName(t *testing.T) {
 			want:             false,
 		},
 		{
-			name:             "name cannot end with hyphen",
-			clusterName:      "cluster-name-",
-			clusterNamespace: "fleet-default",
-			clusterExists:    true,
-			want:             false,
-		},
-		{
 			name:             "name cannot only be hyphens",
 			clusterName:      "---------------------------",
 			clusterNamespace: "fleet-default",


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from other PRs, link them here and describe why they are needed for your solution section. -->
rancher/rancher#43535
## Problem
<!-- Describe the root cause of the issue you are resolving. 
This may include what behavior is observed and why it is not desirable. If this is a new feature, describe why we need it and how it will be used. -->
As the issue described, the validator for cluster creation throws an error when a cluster with single character names. From what I can tell I don't think this is intentional, so instead of changing the error message, I opted to fix the validating Regex to accept names with length of 1 character.

In addition, I also changed the  
## Solution
<!-- Describe what you changed to fix the issue. 
Relate your changes to the original bug/feature and explain why this addresses the issue. -->

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [x] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [x] Docs