### PR TITLE
Dynamic schema rfc

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -359,11 +359,10 @@ When a UserAttribute is updated, the following checks take place:
 
 ##### Dynamic Schema Drop
 
-For all `cluster.provisioning.cattle.io/v1` objects, check for the presence of the 
-`provisioning.cattle.io/allow-dynamic-schema-drop` annotation. If the value is `"true"`, perform no mutations. If the 
-value is not present or not `"true"`, compare the value of the `dynamicSchemaSpec` field for each `machinePool`, to 
-its' previous value. If the values are not identical, revert the value for the `dynamicSchemaSpec` for the specific 
-`machinePool`, but do not reject the request.
+Check for the presence of the `provisioning.cattle.io/allow-dynamic-schema-drop` annotation. If the value is `"true"`, 
+perform no mutations. If the value is not present or not `"true"`, compare the value of the `dynamicSchemaSpec` field 
+for each `machinePool`, to its' previous value. If the values are not identical, revert the value for the 
+`dynamicSchemaSpec` for the specific `machinePool`, but do not reject the request.
 
 # rbac.authorization.k8s.io/v1 
 

--- a/docs.md
+++ b/docs.md
@@ -349,6 +349,22 @@ When a UserAttribute is updated, the following checks take place:
 - If set, `disableAfter` must be zero or a positive duration (e.g. `240h`).
 - If set, `deleteAfter` must be zero or a positive duration (e.g. `240h`).
 
+# provisioning.cattle.io/v1 
+
+## Cluster 
+
+### Mutation Checks
+
+#### On Update
+
+##### Dynamic Schema Drop
+
+For all `cluster.provisioning.cattle.io/v1` objects, check for the presence of the 
+`provisioning.cattle.io/allow-dynamic-schema-drop` annotation. If the value is `"true"`, perform no mutations. If the 
+value is not present or not `"true"`, compare the value of the `dynamicSchemaSpec` field for each `machinePool`, to 
+its' previous value. If the values are not identical, revert the value for the `dynamicSchemaSpec` for the specific 
+`machinePool`, but do not reject the request.
+
 # rbac.authorization.k8s.io/v1 
 
 ## ClusterRole 

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,8 @@ replace (
 	k8s.io/controller-manager => k8s.io/controller-manager v0.30.1
 	k8s.io/cri-api => k8s.io/cri-api v0.30.1
 	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.30.1
+	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.30.1
+	k8s.io/endpointslice => k8s.io/endpointslice v0.30.1
 	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.30.1
 	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.30.1
 	k8s.io/kube-proxy => k8s.io/kube-proxy v0.30.1

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/Cluster.md
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/Cluster.md
@@ -4,8 +4,7 @@
 
 #### Dynamic Schema Drop
 
-For all `cluster.provisioning.cattle.io/v1` objects, check for the presence of the 
-`provisioning.cattle.io/allow-dynamic-schema-drop` annotation. If the value is `"true"`, perform no mutations. If the 
-value is not present or not `"true"`, compare the value of the `dynamicSchemaSpec` field for each `machinePool`, to 
-its' previous value. If the values are not identical, revert the value for the `dynamicSchemaSpec` for the specific 
-`machinePool`, but do not reject the request.
+Check for the presence of the `provisioning.cattle.io/allow-dynamic-schema-drop` annotation. If the value is `"true"`, 
+perform no mutations. If the value is not present or not `"true"`, compare the value of the `dynamicSchemaSpec` field 
+for each `machinePool`, to its' previous value. If the values are not identical, revert the value for the 
+`dynamicSchemaSpec` for the specific `machinePool`, but do not reject the request.

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/Cluster.md
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/Cluster.md
@@ -1,0 +1,11 @@
+## Mutation Checks
+
+### On Update
+
+#### Dynamic Schema Drop
+
+For all `cluster.provisioning.cattle.io/v1` objects, check for the presence of the 
+`provisioning.cattle.io/allow-dynamic-schema-drop` annotation. If the value is `"true"`, perform no mutations. If the 
+value is not present or not `"true"`, compare the value of the `dynamicSchemaSpec` field for each `machinePool`, to 
+its' previous value. If the values are not identical, revert the value for the `dynamicSchemaSpec` for the specific 
+`machinePool`, but do not reject the request.

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/mutator_test.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/mutator_test.go
@@ -631,13 +631,11 @@ func TestDynamicSchemaDrop(t *testing.T) {
 		cluster    *v1.Cluster
 		oldCluster *v1.Cluster
 		expected   []v1.RKEMachinePool
-		expectErr  bool
 	}{
 		{
-			name:      "not v2prov cluster",
-			request:   &admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{Operation: admissionv1.Update}},
-			cluster:   &v1.Cluster{},
-			expectErr: false,
+			name:    "not v2prov cluster",
+			request: &admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{Operation: admissionv1.Update}},
+			cluster: &v1.Cluster{},
 		},
 		{
 			name:    "no schema present on old or new cluster",
@@ -669,7 +667,6 @@ func TestDynamicSchemaDrop(t *testing.T) {
 					Name: "a",
 				},
 			},
