### PR TITLE
Don't fail fast CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,7 @@ jobs:
   build:
     name: CI
     strategy:
+      fail-fast: false
       matrix:
         archBox:
         - { arch: amd64, vmArch: x64 }


### PR DESCRIPTION
# Issue: https://github.com/rancher/rancher/issues/45231

Technically not required for https://github.com/rancher/rancher/issues/45231 but related.

With flaky tests or Docker rate limit, it's very annoying to have a job's failure cancel another job. Instead, let all jobs run to completion, this way we can restart only the failed one.