### PR TITLE
Ensure that Rules in RoleTemplates are encoded

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -291,6 +291,13 @@ If `roletemplates.builtin` is true then all fields are immutable except:
 
 RoleTemplate can not be deleted if they are referenced by other RoleTemplates via `roletemplates.roleTemplateNames` or by GlobalRoles via `globalRoles.inheritedClusterRoles`
 
+### Mutation Checks
+
+#### Ensure Rules are encoded
+
+The fields of `PolicyRule` have the `omitempty` JSON tag, indicating that they will be excluded if they are empty when encoded to JSON.
+Ensure that the `Rules` of the `RoleTemplate` are encoded when there is a difference between the encoded `Rules` and the non-encoded `Rules`.
+
 # rbac.authorization.k8s.io/v1 
 
 ## Role 

--- a/pkg/resources/management.cattle.io/v3/roletemplate/RoleTemplate.md
+++ b/pkg/resources/management.cattle.io/v3/roletemplate/RoleTemplate.md
@@ -32,3 +32,10 @@ If `roletemplates.builtin` is true then all fields are immutable except:
  ### Deletion check
 
 RoleTemplate can not be deleted if they are referenced by other RoleTemplates via `roletemplates.roleTemplateNames` or by GlobalRoles via `globalRoles.inheritedClusterRoles`
+
+## Mutation Checks
+
+### Ensure Rules are encoded
+
+The fields of `PolicyRule` have the `omitempty` JSON tag, indicating that they will be excluded if they are empty when encoded to JSON.
+Ensure that the `Rules` of the `RoleTemplate` are encoded when there is a difference between the encoded `Rules` and the non-encoded `Rules`.

--- a/pkg/resources/management.cattle.io/v3/roletemplate/mutator.go
+++ b/pkg/resources/management.cattle.io/v3/roletemplate/mutator.go
@@ -1,0 +1,82 @@
+package roletemplate
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/webhook/pkg/admission"
+	objectsv3 "github.com/rancher/webhook/pkg/generated/objects/management.cattle.io/v3"
+	"github.com/rancher/webhook/pkg/patch"
+	admissionv1 "k8s.io/api/admission/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/trace"
+)
+
+// Mutator implements admission.MutatingAdmissionWebhook.
+type Mutator struct {
+}
+
+// NewMutator returns a new mutator for RoleTemplates.
+func NewMutator() *Mutator {
+	return &Mutator{}
+}
+
+// GVR returns the GroupVersionKind for this CRD.
+func (m *Mutator) GVR() schema.GroupVersionResource {
+	return gvr
+}
+
+// Operations returns list of operations handled by this mutator.
+func (m *Mutator) Operations() []admissionregistrationv1.OperationType {
+	return []admissionregistrationv1.OperationType{admissionregistrationv1.Create, admissionregistrationv1.Update}
+}
+
+// MutatingWebhook returns the MutatingWebhook used for this CRD.
+func (m *Mutator) MutatingWebhook(clientConfig admissionregistrationv1.WebhookClientConfig) []admissionregistrationv1.MutatingWebhook {
+	mutatingWebhook := admission.NewDefaultMutatingWebhook(m, clientConfig, admissionregistrationv1.ClusterScope, m.Operations())
+
+	return []admissionregistrationv1.MutatingWebhook{*mutatingWebhook}
+}
+
+// Admit handles the webhook admission request sent to this webhook.
+// If this function is called without NewMutator(..) calls will panic.
+func (m *Mutator) Admit(request *admission.Request) (*admissionv1.AdmissionResponse, error) {
+	listTrace := trace.New("RoleTemplate Mutator Admit", trace.Field{Key: "user", Value: request.UserInfo.Username})
+	defer listTrace.LogIfLong(admission.SlowTraceDuration)
+
+	return updateRoleTemplateIfRulesEncodedAreDifferent(request)
+}
+
+// updateRoleTemplateIfRulesEncodedAreDifferent applies a patch to the response to ensure that the RoleTemplate is encoded
+// when the encoded rules differ from the non-encoded rules. This disparity was causing the following issue:
+// A RoleTemplate created with an empty list of rules would lead to the creation of a corresponding ClusterRole with a nil list.
+// When Rancher synchronizes RoleTemplates and ClusterRoles, it detects that an empty list is not equal to a nil list and
+// attempts to update the ClusterRole.
+func updateRoleTemplateIfRulesEncodedAreDifferent(request *admission.Request) (*admissionv1.AdmissionResponse, error) {
+	rt, err := objectsv3.RoleTemplateFromRequest(&request.AdmissionRequest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get %s from request: %w", gvr.Resource, err)
+	}
+	rtEncodedBytes, err := json.Marshal(rt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal roleTemplate: %w", err)
+	}
+	var rtEncoded v3.RoleTemplate
+	err = json.Unmarshal(rtEncodedBytes, &rtEncoded)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal roleTemplate: %w", err)
+	}
+
+	response := &admissionv1.AdmissionResponse{}
+	if !reflect.DeepEqual(rt.Rules, rtEncoded.Rules) {
+		if err := patch.CreatePatch(request.Object.Raw, rtEncoded, response); err != nil {
+			return nil, fmt.Errorf("failed to create patch: %w", err)
+		}
+	}
+	response.Allowed = true
+
+	return response, nil
+}