-			expectErr: false,
 		},
 		{
 			name:    "matching schema present on old and new cluster",
@@ -704,7 +701,6 @@ func TestDynamicSchemaDrop(t *testing.T) {
 					DynamicSchemaSpec: "a",
 				},
 			},
-			expectErr: false,
 		},
 		{
 			name:    "schema present on old cluster but not new cluster without annotation",
@@ -738,7 +734,6 @@ func TestDynamicSchemaDrop(t *testing.T) {
 					DynamicSchemaSpec: "a",
 				},
 			},
-			expectErr: false,
 		},
 		{
 			name:    "schema present on old cluster but not new cluster with false annotation",
@@ -773,7 +768,6 @@ func TestDynamicSchemaDrop(t *testing.T) {
 					DynamicSchemaSpec: "a",
 				},
 			},
-			expectErr: false,
 		},
 		{
 			name:    "schema present on old cluster and new cluster with true annotation",
@@ -809,7 +803,6 @@ func TestDynamicSchemaDrop(t *testing.T) {
 					DynamicSchemaSpec: "a",
 				},
 			},
-			expectErr: false,
 		},
 		{
 			name:    "schema present on old cluster but not new cluster with true annotation",
@@ -843,7 +836,6 @@ func TestDynamicSchemaDrop(t *testing.T) {
 					Name: "a",
 				},
 			},
-			expectErr: false,
 		},
 		{
 			name:    "new machine pool without schema",
@@ -885,7 +877,6 @@ func TestDynamicSchemaDrop(t *testing.T) {
 					Name: "b",
 				},
 			},
-			expectErr: false,
 		},
 	}
 
@@ -894,9 +885,8 @@ func TestDynamicSchemaDrop(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			resp, err := m.handleDynamicSchemaDrop(tt.request, tt.oldCluster, tt.cluster)
-			assert.Equal(t, tt.expectErr, err != nil)
-			assert.Equal(t, !tt.expectErr, resp.Allowed)
+			resp := m.handleDynamicSchemaDrop(tt.request, tt.oldCluster, tt.cluster)
+			assert.True(t, resp.Allowed)
 			if tt.expected != nil {
 				assert.True(t, reflect.DeepEqual(tt.expected, tt.cluster.Spec.RKEConfig.MachinePools))
 			}

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/mutator_test.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/mutator_test.go
@@ -841,7 +841,6 @@ func TestDynamicSchemaDrop(t *testing.T) {
 			name:    "new machine pool without schema",
 			request: &admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{Operation: admissionv1.Update}},
 			cluster: &v1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{"provisioning.cattle.io/allow-dynamic-schema-drop": "true"}},
 				Spec: v1.ClusterSpec{
 					RKEConfig: &v1.RKEConfig{
 						MachinePools: []v1.RKEMachinePool{


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> https://github.com/rancher/rancher/issues/44618
<!-- If your PR depends on changes from other PRs, link them here and describe why they are needed for your solution section. -->
## Problem
<!-- Describe the root cause of the issue you are resolving. 
This may include what behavior is observed and why it is not desirable. If this is a new feature, describe why we need it and how it will be used. -->

An issue was identified (https://github.com/rancher/rancher/issues/40609), where updating the node driver and changing the flags would result in CAPI detecting the supplied fields do not match the existing fields on the machine infrastructure custom resource. The fix for this issue was to persist the dynamicSchema onto the cluster object under the machinePools section, and stripping fields not present at the time of initial provisioning from the related CR, as the alternative of properly versioning CRDs for each node driver was not and continues to not be a viable solution. While this change initially fixed the issue of unintended cluster reprovisioning on node driver update, other cluster update solutions such as terraform and kubectl are still susceptible to this issue as an update unintentionally removing the dynamicSchemaSpec fields will still result in reprovisioning if new fields (whether used or not) are added to a node driver. Since the dynamicSchemaSpec is added by a controller within Rancher, a cluster create request followed by updating the node driver and a subsequent update request (identical to the cluster create request) will cause reprovisioning, due to the dynamicSchemaSpec being unpopulated within the request.

## Solution
<!-- Describe what you changed to fix the issue. 
Relate your changes to the original bug/feature and explain why this addresses the issue. -->

Add an annotation which the webhook will use to determine whether the removal of the dynamicSchemaSpec is intentional. If not present or ”false”, the dynamicSchemaSpec will be reinserted into the cluster object as-is, preventing an unintentional cluster-wide machine rollout. If true, the fields will stay removed from the request, and allow provisioning with the previous behavior, allowing users to opt-in for a potential rollout if the node driver was indeed changed.

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [x] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [ ] Docs

There isn't currently an existing markdown file for provisioning clusters. I'm happy to create one in a follow up PR if necessary.