### PR TITLE
Validate RoleTemplate as non-namespaced

### DIFF
--- a/pkg/resources/management.cattle.io/v3/roletemplate/main_test.go
+++ b/pkg/resources/management.cattle.io/v3/roletemplate/main_test.go
@@ -65,6 +65,10 @@ func (c *RoleTemplateSuite) SetupSuite() {
 		APIGroups: []string{"*"},
 		Resources: []string{"*"},
 	}
+	ruleAdminNonResource := rbacv1.PolicyRule{
+		Verbs:           []string{"*"},
+		NonResourceURLs: []string{"*"},
+	}
 	c.ruleEmptyVerbs = rbacv1.PolicyRule{
 		Verbs:     nil,
 		APIGroups: []string{"v1"},
@@ -83,7 +87,7 @@ func (c *RoleTemplateSuite) SetupSuite() {
 			Name: "admin-role",
 		},
 		DisplayName:    "Admin Role",
-		Rules:          []rbacv1.PolicyRule{ruleAdmin},
+		Rules:          []rbacv1.PolicyRule{ruleAdmin, ruleAdminNonResource},
 		Builtin:        true,
 		Administrative: true,
 		Context:        "cluster",
@@ -101,7 +105,7 @@ func (c *RoleTemplateSuite) SetupSuite() {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "admin-role",
 		},
-		Rules: []rbacv1.PolicyRule{ruleAdmin},
+		Rules: []rbacv1.PolicyRule{ruleAdmin, ruleAdminNonResource},
 	}
 	c.manageNodeRole = &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{Name: "manage-nodes"},

--- a/pkg/resources/management.cattle.io/v3/roletemplate/validator.go
+++ b/pkg/resources/management.cattle.io/v3/roletemplate/validator.go
@@ -132,8 +132,10 @@ func (a *admitter) Admit(request *admission.Request) (*admissionv1.AdmissionResp
 		return nil, fmt.Errorf("failed to get all rules for '%s': %w", newRT.Name, err)
 	}
 
-	// Verify template rules as per kubernetes rbac rules
-	if err := common.ValidateRules(rules, true, fldPath.Child("rules")); err != nil {
+	// Verify template rules as per kubernetes rbac rules. Note that we're
+	// validating according to the non-namespaced rules to allow .rules
+	// including nonResourceURLs.
+	if err := common.ValidateRules(rules, false, fldPath.Child("rules")); err != nil {
 		return admission.ResponseBadRequest(err.Error()), nil
 	}
 

--- a/pkg/resources/management.cattle.io/v3/roletemplate/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/roletemplate/validator_test.go
@@ -580,6 +580,28 @@ func (r *RoleTemplateSuite) Test_Create() {
 			},
 			allowed: false,
 		},
+		{
+			// Ensure we're not blocking the creation of RTs with
+			// NonResourceURLs included such as cluster-owner.
+			name: "ensure accept non resource urls",
+			args: args{
+				username: adminUser,
+				oldRT: func() *v3.RoleTemplate {
+					return nil
+				},
+				newRT: func() *v3.RoleTemplate {
+					baseRT := newDefaultRT()
+					baseRT.Rules = []rbacv1.PolicyRule{
+						{
+							Verbs:           []string{"*"},
+							NonResourceURLs: []string{"*"},
+						},
+					}
+					return baseRT
+				},
+			},
+			allowed: true,
+		},
 	}
 
 	for i := range tests {


### PR DESCRIPTION
## Issue

This should fix the integration tests in rancher/rancher issue that was introduced in https://github.com/rancher/webhook/pull/328 (see also https://github.com/rancher/rancher/issues/40584) which results in the following tests to fail:

```
test_default_roles.py::test_cluster_create_role_locked
test_default_roles.py::test_project_create_default_role
test_default_roles.py::test_project_create_role_locked
test_default_roles.py::test_user_create_default_role
```

The error looks like the following:

```
"rancher.cattle.io.roletemplates.management.cattle.io" denied the request: roletemplate.rules[8].nonResourceURLs: Invalid value: []string{"*"}: namespaced rules cannot apply to non-resource URLs\n\t{\'baseType\': \'error\', \'code\': \'BadRequest\', \'message\': \'admission webhook "rancher.cattle.io.roletemplates.management.cattle.io" denied the request: roletemplate.rules[8].nonResourceURLs: Invalid value: []string{"*"}: namespaced rules cannot apply to non-resource URLs\', \'status\': 400, \'type\': \'error\'}')
```

The issue is that namespaced resources cannot have `nonResourceURLs` in them. The `true` here is passed down to the upstream k8s validation function, which sees the nonResourceURLs in the `cluster-owner` RoleTemplate.

The fix simply uses the rules from non-namespaced resources, which skips the check for nonResourceURLs. Note this is not perfectly 1:1 with k8s but it's still more checks than we had previously.

@andreas-kupries As mentioned in Slack, feel free to take this as inspiration for a fix, or review it as is. Leaving as draft for now.
