### PR TITLE
Remove external-rules feature flag

### DIFF
--- a/pkg/auth/globalrole_test.go
+++ b/pkg/auth/globalrole_test.go
@@ -153,7 +153,7 @@ func TestGlobalRulesFromRole(t *testing.T) {
 			if test.stateSetup != nil {
 				test.stateSetup(state)
 			}
-			grResolver := auth.NewGlobalRoleResolver(auth.NewRoleTemplateResolver(state.rtCacheMock, nil, nil), nil)
+			grResolver := auth.NewGlobalRoleResolver(auth.NewRoleTemplateResolver(state.rtCacheMock, nil), nil)
 			rules := grResolver.GlobalRulesFromRole(test.globalRole)
 
 			require.Len(t, rules, len(test.wantRules))
@@ -264,7 +264,7 @@ func TestClusterRulesFromRole(t *testing.T) {
 			if test.stateSetup != nil {
 				test.stateSetup(state)
 			}
-			grResolver := auth.NewGlobalRoleResolver(auth.NewRoleTemplateResolver(state.rtCacheMock, nil, nil), nil)
+			grResolver := auth.NewGlobalRoleResolver(auth.NewRoleTemplateResolver(state.rtCacheMock, nil), nil)
 			rules, err := grResolver.ClusterRulesFromRole(test.globalRole)
 			if test.wantErr {
 				require.Error(t, err)
@@ -337,7 +337,7 @@ func TestGetRoleTemplatesForGlobalRole(t *testing.T) {
 			if test.stateSetup != nil {
 				test.stateSetup(state)
 			}
-			grResolver := auth.NewGlobalRoleResolver(auth.NewRoleTemplateResolver(state.rtCacheMock, nil, nil), nil)
+			grResolver := auth.NewGlobalRoleResolver(auth.NewRoleTemplateResolver(state.rtCacheMock, nil), nil)
 			roleTemplates, err := grResolver.GetRoleTemplatesForGlobalRole(test.globalRole)
 			if test.wantErr {
 				require.Error(t, err)

--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -66,7 +66,7 @@ func New(ctx context.Context, rest *rest.Config, mcmEnabled bool) (*Clients, err
 	}
 
 	if mcmEnabled {
-		result.RoleTemplateResolver = auth.NewRoleTemplateResolver(mgmt.Management().V3().RoleTemplate().Cache(), clients.RBAC.ClusterRole().Cache(), mgmt.Management().V3().Feature().Cache())
+		result.RoleTemplateResolver = auth.NewRoleTemplateResolver(mgmt.Management().V3().RoleTemplate().Cache(), clients.RBAC.ClusterRole().Cache())
 		result.GlobalRoleResolver = auth.NewGlobalRoleResolver(result.RoleTemplateResolver, mgmt.Management().V3().GlobalRole().Cache())
 	}
 

--- a/pkg/resolvers/crtbResolver_test.go
+++ b/pkg/resolvers/crtbResolver_test.go
@@ -278,7 +278,7 @@ func (c *CRTBResolverSuite) NewTestCRTBResolver() *CRTBRuleResolver {
 	roleTemplateCache.EXPECT().Get(c.readRT.Name).Return(c.readRT, nil).AnyTimes()
 	roleTemplateCache.EXPECT().Get(c.writeRT.Name).Return(c.writeRT, nil).AnyTimes()
 	roleTemplateCache.EXPECT().Get(invalidName).Return(nil, errNotFound).AnyTimes()
-	roleResolver := auth.NewRoleTemplateResolver(roleTemplateCache, clusterRoleCache, nil)
+	roleResolver := auth.NewRoleTemplateResolver(roleTemplateCache, clusterRoleCache)
 	return NewCRTBRuleResolver(crtbCache, roleResolver)
 }
 

--- a/pkg/resolvers/grbRuleResolvers_test.go
+++ b/pkg/resolvers/grbRuleResolvers_test.go
@@ -324,7 +324,7 @@ func (g *GRBClusterRuleResolverSuite) TestGRBClusterRuleResolver() {
 				test.setup(state)
 			}
 
-			grResolver := auth.NewGlobalRoleResolver(auth.NewRoleTemplateResolver(state.rtCache, nil, nil), state.grCache)
+			grResolver := auth.NewGlobalRoleResolver(auth.NewRoleTemplateResolver(state.rtCache, nil), state.grCache)
 			grbResolvers := NewGRBRuleResolvers(state.grbCache, grResolver)
 
 			rules, err := grbResolvers.ICRResolver.RulesFor(g.userInfo, test.namespace)

--- a/pkg/resolvers/prtbResolver_test.go
+++ b/pkg/resolvers/prtbResolver_test.go
@@ -281,7 +281,7 @@ func (p *PRTBResolverSuite) NewTestPRTBResolver() *PRTBRuleResolver {
 	roleTemplateCache.EXPECT().Get(p.readRT.Name).Return(p.readRT, nil).AnyTimes()
 	roleTemplateCache.EXPECT().Get(p.writeRT.Name).Return(p.writeRT, nil).AnyTimes()
 	roleTemplateCache.EXPECT().Get(invalidName).Return(nil, errNotFound).AnyTimes()
-	roleResolver := auth.NewRoleTemplateResolver(roleTemplateCache, clusterRoleCache, nil)
+	roleResolver := auth.NewRoleTemplateResolver(roleTemplateCache, clusterRoleCache)
 	return NewPRTBRuleResolver(PRTBCache, roleResolver)
 }
 

--- a/pkg/resources/management.cattle.io/v3/feature/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/feature/validator_test.go
@@ -4,16 +4,12 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/golang/mock/gomock"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/webhook/pkg/admission"
-	"github.com/rancher/webhook/pkg/auth"
-	"github.com/rancher/webhook/pkg/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	admissionv1 "k8s.io/api/admission/v1"
 	authenicationv1 "k8s.io/api/authentication/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -24,11 +20,6 @@ var (
 )
 
 func TestFeatureValueValid(t *testing.T) {
-	type testState struct {
-		authorizationRuleResolverMock *mocks.MockAuthorizationRuleResolver
-	}
-	ctrl := gomock.NewController(t)
-
 	t.Parallel()
 	tests := []struct {
 		name       string
@@ -36,7 +27,6 @@ func TestFeatureValueValid(t *testing.T) {
 		oldFeature v3.Feature
 		wantError  bool
 		wantAdmit  bool
-		stateSetup func(state testState)
 	}{
 		{
 			name: "new feature locked with spec value changed",
@@ -105,319 +95,13 @@ func TestFeatureValueValid(t *testing.T) {
 			},
 			wantAdmit: true,
 		},
-		{
-			name: "external rules feature can be changed by admins",
-			oldFeature: v3.Feature{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: auth.ExternalRulesFeature,
-				},
-				Spec: v3.FeatureSpec{
-					Value: admission.Ptr(true),
-				},
-			},
-			newFeature: v3.Feature{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: auth.ExternalRulesFeature,
-				},
-				Spec: v3.FeatureSpec{
-					Value: admission.Ptr(false),
-				},
-			},
-			stateSetup: func(state testState) {
-				adminRules := []rbacv1.PolicyRule{
-					{
-						Verbs:     []string{"*"},
-						APIGroups: []string{"*"},
-						Resources: []string{"*"},
-					},
-				}
-				state.authorizationRuleResolverMock.EXPECT().RulesFor(gomock.Any(), gomock.Any()).Return(adminRules, nil)
-			},
-			wantAdmit: true,
-		},
-		{
-			name: "external rules feature can't be enabled by users with update permissions",
-			oldFeature: v3.Feature{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: auth.ExternalRulesFeature,
-				},
-				Spec: v3.FeatureSpec{
-					Value: admission.Ptr(false),
-				},
-			},
-			newFeature: v3.Feature{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: auth.ExternalRulesFeature,
-				},
-				Spec: v3.FeatureSpec{
-					Value: admission.Ptr(true),
-				},
-			},
-			stateSetup: func(state testState) {
-				adminRules := []rbacv1.PolicyRule{
-					{
-						Verbs:     []string{"update"},
-						APIGroups: []string{"management.cattle.io"},
-						Resources: []string{"features"},
-					},
-				}
-				state.authorizationRuleResolverMock.EXPECT().RulesFor(gomock.Any(), gomock.Any()).Return(adminRules, nil)
-			},
-			wantAdmit: false,
-		},
-		{
-			name: "external rules feature can't be disabled by users with update permissions",
-			oldFeature: v3.Feature{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: auth.ExternalRulesFeature,
-				},
-				Spec: v3.FeatureSpec{
-					Value: admission.Ptr(true),
-				},
-			},
-			newFeature: v3.Feature{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: auth.ExternalRulesFeature,
-				},
-				Spec: v3.FeatureSpec{
-					Value: admission.Ptr(false),
-				},
-			},
-			stateSetup: func(state testState) {
-				adminRules := []rbacv1.PolicyRule{
-					{
-						Verbs:     []string{"update"},
-						APIGroups: []string{"management.cattle.io"},
-						Resources: []string{"features"},
-					},
-				}
-				state.authorizationRuleResolverMock.EXPECT().RulesFor(gomock.Any(), gomock.Any()).Return(adminRules, nil)
-			},
-			wantAdmit: false,
-		},
-		{
-			name: "external rules feature can't be set to nil by users with update permissions",
-			oldFeature: v3.Feature{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: auth.ExternalRulesFeature,
-				},
-				Spec: v3.FeatureSpec{
-					Value: admission.Ptr(true),
-				},
-			},
-			newFeature: v3.Feature{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: auth.ExternalRulesFeature,
-				},
-				Spec: v3.FeatureSpec{
-					Value: nil,
-				},
-			},
-			stateSetup: func(state testState) {
-				adminRules := []rbacv1.PolicyRule{
-					{
-						Verbs:     []string{"update"},
-						APIGroups: []string{"management.cattle.io"},
-						Resources: []string{"features"},
-					},
-				}
-				state.authorizationRuleResolverMock.EXPECT().RulesFor(gomock.Any(), gomock.Any()).Return(adminRules, nil)
-			},
-			wantAdmit: false,
-		},
-		{
-			name: "external rules feature can be enabled for users with security-enable (RA)",
-			oldFeature: v3.Feature{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: auth.ExternalRulesFeature,
-				},
-				Spec: v3.FeatureSpec{
-					Value: admission.Ptr(false),
-				},
-			},
-			newFeature: v3.Feature{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: auth.ExternalRulesFeature,
-				},
-				Spec: v3.FeatureSpec{
-					Value: admission.Ptr(true),
-				},
-			},
-			stateSetup: func(state testState) {
-				state.authorizationRuleResolverMock.EXPECT().RulesFor(gomock.Any(), gomock.Any()).Return([]rbacv1.PolicyRule{
-					{
-						Verbs:         []string{"security-enable"},
-						APIGroups:     []string{"management.cattle.io"},
-						Resources:     []string{"features"},
-						ResourceNames: []string{"external-rules"},
-					},
-				}, nil)
-			},
-			wantAdmit: true,
-		},
-		{
-			name: "external rules feature can't be disabled for users with security-enable (RA)",
-			oldFeature: v3.Feature{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: auth.ExternalRulesFeature,
-				},
-				Spec: v3.FeatureSpec{
-					Value: admission.Ptr(true),
-				},
-			},
-			newFeature: v3.Feature{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: auth.ExternalRulesFeature,
-				},
-				Spec: v3.FeatureSpec{
-					Value: admission.Ptr(false),
-				},
-			},
-			stateSetup: func(state testState) {
-				state.authorizationRuleResolverMock.EXPECT().RulesFor(gomock.Any(), gomock.Any()).Return([]rbacv1.PolicyRule{
-					{
-						Verbs:         []string{"security-enable", "update"},
-						APIGroups:     []string{"management.cattle.io"},
-						Resources:     []string{"features"},
-						ResourceNames: []string{"external-rules"},
-					},
-				}, nil)
-			},
-			wantAdmit: false,
-		},
-		{
-			name: "external rules feature can be enabled with default value for users with security-enable (RA)",
-			oldFeature: v3.Feature{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: auth.ExternalRulesFeature,
-				},
-				Spec: v3.FeatureSpec{
-					Value: nil,
-				},
-				Status: v3.FeatureStatus{
-					Default: false,
-				},
-			},
-			newFeature: v3.Feature{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: auth.ExternalRulesFeature,
-				},
-				Spec: v3.FeatureSpec{
-					Value: admission.Ptr(true),
-				},
-			},
-			stateSetup: func(state testState) {
-				state.authorizationRuleResolverMock.EXPECT().RulesFor(gomock.Any(), gomock.Any()).Return([]rbacv1.PolicyRule{
-					{
-						Verbs:         []string{"security-enable"},
-						APIGroups:     []string{"management.cattle.io"},
-						Resources:     []string{"features"},
-						ResourceNames: []string{"external-rules"},
-					},
-				}, nil)
-			},
-			wantAdmit: true,
-		},
-		{
-			name: "external rules feature can't be disabled for users with security-enable (RA)",
-			oldFeature: v3.Feature{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: auth.ExternalRulesFeature,
-				},
-				Spec: v3.FeatureSpec{
-					Value: nil,
-				},
-				Status: v3.FeatureStatus{
-					Default: true,
-				},
-			},
-			newFeature: v3.Feature{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: auth.ExternalRulesFeature,
-				},
-				Spec: v3.FeatureSpec{
-					Value: admission.Ptr(false),
-				},
-			},
-			stateSetup: func(state testState) {
-				state.authorizationRuleResolverMock.EXPECT().RulesFor(gomock.Any(), gomock.Any()).Return([]rbacv1.PolicyRule{
-					{
-						Verbs:         []string{"security-enable", "update"},
-						APIGroups:     []string{"management.cattle.io"},
-						Resources:     []string{"features"},
-						ResourceNames: []string{"external-rules"},
-					},
-				}, nil)
-			},
-			wantAdmit: false,
-		},
-		{
-			name: "external rules feature can't be set to nil for users with security-enable (RA)",
-			oldFeature: v3.Feature{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: auth.ExternalRulesFeature,
-				},
-				Spec: v3.FeatureSpec{
-					Value: admission.Ptr(true),
-				},
-			},
-			newFeature: v3.Feature{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: auth.ExternalRulesFeature,
-				},
-				Spec: v3.FeatureSpec{
-					Value: nil,
-				},
-			},
-			stateSetup: func(state testState) {
-				state.authorizationRuleResolverMock.EXPECT().RulesFor(gomock.Any(), gomock.Any()).Return([]rbacv1.PolicyRule{
-					{
-						Verbs:         []string{"security-enable", "update"},
-						APIGroups:     []string{"management.cattle.io"},
-						Resources:     []string{"features"},
-						ResourceNames: []string{"external-rules"},
-					},
-				}, nil)
-			},
-			wantAdmit: false,
-		},
-		{
-			name: "external rules feature can be modified if the value doesn't change",
-			oldFeature: v3.Feature{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: auth.ExternalRulesFeature,
-				},
-				Spec: v3.FeatureSpec{
-					Value: admission.Ptr(true),
-				},
-			},
-			newFeature: v3.Feature{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: auth.ExternalRulesFeature,
-					Annotations: map[string]string{
-						"test-annotation": "test-value",
-					},
-				},
-				Spec: v3.FeatureSpec{
-					Value: admission.Ptr(true),
-				},
-			},
-			wantAdmit: true,
-		},
 	}
 
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			authorizationRuleResolverMock := mocks.NewMockAuthorizationRuleResolver(ctrl)
-			state := testState{
-				authorizationRuleResolverMock: authorizationRuleResolverMock,
-			}
-			if test.stateSetup != nil {
-				test.stateSetup(state)
-			}
-			admitters := NewValidator(state.authorizationRuleResolverMock).Admitters()
+			admitters := NewValidator().Admitters()
 			assert.Len(t, admitters, 1)
 
 			req := admission.Request{
@@ -453,7 +137,7 @@ func TestFeatureValueValid(t *testing.T) {
 
 func TestRejectsBadRequest(t *testing.T) {
 	t.Parallel()
-	admitters := NewValidator(nil).Admitters()
+	admitters := NewValidator().Admitters()
 	assert.Len(t, admitters, 1)
 
 	req := admission.Request{

--- a/pkg/resources/management.cattle.io/v3/globalrole/setup_test.go
+++ b/pkg/resources/management.cattle.io/v3/globalrole/setup_test.go
@@ -336,7 +336,7 @@ func newDefaultState(t *testing.T) testState {
 }
 
 func (m *testState) createBaseGRResolver() *auth.GlobalRoleResolver {
-	return auth.NewGlobalRoleResolver(auth.NewRoleTemplateResolver(m.rtCacheMock, nil, nil), m.grCacheMock)
+	return auth.NewGlobalRoleResolver(auth.NewRoleTemplateResolver(m.rtCacheMock, nil), m.grCacheMock)
 }
 
 func (m *testState) createBaseGRBResolvers(grResolver *auth.GlobalRoleResolver) *resolvers.GRBRuleResolvers {

--- a/pkg/resources/management.cattle.io/v3/globalrolebinding/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/globalrolebinding/validator_test.go
@@ -813,7 +813,7 @@ func TestAdmit(t *testing.T) {
 			if test.args.stateSetup != nil {
 				test.args.stateSetup(state)
 			}
-			grResolver := auth.NewGlobalRoleResolver(auth.NewRoleTemplateResolver(state.rtCacheMock, nil, nil), state.grCacheMock)
+			grResolver := auth.NewGlobalRoleResolver(auth.NewRoleTemplateResolver(state.rtCacheMock, nil), state.grCacheMock)
 			gbrResolvers := resolvers.NewGRBRuleResolvers(state.grbCacheMock, grResolver)
 			admitters := globalrolebinding.NewValidator(state.resolver, gbrResolvers, state.sarMock, grResolver).Admitters()
 			require.Len(t, admitters, 1)
@@ -834,7 +834,7 @@ func TestAdmit(t *testing.T) {
 func Test_UnexpectedErrors(t *testing.T) {
 	t.Parallel()
 	state := newDefaultState(t)
-	grResolver := auth.NewGlobalRoleResolver(auth.NewRoleTemplateResolver(state.rtCacheMock, nil, nil), state.grCacheMock)
+	grResolver := auth.NewGlobalRoleResolver(auth.NewRoleTemplateResolver(state.rtCacheMock, nil), state.grCacheMock)
 	gbrResolvers := resolvers.NewGRBRuleResolvers(state.grbCacheMock, grResolver)
 	validator := globalrolebinding.NewValidator(state.resolver, gbrResolvers, state.sarMock, grResolver)
 	admitters := validator.Admitters()

--- a/pkg/resources/management.cattle.io/v3/roletemplate/main_test.go
+++ b/pkg/resources/management.cattle.io/v3/roletemplate/main_test.go
@@ -23,7 +23,6 @@ import (
 var errTest = errors.New("bad error")
 
 type testState struct {
-	featureCacheMock     *fake.MockNonNamespacedCacheInterface[*v3.Feature]
 	clusterRoleCacheMock *fake.MockNonNamespacedCacheInterface[*rbacv1.ClusterRole]
 }
 

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -31,7 +31,7 @@ import (
 // Validation returns a list of all ValidatingAdmissionHandlers used by the webhook.
 func Validation(clients *clients.Clients) ([]admission.ValidatingAdmissionHandler, error) {
 	handlers := []admission.ValidatingAdmissionHandler{
-		feature.NewValidator(clients.DefaultResolver),
+		feature.NewValidator(),
 		managementCluster.NewValidator(clients.K8s.AuthorizationV1().SubjectAccessReviews(), clients.Management.PodSecurityAdmissionConfigurationTemplate().Cache()),
 		provisioningCluster.NewProvisioningClusterValidator(clients),
 		machineconfig.NewValidator(),


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/45863
 
## Problem
`external-rules` feature flag was added in Rancher v2.7 and v2.8 to help admins with the transition of the new `RoleTemplate` field `ExternalRules`. That's no longer needed in Rancher v2.9
 
## Solution
Remove `external-rules` feature flag. It will work as it is always enabled, and can't be disabled. 
