### PR TITLE
Add back rancher/webhook-specific labels

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -150,6 +150,12 @@ jobs:
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ env.DOCKER_PASSWORD }}
 
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REPO }}/rancher-webhook
+
       - name: Build and push the webhook image
         id: build
         # https://github.com/docker/build-push-action/commit/ca052bb54ab0790a636c9b5f226502c73d547a25
@@ -157,6 +163,7 @@ jobs:
         with:
           context: .
           file: ./package/Dockerfile
+          labels: ${{ steps.meta.outputs.labels }}
           platforms: "linux/${{ matrix.arch }}"
           outputs: type=image,name=${{ env.REPO }}/rancher-webhook,push-by-digest=true,name-canonical=true,push=true
 


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/45231

## Problem

Some labels are missing or wrong in the new webhook images built by GHA (docker buildx).

Some labels were previously added by drone via layers. An example can be seen here: [rancher/rancher-webhook:v0.5.0-rc10](https://hub.docker.com/layers/rancher/rancher-webhook/v0.5.0-rc10/images/sha256-869a2ba3bc73ae73f6468cb656d671dcbcb9ef4ec71a0c856c4a9860bc272094?context=explore). With this change, the labels still won't show up as layers, but you will be able to see them using `docker image inspect <image>`.

A comparison of images:
- rancher-webhook before GHA had the following labels:

```
$ docker image inspect docker.io/rancher/rancher-webhook:v0.5.0-rc10
                ...
                "org.opencontainers.image.created": "2024-06-28T14:50:11Z",
                "org.opencontainers.image.description": "A micro environment for containers based on the SLE Base Container Image.",
                "org.opencontainers.image.revision": "97679b88dd800c1cbad320721d721e4250fa7a91",
                "org.opencontainers.image.source": "https://github.com/rancher/webhook.git",
                "org.opencontainers.image.title": "SLE BCI 15 SP5 Micro",
                "org.opencontainers.image.url": "https://github.com/rancher/webhook",
                "org.opencontainers.image.vendor": "SUSE LLC",
                "org.opencontainers.image.version": "15.5.27.1",
                ...
```

- rancher-webhook after GHA but without this change:

```
$ docker image inspect docker.io/rancher/rancher-webhook:v0.5.0-rc11
                ...
                "org.opencontainers.image.created": "2024-06-27T14:10:02.404401630Z",
                "org.opencontainers.image.description": "A micro environment for containers based on the SLE Base Container Image.",
                "org.opencontainers.image.source": "https://sources.suse.com/SUSE:SLE-15-SP5:Update:CR/micro-image/e4aac607525a7db6d7cf18a0c10dfd29/",
                "org.opencontainers.image.title": "SLE BCI 15 SP5 Micro",
                "org.opencontainers.image.url": "https://www.suse.com/products/base-container-images/",
                "org.opencontainers.image.vendor": "SUSE LLC",
                "org.opencontainers.image.version": "15.5.27.1",
                ...
```

- rancher-webhook after GHA and with this change:

```
$ docker image inspect docker.io/tomleb/rancher-webhook:v0.0.2
                ...
                "org.opencontainers.image.created": "2024-07-04T14:16:24.357Z",
                "org.opencontainers.image.description": "Rancher webhook for Kubernetes",
                "org.opencontainers.image.licenses": "Apache-2.0",
                "org.opencontainers.image.revision": "4ed4310a68724fa404987f34c73a525fc05b2035",
                "org.opencontainers.image.source": "https://github.com/tomleb/rancher-webhook",
                "org.opencontainers.image.title": "rancher-webhook",
                "org.opencontainers.image.url": "https://github.com/tomleb/rancher-webhook",
                "org.opencontainers.image.vendor": "SUSE LLC",
                "org.opencontainers.image.version": "v0.0.2",
                ...
```

We can observe the following:
- A lot of labels previously referred to the labels of the BCI image (description, title, version)
- The license label wasn't there
- metadata action doesn't add a `.git` suffix to the source label, drone did

It seems pretty straightforward to pick and choose which label we want to override from the base BCI image, we just gotta decide on which.