### PR TITLE
Fix roletemplate.rules validation, added standard k8s checks

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -115,8 +115,12 @@ Note: all checks are bypassed if the GlobalRole is being deleted, or if only the
 #### Invalid Fields - Create and Update
 
 On create or update, the following checks take place:
-- The webhook checks that each rule has at least one verb.
+- The webhook validates each rule using the standard Kubernetes RBAC checks (see next section).
 - Each new RoleTemplate referred to in `inheritedClusterRoles` must have a context of `cluster` and not be `locked`. This validation is skipped for RoleTemplates in `inheritedClusterRoles` for the prior version of this object.
+
+#### Rules Without Verbs, Resources, API groups
+
+Rules without verbs, resources, or apigroups are not permitted. The `rules` included in a GlobalRole are of the same type as the rules used by standard Kubernetes RBAC types (such as `Roles` from `rbac.authorization.k8s.io/v1`). Because of this, they inherit the same restrictions as these types, including this one.
 
 #### Escalation Prevention
 
@@ -253,9 +257,9 @@ Note: all checks are bypassed if the RoleTemplate is being deleted
 
 Circular references to a `RoleTemplate` (a inherits b, b inherits a) are not allowed. More specifically, if "roleTemplate1" is included in the `roleTemplateNames` of "roleTemplate2", then "roleTemplate2" must not be included in the `roleTemplateNames` of "roleTemplate1". This check prevents the creation of roles whose end-state cannot be resolved.
 
-#### Rules Without Verbs 
+#### Rules Without Verbs, Resources, API groups
 
-Rules without verbs are not permitted. The `rules` included in a RoleTemplate are of the same type as the rules used by standard Kubernetes RBAC types (such as `Roles` from `rbac.authorization.k8s.io/v1`). Because of this, they inherit the same restrictions as these types, including this one.
+Rules without verbs, resources, or apigroups are not permitted. The `rules` included in a RoleTemplate are of the same type as the rules used by standard Kubernetes RBAC types (such as `Roles` from `rbac.authorization.k8s.io/v1`). Because of this, they inherit the same restrictions as these types, including this one.
 
 #### Escalation Prevention
 

--- a/pkg/resources/common/validation.go
+++ b/pkg/resources/common/validation.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -9,6 +10,9 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/kubernetes/pkg/apis/rbac"
+	rbacValidation "k8s.io/kubernetes/pkg/apis/rbac/validation"
 )
 
 func CheckCreatorID(request *admission.Request, oldObj, newObj metav1.Object) *metav1.Status {
@@ -44,7 +48,8 @@ func CheckCreatorID(request *admission.Request, oldObj, newObj metav1.Object) *m
 	return nil
 }
 
-// CheckForVerbs checks that all the rules in the given list have a verb set
+// CheckForVerbs checks that all the rules in the given list have a verb set.
+// This is currently used in the validation of globalroles and roletemplates.
 func CheckForVerbs(rules []rbacv1.PolicyRule) error {
 	for i := range rules {
 		rule := rules[i]
@@ -53,4 +58,18 @@ func CheckForVerbs(rules []rbacv1.PolicyRule) error {
 		}
 	}
 	return nil
+}
+
+// ValidateRules calls on standard kubernetes RBAC functionality for the validation of policy rules
+// to validate Rancher rules. This is currently used in the validation of globalroles and roletemplates.
+func ValidateRules(rules []rbacv1.PolicyRule, isNamespaced bool, fldPath *field.Path) error {
+	var returnErr error
+	for index, r := range rules {
+		fieldErrs := rbacValidation.ValidatePolicyRule(rbac.PolicyRule(r), isNamespaced,
+			fldPath.Index(index))
+		if len(fieldErrs) != 0 {
+			returnErr = errors.Join(returnErr, fieldErrs.ToAggregate())
+		}
+	}
+	return returnErr
 }

--- a/pkg/resources/common/validation.go
+++ b/pkg/resources/common/validation.go
@@ -68,9 +68,7 @@ func ValidateRules(rules []rbacv1.PolicyRule, isNamespaced bool, fldPath *field.
 	for index, r := range rules {
 		fieldErrs := rbacValidation.ValidatePolicyRule(rbac.PolicyRule(r), isNamespaced,
 			fldPath.Index(index))
-		if len(fieldErrs) != 0 {
-			returnErr = errors.Join(returnErr, fieldErrs.ToAggregate())
-		}
+		returnErr = errors.Join(returnErr, fieldErrs.ToAggregate())
 	}
 	return returnErr
 }