--- a/pkg/resources/management.cattle.io/v3/roletemplate/mutator_test.go
+++ b/pkg/resources/management.cattle.io/v3/roletemplate/mutator_test.go
@@ -1,0 +1,79 @@
+package roletemplate
+
+import (
+	"testing"
+
+	"github.com/rancher/webhook/pkg/admission"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/stretchr/testify/assert"
+	admissionv1 "k8s.io/api/admission/v1"
+)
+
+func TestAdmit(t *testing.T) {
+	tests := map[string]struct {
+		rtBytes      []byte
+		wantResponse *admissionv1.AdmissionResponse
+	}{
+		"rt with empty resourceNames should be patched": {
+			rtBytes: []byte(`{
+				"description":"",
+				"builtin":false,
+				"external":false,
+				"hidden":false,
+				"metadata": {"creationTimestamp":null},
+				"rules":[
+					{
+						"apiGroups":[""],
+						"resources":["pods"],
+						"verbs":["get"],
+						"resourceNames":[]
+					}
+				]
+			}`),
+			wantResponse: &admissionv1.AdmissionResponse{
+				Allowed: true,
+				PatchType: func() *admissionv1.PatchType {
+					pt := admissionv1.PatchTypeJSONPatch
+					return &pt
+				}(),
+				Patch: []byte(`[{"op":"remove","path":"/rules/0/resourceNames"}]`),
+			},
+		},
+		"rt should not be patched": {
+			rtBytes: []byte(`{
+				"description":"",
+				"builtin":false,
+				"external":false,
+				"hidden":false,
+				"metadata": {"creationTimestamp":null},
+				"rules":[
+					{
+						"apiGroups":[""],
+						"resources":["pods"],
+						"verbs":["get"]
+					}
+				]
+			}`),
+			wantResponse: &admissionv1.AdmissionResponse{
+				Allowed: true,
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			m := NewMutator()
+			req := &admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Object: runtime.RawExtension{
+						Raw: test.rtBytes,
+					},
+				},
+			}
+			response, err := m.Admit(req)
+			assert.NoError(t, err)
+			assert.Equal(t, response, test.wantResponse)
+		})
+	}
+}

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -60,6 +60,7 @@ func Mutation(clients *clients.Clients) ([]admission.MutatingAdmissionHandler, e
 		provisioningCluster.NewProvisioningClusterMutator(clients.Core.Secret(), clients.Management.PodSecurityAdmissionConfigurationTemplate().Cache()),
 		managementCluster.NewManagementClusterMutator(clients.Management.PodSecurityAdmissionConfigurationTemplate().Cache()),
 		fleetworkspace.NewMutator(clients),
+		roletemplate.NewMutator(),
 		&machineconfig.Mutator{},
 	}
 


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/40484
<!-- If your PR depends on changes from other PRs, link them here and describe why they are needed for your solution section. -->
## Problem
If a `RoleTemplate` is created with an empty list in any `Rule`, then rancher creates a corresponding `ClusterRole` with a nil list. When Rancher goes to sync `RoleTemplates` and `ClusterRoles` it will detect that emptyList != nil list and attempt to update the `ClusterRole`.

The fields of `PolicyRule` have the `omitempty` JSON tag, indicating that they will be excluded if they are empty when encoded to JSON. It appears that Kubernetes encodes to JSON before storing `Roles` or `ClusterRoles` in etcd, resulting in the removal of `resourceNames` and `nonResourceURLs` if they are empty. Rancher doesn't do that, and that's why we see the difference.

## Solution
New mutating webhook that applies a patch to ensure that the `RoleTemplate` is encoded when the encoded rules differ from the non-encoded rules.  

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [x] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [x] Docs