### PR TITLE
Validate container default resource limit on projects

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -192,6 +192,13 @@ The system project cannot be deleted.
 
 Project quotas and default limits must be consistent with one another and must be sufficient for the requirements of active namespaces.
 
+#### Container default resource limit validation
+
+Validation mimics the upstream behavior of the Kubernetes API server when it validates LimitRanges.
+The container default resource configuration must have properly formatted quantities for all requests and limits.
+
+Limits for any resource must not be less than requests.
+
 ### Mutations
 
 #### On create

--- a/pkg/resources/management.cattle.io/v3/project/Project.md
+++ b/pkg/resources/management.cattle.io/v3/project/Project.md
@@ -12,6 +12,13 @@ The system project cannot be deleted.
 
 Project quotas and default limits must be consistent with one another and must be sufficient for the requirements of active namespaces.
 
+### Container default resource limit validation
+
+Validation mimics the upstream behavior of the Kubernetes API server when it validates LimitRanges.
+The container default resource configuration must have properly formatted quantities for all requests and limits.
+
+Limits for any resource must not be less than requests.
+
 ## Mutations
 
 ### On create


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/39700
 
## Problem

The Webhook doesn't validate container resource default limits that are associated with a new or updated Project. This results in controllers responsible for making the corresponding limit ranges in the project's namespaces to fail asynchronously. The K8s API server rejects limit ranges whose requests are greater than limits for any resource.
 
## Solution

Add validation to Webhook on Project create and update.

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [x] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [x] Docs