### PR TITLE
Bump go 1.20

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/golang:1.19
+FROM registry.suse.com/bci/golang:1.20
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/rancher/webhook
 go 1.19
 
 // on release remove this wrangler replace and use the latest tag
-replace github.com/rancher/wrangler v1.1.1 => github.com/rancher/wrangler v1.1.1-0.20230705223603-201b4da5bdaf
+replace github.com/rancher/wrangler v1.1.1 => github.com/rancher/wrangler v1.1.1-0.20230831050635-df1bd5aae9df
 
 replace (
 	k8s.io/api => k8s.io/api v0.27.4
@@ -50,7 +50,7 @@ require (
 	golang.org/x/text v0.11.0
 	golang.org/x/tools v0.9.3
 	k8s.io/api v0.27.4
-	k8s.io/apiextensions-apiserver v0.27.2
+	k8s.io/apiextensions-apiserver v0.27.4
 	k8s.io/apimachinery v0.27.4
 	k8s.io/apiserver v0.27.4
 	k8s.io/client-go v12.0.0+incompatible
@@ -139,7 +139,7 @@ require (
 	k8s.io/gengo v0.0.0-20220902162205-c0856e24416d // indirect
 	k8s.io/klog v1.0.0 // indirect
 	k8s.io/klog/v2 v2.90.1 // indirect
-	k8s.io/kube-aggregator v0.25.5 // indirect
+	k8s.io/kube-aggregator v0.27.4 // indirect
 	k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f // indirect
 	sigs.k8s.io/cli-utils v0.27.0 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/webhook
 
-go 1.19
+go 1.20
 
 // on release remove this wrangler replace and use the latest tag
 replace github.com/rancher/wrangler v1.1.1 => github.com/rancher/wrangler v1.1.1-0.20230831050635-df1bd5aae9df

--- a/go.sum
+++ b/go.sum
@@ -564,8 +564,8 @@ github.com/rancher/rancher/pkg/apis v0.0.0-20230713221208-37ef3050e188 h1:19uz57
 github.com/rancher/rancher/pkg/apis v0.0.0-20230713221208-37ef3050e188/go.mod h1:QZX9Z6lySUnh5TxWyS8Nq7O6nntUWUQnzC57c4y8Kk4=
 github.com/rancher/rke v1.4.8-rc2 h1:bmzGHwIYWdRGHXx+/XIAYUBpp5Qmo63o22cBQ1oamSM=
 github.com/rancher/rke v1.4.8-rc2/go.mod h1:2tq7a87T8d7o6WMDM6q5f6Nu0cL0Y0W3AT07d7Rb4/M=
-github.com/rancher/wrangler v1.1.1-0.20230705223603-201b4da5bdaf h1:XKUtcI795sLmX+joUkvSoX0EbbpAVk1SO6nCPA16xZk=
-github.com/rancher/wrangler v1.1.1-0.20230705223603-201b4da5bdaf/go.mod h1:wcqKmq5FJT34ijBgDMswlx7vOkbkw7LEqaaz6f4XTig=
+github.com/rancher/wrangler v1.1.1-0.20230831050635-df1bd5aae9df h1:WJ+aaUICHPX8HeLmHE9JL/RFHhilMfcJlqmhgpc7gJU=
+github.com/rancher/wrangler v1.1.1-0.20230831050635-df1bd5aae9df/go.mod h1:4T80p+rLh2OLbjCjdExIjRHKNBgK9NUAd7eIU/gRPKk=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/44066

We've decided to bump 1.20 as part of supporting 1.27 in the v2.7 release.

It was done previously in the PR for v2.8: https://github.com/rancher/webhook/pull/287

The changes:
- Bump wrangler to a newer version (same as the one in v2.8)
- Bump go version in the Dapper container image and go.mod