### PR TITLE
[v0.5] Set FailurePolicy to Ignore for settings validator

### DIFF
--- a/pkg/resources/management.cattle.io/v3/setting/validator.go
+++ b/pkg/resources/management.cattle.io/v3/setting/validator.go
@@ -57,9 +57,9 @@ func (v *Validator) Operations() []admissionregistrationv1.OperationType {
 
 // ValidatingWebhook returns the ValidatingWebhook.
 func (v *Validator) ValidatingWebhook(clientConfig admissionregistrationv1.WebhookClientConfig) []admissionregistrationv1.ValidatingWebhook {
-	return []admissionregistrationv1.ValidatingWebhook{
-		*admission.NewDefaultValidatingWebhook(v, clientConfig, admissionregistrationv1.ClusterScope, v.Operations()),
-	}
+	valWebhook := admission.NewDefaultValidatingWebhook(v, clientConfig, admissionregistrationv1.ClusterScope, v.Operations())
+	valWebhook.FailurePolicy = admission.Ptr(admissionregistrationv1.Ignore)
+	return []admissionregistrationv1.ValidatingWebhook{*valWebhook}
 }
 
 // Admitters returns the admitter objects.

--- a/pkg/resources/management.cattle.io/v3/setting/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/setting/validator_test.go
@@ -165,7 +165,7 @@ func (s *SettingSuite) validate(op v1.Operation) {
 	}
 }
 
-func (s *SettingSuite) TestValidatingWebhooFailurePolicy() {
+func (s *SettingSuite) TestValidatingWebhookFailurePolicy() {
 	t := s.T()
 	validator := setting.NewValidator(nil)
 

--- a/pkg/resources/management.cattle.io/v3/setting/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/setting/validator_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/rancher/webhook/pkg/admission"
 	"github.com/rancher/webhook/pkg/resources/management.cattle.io/v3/setting"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 )
 
 type SettingSuite struct {
@@ -162,6 +163,16 @@ func (s *SettingSuite) validate(op v1.Operation) {
 			}
 		})
 	}
+}
+
+func (s *SettingSuite) TestValidatingWebhooFailurePolicy() {
+	t := s.T()
+	validator := setting.NewValidator(nil)
+
+	webhook := validator.ValidatingWebhook(admissionregistrationv1.WebhookClientConfig{})
+	require.Len(t, webhook, 1)
+	ignorePolicy := admissionregistrationv1.Ignore
+	require.Equal(t, &ignorePolicy, webhook[0].FailurePolicy)
 }
 
 func (s *SettingSuite) setup() admission.Admitter {

--- a/tests/integration/failPolicy_test.go
+++ b/tests/integration/failPolicy_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/rancher/lasso/pkg/client"
 	v3 "github.com/rancher/rancher/pkg/apis/cluster.cattle.io/v3"
+	mgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	provisioningv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	"github.com/rancher/wrangler/v3/pkg/gvk"
 	"github.com/rancher/wrangler/v3/pkg/kubeconfig"
@@ -43,21 +44,11 @@ func (m *FailurePolicySuite) SetupSuite() {
 	schemes.Register(provisioningv1.AddToScheme)
 	schemes.Register(corev1.AddToScheme)
 }
+func (m *FailurePolicySuite) SetupTest() {
+	m.checkWebhookIsDown()
+}
 
-func (m *FailurePolicySuite) TestNamespaceFail() {
-	const testNamespace = "test-namespace"
-	validCreateObj := &corev1.Namespace{
-		ObjectMeta: v1.ObjectMeta{
-			Name: testNamespace,
-		},
-	}
-
-	objGVK, err := gvk.Get(validCreateObj)
-	m.Require().NoError(err, "failed to get GVK")
-
-	client, err := m.clientFactory.ForKind(objGVK)
-	m.Require().NoError(err, "Failed to create client")
-
+func (m *FailurePolicySuite) checkWebhookIsDown() {
 	podGVK := schema.GroupVersionKind{
 		Group:   "",
 		Version: "v1",
@@ -72,14 +63,29 @@ func (m *FailurePolicySuite) TestNamespaceFail() {
 	pods := corev1.PodList{}
 	podClient.List(context.Background(), "cattle-system", &pods, listOpts)
 	m.Require().Equal(0, len(pods.Items), "Test can not run while rancher-webhook pods are still running")
+}
+
+func (m *FailurePolicySuite) TestNamespaceFail() {
+	const name = "test-namespace"
+	validCreateObj := &corev1.Namespace{
+		ObjectMeta: v1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	objGVK, err := gvk.Get(validCreateObj)
+	m.Require().NoError(err, "failed to get GVK")
+
+	client, err := m.clientFactory.ForKind(objGVK)
+	m.Require().NoError(err, "Failed to create client")
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
 	defer cancel()
 	err = client.Create(ctx, "", validCreateObj, nil, v1.CreateOptions{})
 	m.Require().True(errors.IsInternalError(err), "Webhook should fail with service unavailable when the webhook is down instead we received :%v", err)
 
-	// attempt to clean up namespace if the create went through
-	defer client.Delete(ctx, "", testNamespace, v1.DeleteOptions{})
+	// Attempt to clean up the namespace if the create went through.
+	defer client.Delete(ctx, "", name, v1.DeleteOptions{})
 
 	validCreateObj.Name = "default"
 	err = client.Update(ctx, "", validCreateObj, nil, v1.UpdateOptions{})
@@ -91,4 +97,34 @@ func (m *FailurePolicySuite) TestNamespaceFail() {
 
 	err = client.Update(ctx, "", validCreateObj, nil, v1.UpdateOptions{})
 	m.Require().True(errors.IsInternalError(err), "Webhook should fail to update kube-system namespace with service unavailable when the webhook is down instead we received :%v", err)
+}
+
+func (m *FailurePolicySuite) TestSettingSucceed() {
+	const name = "new-setting"
+	createObj := &mgmtv3.Setting{
+		ObjectMeta: v1.ObjectMeta{
+			Name: name,
+		},
+	}
+	objGVK, err := gvk.Get(createObj)
+	m.Require().NoError(err, "failed to get GVK")
+
+	client, err := m.clientFactory.ForKind(objGVK)
+	m.Require().NoError(err, "Failed to create client")
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	defer cancel()
+	err = client.Create(ctx, "", createObj, nil, v1.CreateOptions{})
+	m.Require().NoError(err)
+
+	// Attempt to clean up the setting if the create went through.
+	defer client.Delete(ctx, "", name, v1.DeleteOptions{})
+
+	updateObj := &mgmtv3.Setting{}
+	err = client.Get(ctx, "", name, updateObj, v1.GetOptions{})
+	m.Require().NoError(err)
+	updateObj.Value = "new-value"
+
+	err = client.Update(ctx, "", updateObj, updateObj, v1.UpdateOptions{})
+	m.Require().NoError(err)
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from other PRs, link them here and describe why they are needed for your solution section. -->

https://github.com/rancher/rancher/issues/45841

## Problem
<!-- Describe the root cause of the issue you are resolving. 
This may include what behavior is observed and why it is not desirable. If this is a new feature, describe why we need it and how it will be used. -->

We have a "catch 22" situation with the settings validator as rancher may update some settings on startup while the webhook is starting up.

## Solution
<!-- Describe what you changed to fix the issue. 
Relate your changes to the original bug/feature and explain why this addresses the issue. -->

Change the `FailurePolicy` to `Ignore` on settings' validator to avoid timeouts.

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [x] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [ ] Docs