--- a/pkg/resources/common/validation.go
+++ b/pkg/resources/common/validation.go
@@ -50,6 +50,7 @@ func CheckCreatorID(request *admission.Request, oldObj, newObj metav1.Object) *m
 
 // CheckForVerbs checks that all the rules in the given list have a verb set.
 // This is currently used in the validation of globalroles and roletemplates.
+// BEWARE This function may not be required anymore because both places also use ValidateRules, see below.
 func CheckForVerbs(rules []rbacv1.PolicyRule) error {
 	for i := range rules {
 		rule := rules[i]

--- a/pkg/resources/common/validation.go
+++ b/pkg/resources/common/validation.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 
 	"github.com/rancher/webhook/pkg/admission"
@@ -45,19 +44,6 @@ func CheckCreatorID(request *admission.Request, oldObj, newObj metav1.Object) *m
 		return status
 	}
 
-	return nil
-}
-
-// CheckForVerbs checks that all the rules in the given list have a verb set.
-// This is currently used in the validation of globalroles and roletemplates.
-// BEWARE This function may not be required anymore because both places also use ValidateRules, see below.
-func CheckForVerbs(rules []rbacv1.PolicyRule) error {
-	for i := range rules {
-		rule := rules[i]
-		if len(rule.Verbs) == 0 {
-			return fmt.Errorf("policyRules must have at least one verb: %s", rule.String())
-		}
-	}
 	return nil
 }
 

--- a/pkg/resources/common/validation_test.go
+++ b/pkg/resources/common/validation_test.go
@@ -1,0 +1,89 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	rbacv1 "k8s.io/api/rbac/v1"
+	v1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func TestValidateRules(t *testing.T) {
+	t.Parallel()
+
+	gResource := "something-global"
+	nsResource := "something-namespaced"
+
+	gField := field.NewPath(gResource)
+	nsField := field.NewPath(nsResource)
+
+	// Note: The partial error message is prefixed with the resource name during test execution
+	tests := []struct {
+		name string            // label for testcase
+		data rbacv1.PolicyRule // policy rule to be validated
+		err  string            // partial error returned for a resource,     empty string -> no error
+	}{
+		{
+			name: "ok",
+			data: rbacv1.PolicyRule{
+				Verbs:     []string{"*"},
+				APIGroups: []string{""},
+				Resources: []string{"*"},
+			},
+			err: "",
+		},
+		{
+			name: "no-verbs",
+			data: rbacv1.PolicyRule{
+				Verbs:     []string{},
+				APIGroups: []string{""},
+				Resources: []string{"*"},
+			},
+			err: "[0].verbs: Required value: verbs must contain at least one value",
+		},
+		{
+			name: "no-api-groups",
+			data: rbacv1.PolicyRule{
+				Verbs:     []string{"*"},
+				APIGroups: []string{},
+				Resources: []string{"*"},
+			},
+			err: "[0].apiGroups: Required value: resource rules must supply at least one api group",
+		},
+		{
+			name: "no-resources",
+			data: rbacv1.PolicyRule{
+				Verbs:     []string{"*"},
+				APIGroups: []string{""},
+				Resources: []string{},
+			},
+			err: "[0].resources: Required value: resource rules must supply at least one resource",
+		},
+	}
+
+	for _, testcase := range tests {
+		t.Run("global/"+testcase.name, func(t *testing.T) {
+			err := ValidateRules([]v1.PolicyRule{
+				testcase.data,
+			}, false, gField)
+			if testcase.err == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.Equal(t, err.Error(), gResource+testcase.err)
+		})
+		t.Run("namespaced/"+testcase.name, func(t *testing.T) {
+			err := ValidateRules([]v1.PolicyRule{
+				testcase.data,
+			}, true, nsField)
+			if testcase.err == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.Equal(t, err.Error(), nsResource+testcase.err)
+		})
+	}
+}

--- a/pkg/resources/management.cattle.io/v3/globalrole/GlobalRole.md
+++ b/pkg/resources/management.cattle.io/v3/globalrole/GlobalRole.md
@@ -5,8 +5,12 @@ Note: all checks are bypassed if the GlobalRole is being deleted, or if only the
 ### Invalid Fields - Create and Update
 
 On create or update, the following checks take place:
-- The webhook checks that each rule has at least one verb.
+- The webhook validates each rule using the standard Kubernetes RBAC checks (see next section).
 - Each new RoleTemplate referred to in `inheritedClusterRoles` must have a context of `cluster` and not be `locked`. This validation is skipped for RoleTemplates in `inheritedClusterRoles` for the prior version of this object.
