### PR TITLE
[v0.4] Upgrade golangci-lint and fix warnings and errors associated with the new version

### DIFF
--- a/.golangci.json
+++ b/.golangci.json
@@ -22,9 +22,6 @@
 		],
 		"exclude-dirs": [
 			"pkg/generated"
-		],
-		"exclude-files": [
-			"//zz_generated_"
 		]
 	}
 }

--- a/.golangci.json
+++ b/.golangci.json
@@ -11,12 +11,6 @@
 		]
 	},
 	"run": {
-		"skip-dirs": [
-			"pkg/generated"
-		],
-		"skip-files": [
-			"/zz_generated_"
-		],
 		"deadline": "5m"
 	},
 	"issues": {
@@ -25,6 +19,12 @@
 				"linters": "revive",
 				"text": "should have comment or be unexported"
 			}
+		],
+		"exclude-dirs": [
+			"pkg/generated"
+		],
+		"exclude-files": [
+			"//zz_generated_"
 		]
 	}
 }

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -11,7 +11,7 @@ RUN zypper -n install git docker vim less file curl wget awk
 RUN curl -sL https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz | tar xvzf - -C /usr/local/bin --strip-components=1
 
 RUN if [ "${ARCH}" = "amd64" ]; then \
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.55.2; \
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.57.1; \
         helm plugin install https://github.com/helm-unittest/helm-unittest.git --version ${HELM_UNITTEST_VERSION}>/out.txt 2>&1; \
     fi
 

