### PR TITLE
[v0.3] Change codeowners to new team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @rancher/rancher-team-1-neo-dev
+*       @rancher/rancher-squad-frameworks


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/44840

## Problem
The codeowner file references a group that was recently deleted and is no longer valid

## Solution
Updated the codeowner to the new team name