+
+### Rules Without Verbs, Resources, API groups
+
+Rules without verbs, resources, or apigroups are not permitted. The `rules` included in a GlobalRole are of the same type as the rules used by standard Kubernetes RBAC types (such as `Roles` from `rbac.authorization.k8s.io/v1`). Because of this, they inherit the same restrictions as these types, including this one.
 
 ### Escalation Prevention
 

--- a/pkg/resources/management.cattle.io/v3/roletemplate/RoleTemplate.md
+++ b/pkg/resources/management.cattle.io/v3/roletemplate/RoleTemplate.md
@@ -6,9 +6,9 @@ Note: all checks are bypassed if the RoleTemplate is being deleted
 
 Circular references to a `RoleTemplate` (a inherits b, b inherits a) are not allowed. More specifically, if "roleTemplate1" is included in the `roleTemplateNames` of "roleTemplate2", then "roleTemplate2" must not be included in the `roleTemplateNames` of "roleTemplate1". This check prevents the creation of roles whose end-state cannot be resolved.
 
-### Rules Without Verbs 
+### Rules Without Verbs, Resources, API groups
 
-Rules without verbs are not permitted. The `rules` included in a RoleTemplate are of the same type as the rules used by standard Kubernetes RBAC types (such as `Roles` from `rbac.authorization.k8s.io/v1`). Because of this, they inherit the same restrictions as these types, including this one.
+Rules without verbs, resources, or apigroups are not permitted. The `rules` included in a RoleTemplate are of the same type as the rules used by standard Kubernetes RBAC types (such as `Roles` from `rbac.authorization.k8s.io/v1`). Because of this, they inherit the same restrictions as these types, including this one.
 
 ### Escalation Prevention
 

--- a/pkg/resources/management.cattle.io/v3/roletemplate/validator.go
+++ b/pkg/resources/management.cattle.io/v3/roletemplate/validator.go
@@ -137,11 +137,6 @@ func (a *admitter) Admit(request *admission.Request) (*admissionv1.AdmissionResp
 		return admission.ResponseBadRequest(err.Error()), nil
 	}
 
-	// verify inherited rules have verbs
-	if err := common.CheckForVerbs(rules); err != nil {
-		return admission.ResponseBadRequest(err.Error()), nil
-	}
-
 	allowed, err := auth.RequestUserHasVerb(request, gvr, a.sar, escalateVerb, "", "")
 	if err != nil {
 		logrus.Warnf("Failed to check for the 'escalate' verb on RoleTemplates: %v", err)

--- a/pkg/resources/management.cattle.io/v3/roletemplate/validator.go
+++ b/pkg/resources/management.cattle.io/v3/roletemplate/validator.go
@@ -132,6 +132,11 @@ func (a *admitter) Admit(request *admission.Request) (*admissionv1.AdmissionResp
 		return nil, fmt.Errorf("failed to get all rules for '%s': %w", newRT.Name, err)
 	}
 
+	// Verify template rules as per kubernetes rbac rules
+	if err := common.ValidateRules(rules, true, fldPath.Child("rules")); err != nil {
+		return admission.ResponseBadRequest(err.Error()), nil
+	}
+
 	// verify inherited rules have verbs
 	if err := common.CheckForVerbs(rules); err != nil {
 		return admission.ResponseBadRequest(err.Error()), nil

--- a/tests/integration/globalRole_test.go
+++ b/tests/integration/globalRole_test.go
@@ -52,3 +52,69 @@ func (m *IntegrationSuite) TestGlobalRole() {
 	}
 	validateEndpoints(m.T(), endPoints, m.clientFactory)
 }
+
+func (m *IntegrationSuite) TestGlobalRoleNoResources() {
+	newObj := func() *v3.GlobalRole { return &v3.GlobalRole{} }
+	validCreateObj := &v3.GlobalRole{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "test-globalrole-no-resources",
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				Verbs:     []string{"GET", "WATCH"},
+				APIGroups: []string{"v1"},
+				Resources: []string{"pods"},
+			},
+		},
+	}
+	invalidCreate := func() *v3.GlobalRole {
+		invalidCreate := validCreateObj.DeepCopy()
+		if len(invalidCreate.Rules) != 0 {
+			invalidCreate.Rules[0].Resources = nil
+		}
+		return invalidCreate
+	}
+	validDelete := func() *v3.GlobalRole {
+		return validCreateObj
+	}
+	endPoints := &endPointObjs[*v3.GlobalRole]{
+		invalidCreate:  invalidCreate,
+		newObj:         newObj,
+		validCreateObj: validCreateObj,
+		validDelete:    validDelete,
+	}
+	validateEndpoints(m.T(), endPoints, m.clientFactory)
+}
+
+func (m *IntegrationSuite) TestGlobalRoleNoAPIGroups() {
+	newObj := func() *v3.GlobalRole { return &v3.GlobalRole{} }
+	validCreateObj := &v3.GlobalRole{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "test-globalrole-no-apigroups",
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				Verbs:     []string{"GET", "WATCH"},
+				APIGroups: []string{"v1"},
+				Resources: []string{"pods"},
+			},
+		},
+	}
+	invalidCreate := func() *v3.GlobalRole {
+		invalidCreate := validCreateObj.DeepCopy()
+		if len(invalidCreate.Rules) != 0 {
+			invalidCreate.Rules[0].APIGroups = nil
+		}
+		return invalidCreate
+	}
+	validDelete := func() *v3.GlobalRole {
+		return validCreateObj
+	}
+	endPoints := &endPointObjs[*v3.GlobalRole]{
+		invalidCreate:  invalidCreate,
+		newObj:         newObj,
+		validCreateObj: validCreateObj,
+		validDelete:    validDelete,
+	}
+	validateEndpoints(m.T(), endPoints, m.clientFactory)
+}

