### PR TITLE
[v0.4] [GHA] Move fossa checking to GHA for v0.4

### DIFF
--- a/.github/workflows/fossa.yaml
+++ b/.github/workflows/fossa.yaml
@@ -5,7 +5,7 @@ name: FOSSA Scanning
 on:
   # List the branches that must be scanned when a push event happens.
   push:
-    branches: ["master", "release/v*"]
+    branches: ["main", "release/v*"]
   pull_request:
   # For manual scans.
   workflow_dispatch:
@@ -18,8 +18,9 @@ permissions:
 
 jobs:
   fossa-scanning:
-    # We're running inside a public repo, so use the public provided GH runners.
-    runs-on: ubuntu-latest
+    runs-on: org-${{ github.repository_owner_id }}-amd64-k8s
+    # We need an explicit container with the runner
+    container: registry.suse.com/bci/bci-base:15.6
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/fossa.yaml
+++ b/.github/workflows/fossa.yaml
@@ -1,0 +1,41 @@
+# Adapted from https://github.com/rancher/security-team/blob/main/docs/guides/fossa-gha-workflow.md
+
+name: FOSSA Scanning
+
+on:
+  # List the branches that must be scanned when a push event happens.
+  push:
+    branches: ["master", "release/v*"]
+  pull_request:
+  # For manual scans.
+  workflow_dispatch:
+
+permissions:
+  # Basic read access needed.
+  contents: read
+  # Required to authenticate in EIO's Vault.
+  id-token: write
+
+jobs:
+  fossa-scanning:
+    # We're running inside a public repo, so use the public provided GH runners.
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Read FOSSA token
+      uses: rancher-eio/read-vault-secrets@main
+      with:
+        secrets: |
+          secret/data/github/org/rancher/fossa/push token | FOSSA_API_KEY_PUSH_ONLY
+
+    - name: FOSSA scan
+      uses: fossas/fossa-action@main
+      with:
+        api-key: ${{ env.FOSSA_API_KEY_PUSH_ONLY }}
+        # Only runs the scan and do not provide/returns any results back to the
+        # pipeline.
+        run-tests: false
+
+


### PR DESCRIPTION
The Fossa migration PR has to be from this repro.

Related to https://github.com/rancher/rancher/issues/45231
Backport the v0.5 PR