### PR TITLE
[v0.3] Bump copyright year and remove s390x runner

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -139,82 +139,6 @@ volumes:
 
 ---
 kind: pipeline
-name: s390x
-type: docker
-
-platform:
-  os: linux
-  arch: amd64
-
-node:
-  arch: s390x
-
-steps:
-  - name: build
-    image: rancher/dapper:v0.6.0
-    commands:
-      - dapper ci
-    volumes:
-      - name: docker
-        path: /var/run/docker.sock
-
-  - name: integration-test
-    image: rancher/rancher:v2.7-head
-    privileged: true
-    commands:
-      - zypper -n install helm
-      - scripts/integration-test
-
-  - name: github_binary_release
-    image: rancher/drone-images:github-release-s390x
-    settings:
-      api_key:
-        from_secret: github_token
-      prerelease: true
-      checksum:
-        - sha256
-      checksum_file: CHECKSUMsum-s390x.txt
-      checksum_flatten: true
-      files:
-        - "dist/artifacts/*"
-    when:
-      instance:
-        - drone-publish.rancher.io
-      ref:
-        - refs/head/master
-        - refs/tags/*
-      event:
-        - tag
-
-  - name: docker-publish
-    image: rancher/drone-images:docker-s390x
-    volumes:
-      - name: docker
-        path: /var/run/docker.sock
-    settings:
-      dockerfile: package/Dockerfile
-      password:
-        from_secret: docker_password
-      repo: "rancher/rancher-webhook"
-      tag: "${DRONE_TAG}-s390x"
-      username:
-        from_secret: docker_username
-    when:
-      instance:
-        - drone-publish.rancher.io
-      ref:
-        - refs/head/master
-        - refs/tags/*
-      event:
-        - tag
-
-volumes:
-  - name: docker
-    host:
-      path: /var/run/docker.sock
-
----
-kind: pipeline
 name: manifest
 type: docker
 
@@ -233,7 +157,6 @@ steps:
       platforms:
         - linux/amd64
         - linux/arm64
-        - linux/s390x
       target: "rancher/rancher-webhook:${DRONE_TAG}"
       template: "rancher/rancher-webhook:${DRONE_TAG}-ARCH"
     when:
@@ -248,7 +171,6 @@ steps:
 depends_on:
   - amd64
   - arm64
-  - s390x
 
 ---
 kind: pipeline

--- a/pkg/generated/controllers/management.cattle.io/factory.go
+++ b/pkg/generated/controllers/management.cattle.io/factory.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Rancher Labs, Inc.
+Copyright 2024 Rancher Labs, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/generated/controllers/management.cattle.io/interface.go
+++ b/pkg/generated/controllers/management.cattle.io/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Rancher Labs, Inc.
+Copyright 2024 Rancher Labs, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/generated/controllers/management.cattle.io/v3/cluster.go
+++ b/pkg/generated/controllers/management.cattle.io/v3/cluster.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Rancher Labs, Inc.
+Copyright 2024 Rancher Labs, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/generated/controllers/management.cattle.io/v3/clusterroletemplatebinding.go
+++ b/pkg/generated/controllers/management.cattle.io/v3/clusterroletemplatebinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Rancher Labs, Inc.
+Copyright 2024 Rancher Labs, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/generated/controllers/management.cattle.io/v3/globalrole.go
+++ b/pkg/generated/controllers/management.cattle.io/v3/globalrole.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Rancher Labs, Inc.
+Copyright 2024 Rancher Labs, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/generated/controllers/management.cattle.io/v3/interface.go
+++ b/pkg/generated/controllers/management.cattle.io/v3/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Rancher Labs, Inc.
+Copyright 2024 Rancher Labs, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/generated/controllers/management.cattle.io/v3/node.go
+++ b/pkg/generated/controllers/management.cattle.io/v3/node.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Rancher Labs, Inc.
+Copyright 2024 Rancher Labs, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/generated/controllers/management.cattle.io/v3/podsecurityadmissionconfigurationtemplate.go
+++ b/pkg/generated/controllers/management.cattle.io/v3/podsecurityadmissionconfigurationtemplate.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Rancher Labs, Inc.
+Copyright 2024 Rancher Labs, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/generated/controllers/management.cattle.io/v3/projectroletemplatebinding.go
+++ b/pkg/generated/controllers/management.cattle.io/v3/projectroletemplatebinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Rancher Labs, Inc.
+Copyright 2024 Rancher Labs, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/generated/controllers/management.cattle.io/v3/roletemplate.go
+++ b/pkg/generated/controllers/management.cattle.io/v3/roletemplate.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Rancher Labs, Inc.
+Copyright 2024 Rancher Labs, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/generated/controllers/provisioning.cattle.io/factory.go
+++ b/pkg/generated/controllers/provisioning.cattle.io/factory.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Rancher Labs, Inc.
+Copyright 2024 Rancher Labs, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/generated/controllers/provisioning.cattle.io/interface.go
+++ b/pkg/generated/controllers/provisioning.cattle.io/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Rancher Labs, Inc.
+Copyright 2024 Rancher Labs, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/generated/controllers/provisioning.cattle.io/v1/cluster.go
+++ b/pkg/generated/controllers/provisioning.cattle.io/v1/cluster.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Rancher Labs, Inc.
+Copyright 2024 Rancher Labs, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/generated/controllers/provisioning.cattle.io/v1/interface.go
+++ b/pkg/generated/controllers/provisioning.cattle.io/v1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Rancher Labs, Inc.
+Copyright 2024 Rancher Labs, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
CI fails since we're no longer in 2023, so I just ran `go generate ./...`

Also cherry-pick the commit that removes the s390x runner.