--- a/tests/integration/roleTemplate_test.go
+++ b/tests/integration/roleTemplate_test.go
@@ -52,3 +52,69 @@ func (m *IntegrationSuite) TestRoleTemplate() {
 	}
 	validateEndpoints(m.T(), endPoints, m.clientFactory)
 }
+
+func (m *IntegrationSuite) TestRoleTemplateNoResources() {
+	newObj := func() *v3.RoleTemplate { return &v3.RoleTemplate{} }
+	validCreateObj := &v3.RoleTemplate{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "test-roletemplate-no-resources",
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				Verbs:     []string{"GET", "WATCH"},
+				APIGroups: []string{"v1"},
+				Resources: []string{"pods"},
+			},
+		},
+	}
+	invalidCreate := func() *v3.RoleTemplate {
+		invalidCreate := validCreateObj.DeepCopy()
+		if len(invalidCreate.Rules) != 0 {
+			invalidCreate.Rules[0].Resources = nil
+		}
+		return invalidCreate
+	}
+	validDelete := func() *v3.RoleTemplate {
+		return validCreateObj
+	}
+	endPoints := &endPointObjs[*v3.RoleTemplate]{
+		invalidCreate:  invalidCreate,
+		newObj:         newObj,
+		validCreateObj: validCreateObj,
+		validDelete:    validDelete,
+	}
+	validateEndpoints(m.T(), endPoints, m.clientFactory)
+}
+
+func (m *IntegrationSuite) TestRoleTemplateNoAPIGroups() {
+	newObj := func() *v3.RoleTemplate { return &v3.RoleTemplate{} }
+	validCreateObj := &v3.RoleTemplate{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "test-roletemplate-no-apigroups",
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				Verbs:     []string{"GET", "WATCH"},
+				APIGroups: []string{"v1"},
+				Resources: []string{"pods"},
+			},
+		},
+	}
+	invalidCreate := func() *v3.RoleTemplate {
+		invalidCreate := validCreateObj.DeepCopy()
+		if len(invalidCreate.Rules) != 0 {
+			invalidCreate.Rules[0].APIGroups = nil
+		}
+		return invalidCreate
+	}
+	validDelete := func() *v3.RoleTemplate {
+		return validCreateObj
+	}
+	endPoints := &endPointObjs[*v3.RoleTemplate]{
+		invalidCreate:  invalidCreate,
+		newObj:         newObj,
+		validCreateObj: validCreateObj,
+		validDelete:    validDelete,
+	}
+	validateEndpoints(m.T(), endPoints, m.clientFactory)
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

See https://github.com/rancher/rancher/issues/40584

## Problem

As described in the referenced issue, the roletemplate rules validation performs only a subset of the checks done by k8s on policy roles (besides the rancher-specific checks). In the referenced issue this is noted for `apiGroups`. The same problem would happen for the `resources`. The `verbs` field is ok, because this is checked explicitly.

## Solution

The chosen solution calls on k8s functionality performing the entire set of rule checks for us.
The basic ability to do so was added with #309.

The core function for doing so, `validateRules`, is moved out of `globalrole` into the `common` package, to keep DRY.
As part of this unit tests were added. The tests pass.

After this refactor the `roletemplate` package is simply extended to call on this functionality.

## CheckList
- [x] Test
- [x] Docs