### PR TITLE
Remove PSP validation

### DIFF
--- a/pkg/resources/management.cattle.io/v3/cluster/validator.go
+++ b/pkg/resources/management.cattle.io/v3/cluster/validator.go
@@ -280,9 +280,6 @@ func (a *admitter) validatePSP(request *admission.Request) (*admissionv1.Admissi
 	if parsedRangeLessThan125(parsedVersion) {
 		return admission.ResponseAllowed(), nil
 	}
-	if cluster.Spec.DefaultPodSecurityPolicyTemplateName != "" || cluster.Spec.RancherKubernetesEngineConfig.Services.KubeAPI.PodSecurityPolicy {
-		return admission.ResponseBadRequest("cannot enable PodSecurityPolicy(PSP) or use PSP Template in cluster which k8s version is 1.25 and above"), nil
-	}
 
 	return admission.ResponseAllowed(), nil
 }


### PR DESCRIPTION
Remove PSP validation. PSP fields were removed from the `Cluster` resource in Rancher v2.9 in this [PR](https://github.com/rancher/rancher/pull/45380), this causes the webhook to fail if the Rancher version is bumped. 

The minimum k8s version that rancher v2.9 will support is 1.25 where PSP is removed from the upstream.