--- a/pkg/resolvers/aggregateResolver_test.go
+++ b/pkg/resolvers/aggregateResolver_test.go
@@ -57,7 +57,7 @@ func (a *AggregateResolverSuite) TestAggregateRuleResolverGetRules() {
 				expectedRules := []rbacv1.PolicyRule{a.ruleAdmin}
 				resolver := NewMockAuthorizationRuleResolver(gomock.NewController(t))
 				resolver.EXPECT().VisitRulesFor(testUser, testNameSpace, gomock.Any()).
-					DoAndReturn(func(userInfo user.Info, namespace string, visitor func(source fmt.Stringer, rule *rbacv1.PolicyRule, err error) bool) bool {
+					DoAndReturn(func(_ user.Info, _ string, visitor func(source fmt.Stringer, rule *rbacv1.PolicyRule, err error) bool) bool {
 						for _, rule := range expectedRules {
 							visitor(nil, &rule, nil)
 						}
@@ -76,13 +76,13 @@ func (a *AggregateResolverSuite) TestAggregateRuleResolverGetRules() {
 				expectedRules := []rbacv1.PolicyRule{}
 				resolver := NewMockAuthorizationRuleResolver(gomock.NewController(t))
 				resolver.EXPECT().VisitRulesFor(gomock.Any(), testNameSpace, gomock.Any()).
-					DoAndReturn(func(userInfo user.Info, namespace string, visitor func(source fmt.Stringer, rule *rbacv1.PolicyRule, err error) bool) bool {
+					DoAndReturn(func(_ user.Info, _ string, visitor func(source fmt.Stringer, rule *rbacv1.PolicyRule, err error) bool) bool {
 						visitor(nil, nil, errNotFound)
 						return true
 					})
 				resolver2 := NewMockAuthorizationRuleResolver(gomock.NewController(t))
 				resolver2.EXPECT().VisitRulesFor(gomock.Any(), testNameSpace, gomock.Any()).
-					DoAndReturn(func(userInfo user.Info, namespace string, visitor func(source fmt.Stringer, rule *rbacv1.PolicyRule, err error) bool) bool {
+					DoAndReturn(func(_ user.Info, _ string, visitor func(source fmt.Stringer, rule *rbacv1.PolicyRule, err error) bool) bool {
 						visitor(nil, nil, errNotFound)
 						return true
 					})
@@ -97,13 +97,13 @@ func (a *AggregateResolverSuite) TestAggregateRuleResolverGetRules() {
 				expectedRules := []rbacv1.PolicyRule{a.ruleReadPods}
 				resolver := NewMockAuthorizationRuleResolver(gomock.NewController(t))
 				resolver.EXPECT().VisitRulesFor(testUser, testNameSpace, gomock.Any()).
-					DoAndReturn(func(userInfo user.Info, namespace string, visitor func(source fmt.Stringer, rule *rbacv1.PolicyRule, err error) bool) bool {
+					DoAndReturn(func(_ user.Info, _ string, _ func(source fmt.Stringer, rule *rbacv1.PolicyRule, err error) bool) bool {
 						return true
 					})
 				resolver.EXPECT().GetRoleReferenceRules(gomock.Any(), gomock.Any()).Return(expectedRules, nil)
 				resolver2 := NewMockAuthorizationRuleResolver(gomock.NewController(t))
 				resolver2.EXPECT().VisitRulesFor(testUser, testNameSpace, gomock.Any()).
-					DoAndReturn(func(userInfo user.Info, namespace string, visitor func(source fmt.Stringer, rule *rbacv1.PolicyRule, err error) bool) bool {
+					DoAndReturn(func(_ user.Info, _ string, visitor func(source fmt.Stringer, rule *rbacv1.PolicyRule, err error) bool) bool {
 						for _, rule := range expectedRules {
 							visitor(nil, &rule, nil)
 						}
@@ -122,7 +122,7 @@ func (a *AggregateResolverSuite) TestAggregateRuleResolverGetRules() {
 				expectedRules2 := []rbacv1.PolicyRule{a.ruleReadPods}
 				resolver := NewMockAuthorizationRuleResolver(gomock.NewController(t))
 				resolver.EXPECT().VisitRulesFor(testUser, testNameSpace, gomock.Any()).
-					DoAndReturn(func(userInfo user.Info, namespace string, visitor func(source fmt.Stringer, rule *rbacv1.PolicyRule, err error) bool) bool {
+					DoAndReturn(func(_ user.Info, _ string, visitor func(source fmt.Stringer, rule *rbacv1.PolicyRule, err error) bool) bool {
 						for _, rule := range expectedRules1 {
 							visitor(nil, &rule, nil)
 						}
@@ -131,7 +131,7 @@ func (a *AggregateResolverSuite) TestAggregateRuleResolverGetRules() {
 				resolver.EXPECT().GetRoleReferenceRules(gomock.Any(), gomock.Any()).Return(expectedRules1, nil)
 				resolver2 := NewMockAuthorizationRuleResolver(gomock.NewController(t))
 				resolver2.EXPECT().VisitRulesFor(testUser, testNameSpace, gomock.Any()).
-					DoAndReturn(func(userInfo user.Info, namespace string, visitor func(source fmt.Stringer, rule *rbacv1.PolicyRule, err error) bool) bool {
+					DoAndReturn(func(_ user.Info, _ string, visitor func(source fmt.Stringer, rule *rbacv1.PolicyRule, err error) bool) bool {
 						for _, rule := range expectedRules2 {
 							visitor(nil, &rule, nil)
 						}

--- a/pkg/resolvers/crtbResolver_test.go
+++ b/pkg/resolvers/crtbResolver_test.go
@@ -294,7 +294,7 @@ func NewCRTBCache(ctrl *gomock.Controller, bindings []*apisv3.ClusterRoleTemplat
 		return nil, errNotFound
 	}).AnyTimes()
 	clusterCache.EXPECT().AddIndexer(crtbSubjectIndex, gomock.Any()).AnyTimes()
-	clusterCache.EXPECT().GetByIndex(crtbSubjectIndex, gomock.Any()).DoAndReturn(func(index string, subject string) ([]*apisv3.ClusterRoleTemplateBinding, error) {
+	clusterCache.EXPECT().GetByIndex(crtbSubjectIndex, gomock.Any()).DoAndReturn(func(_ string, subject string) ([]*apisv3.ClusterRoleTemplateBinding, error) {
 		retList := []*apisv3.ClusterRoleTemplateBinding{}
 		// for each binding create a lists of subject keys from the binding
 		// if the provided subject matches any of those keys at the binding to the returned list

--- a/pkg/resolvers/prtbResolver_test.go
+++ b/pkg/resolvers/prtbResolver_test.go
@@ -290,7 +290,7 @@ func NewPRTBCache(ctrl *gomock.Controller, bindings []*apisv3.ProjectRoleTemplat
 
 	projectCache.EXPECT().AddIndexer(prtbSubjectIndex, gomock.Any()).AnyTimes()
 
-	projectCache.EXPECT().GetByIndex(prtbSubjectIndex, gomock.Any()).DoAndReturn(func(index string, subject string) ([]*apisv3.ProjectRoleTemplateBinding, error) {
+	projectCache.EXPECT().GetByIndex(prtbSubjectIndex, gomock.Any()).DoAndReturn(func(_ string, subject string) ([]*apisv3.ProjectRoleTemplateBinding, error) {
 		retList := []*apisv3.ProjectRoleTemplateBinding{}
 
 		// for each binding create a lists of subject keys from the binding

--- a/tests/integration/rkeMachineConfig_test.go
+++ b/tests/integration/rkeMachineConfig_test.go
@@ -17,7 +17,7 @@ func (m *IntegrationSuite) TestRKEMachineConfig() {
 	validCreateObj.SetName("test-rke.machine")
 	validCreateObj.SetNamespace(testNamespace)
 	validCreateObj.SetGroupVersionKind(objGVK)
-	invalidUpdate := func(created *unstructured.Unstructured) *unstructured.Unstructured {
+	invalidUpdate := func(_ *unstructured.Unstructured) *unstructured.Unstructured {
 		invalidUpdateObj := validCreateObj.DeepCopy()
 		invalidUpdateObj.SetAnnotations(map[string]string{auth.CreatorIDAnn: "foobar"})
 		return invalidUpdateObj


### PR DESCRIPTION
## Issue: https://github.com/rancher/webhook/pull/331

## Problem
Renovate bot is attempting to update `golangci-lint`, but in the newer version there are checks that fail. Specifically, it no longer allows variables in functions that go unused, instead requiring they be removed or set to `_`. Additionally, `run.skip-files` and `run.skip-dirs` are deprecated for `golangci-lint`.

## Solution
Ran `golangci-lint` manually and fixed up all the errors. Used `issues.exclude-dirs` and `issues.exclude-files`, which are the newer, supported method of ignoring files/dirs.