### PR TITLE
Add workflow to release webhook in rancher/charts and rancher/rancher

### DIFF
--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -24,6 +24,7 @@ jobs:
   create-charts-pr:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       # Required for vault
       id-token: write
     steps:
@@ -60,9 +61,9 @@ jobs:
       - name: Configure the committer
         run: |
           cd charts
-          user_id=$(gh api "/users/$APP_USER" --jq .id)"
+          user_id=$(gh api "/users/$APP_USER" --jq .id)
           git config --global user.name "$APP_USER"
-          git config --global user.email "${user_id}+${APP_USER}@users.noreply.github.com>"
+          git config --global user.email "${user_id}+${APP_USER}@users.noreply.github.com"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           APP_USER: "${{ steps.app-token.outputs.app-slug }}[bot]"

--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -1,17 +1,17 @@
-name: Bump Webhook RC against rancher/charts
+name: Bump webhook in rancher/charts
 on:
   workflow_dispatch:
     inputs:
       charts_ref:
-        description: "Submit PR against the following rancher/charts branch (eg: dev-v2.9)"
+        description: "Submit PR against the following rancher/charts branch (eg: dev-v2.10)"
         required: true
-        default: "dev-v2.9"
+        default: "dev-v2.10"
       prev_webhook:
-        description: "Previous Webhook version (eg: 0.5.0-rc13)"
+        description: "Previous Webhook version (eg: 0.5.0-rc.13)"
         required: true
         default: ""
       new_webhook:
-        description: "New Webhook version (eg: 0.5.0-rc14)"
+        description: "New Webhook version (eg: 0.5.0-rc.14)"
         required: true
         default: ""
 
@@ -21,54 +21,75 @@ env:
   NEW_WEBHOOK: ${{ github.event.inputs.new_webhook }}
 
 jobs:
-  create-rancher-charts-pr:
+  create-charts-pr:
     runs-on: ubuntu-latest
+    permissions:
+      # Required for vault
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.ref }}
           path: webhook
 
-      # Checkout the fork first because it's simpler to setup the token for the
-      # push later on
-      - name: Checkout fork of rancher/charts
+      - uses: rancher-eio/read-vault-secrets@main
+        with:
+          secrets: |
+            secret/data/github/repo/${{ github.repository }}/github/app-credentials appId | APP_ID ;
+            secret/data/github/repo/${{ github.repository }}/github/app-credentials privateKey | PRIVATE_KEY
+
+      # Fetch github token just for the charts repository
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ env.APP_ID }}
+          private-key: ${{ env.PRIVATE_KEY }}
+          repositories: |
+            charts
+
+      - name: Checkout charts repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          repository: tomleb/rancher-charts
-          token: ${{ secrets.PUSH_TO_FORKS_TOKEN }}
+          repository: ${{ github.repository_owner }}/charts
+          token: ${{ steps.app-token.outputs.token }}
           path: charts
+          # Allow making git push request later on
+          persist-credentials: true
+
+      - name: Configure the committer
+        run: |
+          cd charts
+          user_id=$(gh api "/users/$APP_USER" --jq .id)"
+          git config --global user.name "$APP_USER"
+          git config --global user.email "${user_id}+${APP_USER}@users.noreply.github.com>"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_USER: "${{ steps.app-token.outputs.app-slug }}[bot]"
 
       - name: Install dependencies
         run: sudo snap install yq --channel=v4/stable
 
-      - name: Setup repo dir
-        run: |
-          cd charts
-          BRANCH="gha-test-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
-          git config --global user.email "webhook@example.com"
-          git config --global user.name "tomleb webhook Bot"
-          git remote add upstream https://github.com/rancher/charts
-          git fetch upstream
-          git checkout -b $BRANCH "upstream/$CHARTS_REF"
-
       - name: Run release script
         run: |
-          ./webhook/.github/workflows/scripts/release-against-charts.sh charts "$PREV_WEBHOOK" "$NEW_WEBHOOK"
+          cd charts
+          BRANCH="bump-webhook-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
+          git checkout -b "$BRANCH" "$CHARTS_REF"
+          ./webhook/.github/workflows/scripts/release-against-charts.sh . "$PREV_WEBHOOK" "$NEW_WEBHOOK"
 
       - name: Push and create pull request
         env:
-           GITHUB_TOKEN: ${{ secrets.PUSH_TO_FORKS_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           cd charts
-          git push origin $BRANCH
+          git push origin "$BRANCH"
 
           body=$(../webhook/.github/workflows/scripts/release-message.sh "$PREV_WEBHOOK" "$NEW_WEBHOOK")
 
           gh pr create \
             --title "[$CHARTS_REF] Bump rancher-webhook to v$NEW_WEBHOOK" \
             --body "$body" \
-            --repo rancher/charts \
-            --head "tomleb:$BRANCH" \
+            --repo ${{ github.repository_owner }}/charts \
+            --head "${{ github.repository_owner }}:$BRANCH" \
             --base "$CHARTS_REF"

--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -7,11 +7,11 @@ on:
         required: true
         default: "dev-v2.10"
       prev_webhook:
-        description: "Previous Webhook version (eg: 0.5.0-rc.13)"
+        description: "Previous Webhook version (eg: v0.5.0-rc.13)"
         required: true
         default: ""
       new_webhook:
-        description: "New Webhook version (eg: 0.5.0-rc.14)"
+        description: "New Webhook version (eg: v0.5.0-rc.14)"
         required: true
         default: ""
 
@@ -88,7 +88,7 @@ jobs:
           body=$(../webhook/.github/workflows/scripts/release-message.sh "$PREV_WEBHOOK" "$NEW_WEBHOOK")
 
           gh pr create \
-            --title "[$CHARTS_REF] Bump rancher-webhook to v$NEW_WEBHOOK" \
+            --title "[$CHARTS_REF] Bump rancher-webhook to $NEW_WEBHOOK" \
             --body "$body" \
             --repo ${{ github.repository_owner }}/charts \
             --head "${{ github.repository_owner }}:$BRANCH" \

--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -1,0 +1,74 @@
+name: Bump Webhook RC against rancher/charts
+on:
+  workflow_dispatch:
+    inputs:
+      charts_ref:
+        description: "Submit PR against the following rancher/charts branch (eg: dev-v2.9)"
+        required: true
+        default: "dev-v2.9"
+      prev_webhook:
+        description: "Previous Webhook version (eg: 0.5.0-rc13)"
+        required: true
+        default: ""
+      new_webhook:
+        description: "New Webhook version (eg: 0.5.0-rc14)"
+        required: true
+        default: ""
+
+env:
+  CHARTS_REF: ${{ github.event.inputs.charts_ref }}
+  PREV_WEBHOOK: ${{ github.event.inputs.prev_webhook }}
+  NEW_WEBHOOK: ${{ github.event.inputs.new_webhook }}
+
+jobs:
+  create-rancher-charts-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref }}
+          path: webhook
+
+      # Checkout the fork first because it's simpler to setup the token for the
+      # push later on
+      - name: Checkout fork of rancher/charts
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          repository: tomleb/rancher-charts
+          token: ${{ secrets.PUSH_TO_FORKS_TOKEN }}
+          path: charts
+
+      - name: Install dependencies
+        run: sudo snap install yq --channel=v4/stable
+
+      - name: Setup repo dir
+        run: |
+          cd charts
+          BRANCH="gha-test-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
+          git config --global user.email "webhook@example.com"
+          git config --global user.name "tomleb webhook Bot"
+          git remote add upstream https://github.com/rancher/charts
+          git fetch upstream
+          git checkout -b $BRANCH "upstream/$CHARTS_REF"
+
+      - name: Run release script
+        run: |
+          ./webhook/.github/workflows/scripts/release-against-charts.sh charts "$PREV_WEBHOOK" "$NEW_WEBHOOK"
+
+      - name: Push and create pull request
+        env:
+           GITHUB_TOKEN: ${{ secrets.PUSH_TO_FORKS_TOKEN }}
+        run: |
+          cd charts
+          git push origin $BRANCH
+
+          body=$(../webhook/.github/workflows/scripts/release-message.sh "$PREV_WEBHOOK" "$NEW_WEBHOOK")
+
+          gh pr create \
+            --title "[$CHARTS_REF] Bump rancher-webhook to v$NEW_WEBHOOK" \
+            --body "$body" \
+            --repo rancher/charts \
+            --head "tomleb:$BRANCH" \
+            --base "$CHARTS_REF"

--- a/.github/workflows/release-rancher.yaml
+++ b/.github/workflows/release-rancher.yaml
@@ -1,17 +1,17 @@
-name: Bump Webhook RC against rancher/rancher
+name: Bump webhook in rancher/rancher
 on:
   workflow_dispatch:
     inputs:
       rancher_ref:
-        description: "Submit PR against the following rancher/charts branch (eg: dev-v2.9)"
+        description: "Submit PR against the following rancher/rancher branch (eg: main)"
         required: true
-        default: "release/v2.9"
+        default: "main"
       prev_webhook:
-        description: "Previous Webhook version (eg: 0.5.0-rc13)"
+        description: "Previous Webhook version (eg: 0.5.0-rc.13)"
         required: true
         default: ""
       new_webhook:
-        description: "New Webhook version (eg: 0.5.0-rc14)"
+        description: "New Webhook version (eg: 0.5.0-rc.14)"
         required: true
         default: ""
 
@@ -21,45 +21,66 @@ env:
   NEW_WEBHOOK: ${{ github.event.inputs.new_webhook }}
 
 jobs:
-  create-rancher-charts-pr:
+  create-rancher-pr:
     runs-on: ubuntu-latest
+    permissions:
+      # Required for vault
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.ref }}
           path: webhook
 
-      # Checkout the fork first because it's simpler to setup the token for the
-      # push later on
-      - name: Checkout fork of rancher/rancher
+      - uses: rancher-eio/read-vault-secrets@main
+        with:
+          secrets: |
+            secret/data/github/repo/${{ github.repository }}/github/app-credentials appId | APP_ID ;
+            secret/data/github/repo/${{ github.repository }}/github/app-credentials privateKey | PRIVATE_KEY
+
+      # Fetch github token just for the rancher repository
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ env.APP_ID }}
+          private-key: ${{ env.PRIVATE_KEY }}
+          repositories: |
+            rancher
+
+      - name: Checkout rancher repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          repository: tomleb/rancher-rancher
-          token: ${{ secrets.PUSH_TO_FORKS_TOKEN }}
+          repository: ${{ github.repository_owner }}/rancher
+          token: ${{ steps.app-token.outputs.token }}
           path: rancher
+          # Allow making git push request later on
+          persist-credentials: true
+
+      - name: Configure the committer
+        run: |
+          cd rancher
+          user_id=$(gh api "/users/$APP_USER" --jq .id)"
+          git config --global user.name "$APP_USER"
+          git config --global user.email "${user_id}+${APP_USER}@users.noreply.github.com>"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_USER: "${{ steps.app-token.outputs.app-slug }}[bot]"
 
       - name: Install dependencies
         run: sudo snap install yq --channel=v4/stable
 
-      - name: Setup repo dir
-        run: |
-          cd rancher
-          BRANCH="gha-test-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
-          git config --global user.email "webhook@example.com"
-          git config --global user.name "tomleb webhook Bot"
-          git remote add upstream https://github.com/rancher/rancher
-          git fetch upstream
-          git checkout -b $BRANCH "upstream/$RANCHER_REF"
-
       - name: Run release script
         run: |
-          ./webhook/.github/workflows/scripts/release-against-rancher.sh rancher "$NEW_WEBHOOK"
+          cd rancher
+          BRANCH="bump-webhook-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
+          git checkout -b "$BRANCH" "$RANCHER_REF"
+          ./webhook/.github/workflows/scripts/release-against-rancher.sh . "$NEW_WEBHOOK"
 
       - name: Push and create pull request
         env:
-           GITHUB_TOKEN: ${{ secrets.PUSH_TO_FORKS_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           cd rancher
           git push origin $BRANCH
@@ -69,6 +90,6 @@ jobs:
           gh pr create \
             --title "[$RANCHER_REF] Bump rancher-webhook to v$NEW_WEBHOOK" \
             --body "$body" \
-            --repo rancher/rancher \
-            --head "tomleb:$BRANCH" \
+            --repo ${{ github.repository_owner }}/rancher \
+            --head "${{ github.repository_owner }}:$BRANCH" \
             --base "$RANCHER_REF"

--- a/.github/workflows/release-rancher.yaml
+++ b/.github/workflows/release-rancher.yaml
@@ -1,0 +1,74 @@
+name: Bump Webhook RC against rancher/rancher
+on:
+  workflow_dispatch:
+    inputs:
+      rancher_ref:
+        description: "Submit PR against the following rancher/charts branch (eg: dev-v2.9)"
+        required: true
+        default: "release/v2.9"
+      prev_webhook:
+        description: "Previous Webhook version (eg: 0.5.0-rc13)"
+        required: true
+        default: ""
+      new_webhook:
+        description: "New Webhook version (eg: 0.5.0-rc14)"
+        required: true
+        default: ""
+
+env:
+  RANCHER_REF: ${{ github.event.inputs.rancher_ref }}
+  PREV_WEBHOOK: ${{ github.event.inputs.prev_webhook }}
+  NEW_WEBHOOK: ${{ github.event.inputs.new_webhook }}
+
+jobs:
+  create-rancher-charts-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref }}
+          path: webhook
+
+      # Checkout the fork first because it's simpler to setup the token for the
+      # push later on
+      - name: Checkout fork of rancher/rancher
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          repository: tomleb/rancher-rancher
+          token: ${{ secrets.PUSH_TO_FORKS_TOKEN }}
+          path: rancher
+
+      - name: Install dependencies
+        run: sudo snap install yq --channel=v4/stable
+
+      - name: Setup repo dir
+        run: |
+          cd rancher
+          BRANCH="gha-test-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
+          git config --global user.email "webhook@example.com"
+          git config --global user.name "tomleb webhook Bot"
+          git remote add upstream https://github.com/rancher/rancher
+          git fetch upstream
+          git checkout -b $BRANCH "upstream/$RANCHER_REF"
+
+      - name: Run release script
+        run: |
+          ./webhook/.github/workflows/scripts/release-against-rancher.sh rancher "$NEW_WEBHOOK"
+
+      - name: Push and create pull request
+        env:
+           GITHUB_TOKEN: ${{ secrets.PUSH_TO_FORKS_TOKEN }}
+        run: |
+          cd rancher
+          git push origin $BRANCH
+
+          body=$(../webhook/.github/workflows/scripts/release-message.sh "$PREV_WEBHOOK" "$NEW_WEBHOOK")
+
+          gh pr create \
+            --title "[$RANCHER_REF] Bump rancher-webhook to v$NEW_WEBHOOK" \
+            --body "$body" \
+            --repo rancher/rancher \
+            --head "tomleb:$BRANCH" \
+            --base "$RANCHER_REF"

--- a/.github/workflows/release-rancher.yaml
+++ b/.github/workflows/release-rancher.yaml
@@ -7,11 +7,11 @@ on:
         required: true
         default: "main"
       prev_webhook:
-        description: "Previous Webhook version (eg: 0.5.0-rc.13)"
+        description: "Previous Webhook version (eg: v0.5.0-rc.13)"
         required: true
         default: ""
       new_webhook:
-        description: "New Webhook version (eg: 0.5.0-rc.14)"
+        description: "New Webhook version (eg: v0.5.0-rc.14)"
         required: true
         default: ""
 
@@ -88,7 +88,7 @@ jobs:
           body=$(../webhook/.github/workflows/scripts/release-message.sh "$PREV_WEBHOOK" "$NEW_WEBHOOK")
 
           gh pr create \
-            --title "[$RANCHER_REF] Bump rancher-webhook to v$NEW_WEBHOOK" \
+            --title "[$RANCHER_REF] Bump rancher-webhook to $NEW_WEBHOOK" \
             --body "$body" \
             --repo ${{ github.repository_owner }}/rancher \
             --head "${{ github.repository_owner }}:$BRANCH" \

--- a/.github/workflows/release-rancher.yaml
+++ b/.github/workflows/release-rancher.yaml
@@ -24,6 +24,7 @@ jobs:
   create-rancher-pr:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       # Required for vault
       id-token: write
     steps:
@@ -60,9 +61,9 @@ jobs:
       - name: Configure the committer
         run: |
           cd rancher
-          user_id=$(gh api "/users/$APP_USER" --jq .id)"
+          user_id=$(gh api "/users/$APP_USER" --jq .id)
           git config --global user.name "$APP_USER"
-          git config --global user.email "${user_id}+${APP_USER}@users.noreply.github.com>"
+          git config --global user.email "${user_id}+${APP_USER}@users.noreply.github.com"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           APP_USER: "${{ steps.app-token.outputs.app-slug }}[bot]"

--- a/.github/workflows/scripts/release-against-charts.sh
+++ b/.github/workflows/scripts/release-against-charts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Bumps Webhook version in a locally checked out rancher/charts repository
 #
@@ -19,9 +19,35 @@ Usage:
 EOF
 }
 
+bump_patch() {
+    version=$1
+    major=$(echo "$version" | cut -d. -f1)
+    minor=$(echo "$version" | cut -d. -f2)
+    patch=$(echo "$version" | cut -d. -f3)
+    new_patch=$((patch + 1))
+    echo "${major}.${minor}.${new_patch}"
+}
+
+validate_version_format() {
+    version=$1
+    if ! echo "$version" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$'; then
+        echo "Error: Version $version must be in the format v<major>.<minor>.<patch> or v<major>.<minor>.<patch>-rc.<number>"
+        exit 1
+    fi
+}
+
 if [ -z "$CHARTS_DIR" ] || [ -z "$PREV_WEBHOOK_VERSION" ] || [ -z "$NEW_WEBHOOK_VERSION" ]; then
     usage
     exit 1
+fi
+
+validate_version_format "$PREV_WEBHOOK_VERSION"
+validate_version_format "$NEW_WEBHOOK_VERSION"
+
+if echo "$PREV_WEBHOOK_VERSION" | grep -q '\-rc'; then
+    is_prev_rc=true
+else
+    is_prev_rc=false
 fi
 
 if [ "$PREV_WEBHOOK_VERSION" = "$NEW_WEBHOOK_VERSION" ]; then
@@ -35,7 +61,7 @@ NEW_WEBHOOK_VERSION_SHORT=$(echo "$NEW_WEBHOOK_VERSION" | sed 's|^v||')  # e.g. 
 
 set -ue
 
-pushd "${CHARTS_DIR}" > /dev/null
+cd "${CHARTS_DIR}"
 
 # Validate the given webhook version (eg: 0.5.0-rc.13)
 if ! grep -q "${PREV_WEBHOOK_VERSION_SHORT}" ./packages/rancher-webhook/package.yaml; then
@@ -50,26 +76,35 @@ if ! PREV_CHART_VERSION=$(yq '.version' ./packages/rancher-webhook/package.yaml)
     cat ./packages/rancher-webhook/package.yaml
     exit 1
 fi
-NEW_CHART_VERSION=$PREV_CHART_VERSION
+
+if [ "$is_prev_rc" = "false" ]; then
+    NEW_CHART_VERSION=$(bump_patch "$PREV_CHART_VERSION")
+else
+    NEW_CHART_VERSION=$PREV_CHART_VERSION
+fi
 
 sed -i "s/${PREV_WEBHOOK_VERSION_SHORT}/${NEW_WEBHOOK_VERSION_SHORT}/g" ./packages/rancher-webhook/package.yaml
+sed -i "s/${PREV_CHART_VERSION}/${NEW_CHART_VERSION}/g" ./packages/rancher-webhook/package.yaml
 
 git add packages/rancher-webhook
 git commit -m "Bump rancher-webhook to $NEW_WEBHOOK_VERSION"
 
 PACKAGE=rancher-webhook make charts
-git add ./assets/rancher-webhook ./charts/rancher-webhook
+git add ./assets/rancher-webhook ./charts/rancher-webhook index.yaml
 git commit -m "make charts"
 
-CHART=rancher-webhook VERSION=${PREV_CHART_VERSION}+up${PREV_WEBHOOK_VERSION_SHORT} make remove
-git add ./assets/rancher-webhook ./charts/rancher-webhook ./index.yaml
-git commit -m "make remove"
+# When previous webhook version is an RC, then we want to remove that RC. We keep
+# non-RC version.
+if [ "$is_prev_rc" = "true" ]; then
+    CHART=rancher-webhook VERSION=${PREV_CHART_VERSION}+up${PREV_WEBHOOK_VERSION_SHORT} make remove
+    git add ./assets/rancher-webhook ./charts/rancher-webhook ./index.yaml
+    git commit -m "make remove"
 
-yq --inplace "del(.rancher-webhook.[] | select(. == \"${PREV_CHART_VERSION}+up${PREV_WEBHOOK_VERSION_SHORT}\"))" release.yaml
+    yq --inplace "del(.rancher-webhook.[] | select(. == \"${PREV_CHART_VERSION}+up${PREV_WEBHOOK_VERSION_SHORT}\"))" release.yaml
+fi
+
 # Prepends to list
 yq --inplace ".rancher-webhook = [\"${NEW_CHART_VERSION}+up${NEW_WEBHOOK_VERSION_SHORT}\"] + .rancher-webhook" release.yaml
 
 git add release.yaml
 git commit -m "Add rancher-webhook ${NEW_CHART_VERSION}+up${NEW_WEBHOOK_VERSION_SHORT} to release.yaml"
- 
-popd > /dev/null

--- a/.github/workflows/scripts/release-against-charts.sh
+++ b/.github/workflows/scripts/release-against-charts.sh
@@ -6,11 +6,11 @@
 #   ./release-against-charts.sh <path to charts repo> <prev webhook release> <new webhook release>
 #
 # Example:
-# ./release-against-charts.sh "${GITHUB_WORKSPACE}" "0.5.0-rc.13" "0.5.0-rc.14"
+# ./release-against-charts.sh "${GITHUB_WORKSPACE}" "v0.5.0-rc.13" "v0.5.0-rc.14"
 
 CHARTS_DIR=$1
-PREV_WEBHOOK_VERSION=$2   # e.g. 0.5.2-rc.3
-NEW_WEBHOOK_VERSION=$3
+PREV_WEBHOOK_VERSION=$2   # e.g. v0.5.2-rc.3
+NEW_WEBHOOK_VERSION=$3    # e.g. v0.5.2-rc.4
 
 usage() {
     cat <<EOF
@@ -24,12 +24,16 @@ if [ -z "$CHARTS_DIR" ] || [ -z "$PREV_WEBHOOK_VERSION" ] || [ -z "$NEW_WEBHOOK_
     exit 1
 fi
 
+# Remove the prefix v because the chart version doesn't contain it
+PREV_WEBHOOK_VERSION_SHORT=$(echo "$PREV_WEBHOOK_VERSION" | sed 's|^v||')  # e.g. 0.5.2-rc.3
+NEW_WEBHOOK_VERSION_SHORT=$(echo "$NEW_WEBHOOK_VERSION" | sed 's|^v||')  # e.g. 0.5.2-rc.4
+
 set -ue
 
 pushd "${CHARTS_DIR}" > /dev/null
 
 # Validate the given webhook version (eg: 0.5.0-rc.13)
-if ! grep -q "${PREV_WEBHOOK_VERSION}" ./packages/rancher-webhook/package.yaml; then
+if ! grep -q "${PREV_WEBHOOK_VERSION_SHORT}" ./packages/rancher-webhook/package.yaml; then
     echo "Previous Webhook version references do not exist in ./packages/rancher-webhook/. The content of the file is:"
     cat ./packages/rancher-webhook/package.yaml
     exit 1
@@ -43,24 +47,24 @@ if ! PREV_CHART_VERSION=$(yq '.version' ./packages/rancher-webhook/package.yaml)
 fi
 NEW_CHART_VERSION=$PREV_CHART_VERSION
 
-sed -i "s/${PREV_WEBHOOK_VERSION}/${NEW_WEBHOOK_VERSION}/g" ./packages/rancher-webhook/package.yaml
+sed -i "s/${PREV_WEBHOOK_VERSION_SHORT}/${NEW_WEBHOOK_VERSION_SHORT}/g" ./packages/rancher-webhook/package.yaml
 
 git add packages/rancher-webhook
-git commit -m "Bump rancher-webhook to v$NEW_WEBHOOK_VERSION"
+git commit -m "Bump rancher-webhook to $NEW_WEBHOOK_VERSION"
 
 PACKAGE=rancher-webhook make charts
 git add ./assets/rancher-webhook ./charts/rancher-webhook
 git commit -m "make charts"
 
-CHART=rancher-webhook VERSION=${PREV_CHART_VERSION}+up${PREV_WEBHOOK_VERSION} make remove
+CHART=rancher-webhook VERSION=${PREV_CHART_VERSION}+up${PREV_WEBHOOK_VERSION_SHORT} make remove
 git add ./assets/rancher-webhook ./charts/rancher-webhook ./index.yaml
 git commit -m "make remove"
 
-yq --inplace "del(.rancher-webhook.[] | select(. == \"${PREV_CHART_VERSION}+up${PREV_WEBHOOK_VERSION}\"))" release.yaml
+yq --inplace "del(.rancher-webhook.[] | select(. == \"${PREV_CHART_VERSION}+up${PREV_WEBHOOK_VERSION_SHORT}\"))" release.yaml
 # Prepends to list
-yq --inplace ".rancher-webhook = [\"${NEW_CHART_VERSION}+up${NEW_WEBHOOK_VERSION}\"] + .rancher-webhook" release.yaml
+yq --inplace ".rancher-webhook = [\"${NEW_CHART_VERSION}+up${NEW_WEBHOOK_VERSION_SHORT}\"] + .rancher-webhook" release.yaml
 
 git add release.yaml
-git commit -m "Add rancher-webhook ${NEW_CHART_VERSION}+up${NEW_WEBHOOK_VERSION} to release.yaml"
+git commit -m "Add rancher-webhook ${NEW_CHART_VERSION}+up${NEW_WEBHOOK_VERSION_SHORT} to release.yaml"
  
 popd > /dev/null

--- a/.github/workflows/scripts/release-against-charts.sh
+++ b/.github/workflows/scripts/release-against-charts.sh
@@ -6,7 +6,7 @@
 #   ./release-against-charts.sh <path to charts repo> <prev webhook release> <new webhook release>
 #
 # Example:
-# ./release-against-charts.sh "${GITHUB_WORKSPACE}" "0.5.0-rc13" "0.5.0-rc14"
+# ./release-against-charts.sh "${GITHUB_WORKSPACE}" "0.5.0-rc.13" "0.5.0-rc.14"
 
 CHARTS_DIR=$1
 PREV_WEBHOOK_VERSION=$2   # e.g. 0.5.2-rc.3

--- a/.github/workflows/scripts/release-against-charts.sh
+++ b/.github/workflows/scripts/release-against-charts.sh
@@ -57,7 +57,8 @@ git add ./assets/rancher-webhook ./charts/rancher-webhook ./index.yaml
 git commit -m "make remove"
 
 yq --inplace "del(.rancher-webhook.[] | select(. == \"${PREV_CHART_VERSION}+up${PREV_WEBHOOK_VERSION}\"))" release.yaml
-yq --inplace ".rancher-webhook += [\"${NEW_CHART_VERSION}+up${NEW_WEBHOOK_VERSION}\"]" release.yaml
+# Prepends to list
+yq --inplace ".rancher-webhook = [\"${NEW_CHART_VERSION}+up${NEW_WEBHOOK_VERSION}\"] + .rancher-webhook" release.yaml
 
 git add release.yaml
 git commit -m "Add rancher-webhook ${NEW_CHART_VERSION}+up${NEW_WEBHOOK_VERSION} to release.yaml"

--- a/.github/workflows/scripts/release-against-charts.sh
+++ b/.github/workflows/scripts/release-against-charts.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+#
+# Bumps Webhook version in a locally checked out rancher/charts repository
+#
+# Usage:
+#   ./release-against-charts.sh <path to charts repo> <prev webhook release> <new webhook release>
+#
+# Example:
+# ./release-against-charts.sh "${GITHUB_WORKSPACE}" "0.5.0-rc13" "0.5.0-rc14"
+
+CHARTS_DIR=$1
+PREV_WEBHOOK_VERSION=$2   # e.g. 0.5.2-rc.3
+NEW_WEBHOOK_VERSION=$3
+
+usage() {
+    cat <<EOF
+Usage:
+  $0 <path to charts repo> <prev webhook release> <new webhook release>
+EOF
+}
+
+if [ -z "$CHARTS_DIR" ] || [ -z "$PREV_WEBHOOK_VERSION" ] || [ -z "$NEW_WEBHOOK_VERSION" ]; then
+    usage
+    exit 1
+fi
+
+set -ue
+
+pushd "${CHARTS_DIR}" > /dev/null
+
+# Validate the given webhook version (eg: 0.5.0-rc.13)
+if ! grep -q "${PREV_WEBHOOK_VERSION}" ./packages/rancher-webhook/package.yaml; then
+    echo "Previous Webhook version references do not exist in ./packages/rancher-webhook/. The content of the file is:"
+    cat ./packages/rancher-webhook/package.yaml
+    exit 1
+fi
+
+# Get the chart version (eg: 104.0.0)
+if ! PREV_CHART_VERSION=$(yq '.version' ./packages/rancher-webhook/package.yaml); then
+    echo "Unable to get chart version from ./packages/rancher-webhook/package.yaml. The content of the file is:"
+    cat ./packages/rancher-webhook/package.yaml
+    exit 1
+fi
+NEW_CHART_VERSION=$PREV_CHART_VERSION
+
+sed -i "s/${PREV_WEBHOOK_VERSION}/${NEW_WEBHOOK_VERSION}/g" ./packages/rancher-webhook/package.yaml
+
+git add packages/rancher-webhook
+git commit -m "Bump rancher-webhook to v$NEW_WEBHOOK_VERSION"
+
+PACKAGE=rancher-webhook make charts
+git add ./assets/rancher-webhook ./charts/rancher-webhook
+git commit -m "make charts"
+
+CHART=rancher-webhook VERSION=${PREV_CHART_VERSION}+up${PREV_WEBHOOK_VERSION} make remove
+git add ./assets/rancher-webhook ./charts/rancher-webhook ./index.yaml
+git commit -m "make remove"
+
+yq --inplace "del(.rancher-webhook.[] | select(. == \"${PREV_CHART_VERSION}+up${PREV_WEBHOOK_VERSION}\"))" release.yaml
+yq --inplace ".rancher-webhook += [\"${NEW_CHART_VERSION}+up${NEW_WEBHOOK_VERSION}\"]" release.yaml
+
+git add release.yaml
+git commit -m "Add rancher-webhook ${NEW_CHART_VERSION}+up${NEW_WEBHOOK_VERSION} to release.yaml"
+ 
+popd > /dev/null

--- a/.github/workflows/scripts/release-against-charts.sh
+++ b/.github/workflows/scripts/release-against-charts.sh
@@ -24,6 +24,11 @@ if [ -z "$CHARTS_DIR" ] || [ -z "$PREV_WEBHOOK_VERSION" ] || [ -z "$NEW_WEBHOOK_
     exit 1
 fi
 
+if [ "$PREV_WEBHOOK_VERSION" = "$NEW_WEBHOOK_VERSION" ]; then
+    echo "Previous and new webhook version are the same: $NEW_WEBHOOK_VERSION, but must be different"
+    exit 1
+fi
+
 # Remove the prefix v because the chart version doesn't contain it
 PREV_WEBHOOK_VERSION_SHORT=$(echo "$PREV_WEBHOOK_VERSION" | sed 's|^v||')  # e.g. 0.5.2-rc.3
 NEW_WEBHOOK_VERSION_SHORT=$(echo "$NEW_WEBHOOK_VERSION" | sed 's|^v||')  # e.g. 0.5.2-rc.4

--- a/.github/workflows/scripts/release-against-rancher.sh
+++ b/.github/workflows/scripts/release-against-rancher.sh
@@ -6,7 +6,7 @@
 #   ./release-against-rancher.sh <path to rancher repo> <new webhook release>
 #
 # Example:
-# ./release-against-charts.sh "${GITHUB_WORKSPACE}" "0.5.0-rc14"
+# ./release-against-charts.sh "${GITHUB_WORKSPACE}" "0.5.0-rc.14"
 
 RANCHER_DIR=$1
 NEW_WEBHOOK_VERSION=$2   # e.g. 0.5.2-rc.3

--- a/.github/workflows/scripts/release-against-rancher.sh
+++ b/.github/workflows/scripts/release-against-rancher.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+#
+# Bumps Webhook version in a locally checked out rancher/rancher repository
+#
+# Usage:
+#   ./release-against-rancher.sh <path to rancher repo> <new webhook release>
+#
+# Example:
+# ./release-against-charts.sh "${GITHUB_WORKSPACE}" "0.5.0-rc14"
+
+RANCHER_DIR=$1
+NEW_WEBHOOK_VERSION=$2   # e.g. 0.5.2-rc.3
+
+usage() {
+    cat <<EOF
+Usage:
+  $0 <path to rancher repo> <new webhook release>
+EOF
+}
+
+if [ -z "$RANCHER_DIR" ] || [ -z "$NEW_WEBHOOK_VERSION" ]; then
+    usage
+    exit 1
+fi
+
+set -ue
+
+pushd "${RANCHER_DIR}" > /dev/null
+
+# Validate the given webhook version (eg: 0.5.0-rc.13)
+if grep -q "${NEW_WEBHOOK_VERSION}" ./build.yaml; then
+    echo "build.yaml already at version v${NEW_WEBHOOK_VERSION}"
+    exit 1
+fi
+
+# Get the chart version (eg: 104.0.0)
+if ! PREV_CHART_VERSION=$(yq -r '.webhookVersion' ./build.yaml | cut -d+ -f1); then
+    echo "Unable to get chart version from ./build.yaml. The content of the file is:"
+    cat ./build.yaml
+    exit 1
+fi
+NEW_CHART_VERSION=$PREV_CHART_VERSION
+
+yq --inplace ".webhookVersion = \"${NEW_CHART_VERSION}+up${NEW_WEBHOOK_VERSION}\"" ./build.yaml
+
+# Downloads dapper
+make .dapper
+
+# DAPPER_MODE=bind will make sure we output everything that changed
+DAPPER_MODE=bind ./.dapper go generate ./... || true
+DAPPER_MODE=bind ./.dapper rm -rf go
+
+git add .
+git commit -m "Bump webhook to ${NEW_CHART_VERSION}+up${NEW_WEBHOOK_VERSION}"
+
+popd > /dev/null

--- a/.github/workflows/scripts/release-against-rancher.sh
+++ b/.github/workflows/scripts/release-against-rancher.sh
@@ -18,10 +18,29 @@ Usage:
 EOF
 }
 
+bump_patch() {
+    version=$1
+    major=$(echo "$version" | cut -d. -f1)
+    minor=$(echo "$version" | cut -d. -f2)
+    patch=$(echo "$version" | cut -d. -f3)
+    new_patch=$((patch + 1))
+    echo "${major}.${minor}.${new_patch}"
+}
+
+validate_version_format() {
+    version=$1
+    if ! echo "$version" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$'; then
+        echo "Error: Version $version must be in the format v<major>.<minor>.<patch> or v<major>.<minor>.<patch>-rc.<number>"
+        exit 1
+    fi
+}
+
 if [ -z "$RANCHER_DIR" ] || [ -z "$NEW_WEBHOOK_VERSION" ]; then
     usage
     exit 1
 fi
+
+validate_version_format "$NEW_WEBHOOK_VERSION"
 
 # Remove the prefix v because the chart version doesn't contain it
 NEW_WEBHOOK_VERSION_SHORT=$(echo "$NEW_WEBHOOK_VERSION" | sed 's|^v||')  # e.g. 0.5.2-rc.3
@@ -30,10 +49,22 @@ set -ue
 
 pushd "${RANCHER_DIR}" > /dev/null
 
-# Validate the given webhook version (eg: 0.5.0-rc.13)
-if grep -q "${NEW_WEBHOOK_VERSION_SHORT}" ./build.yaml; then
-    echo "build.yaml already at version ${NEW_WEBHOOK_VERSION}"
+# Get the webhook version (eg: 0.5.0-rc.12)
+if ! PREV_WEBHOOK_VERSION_SHORT=$(yq -r '.webhookVersion' ./build.yaml | sed 's|.*+up||'); then
+    echo "Unable to get webhook version from ./build.yaml. The content of the file is:"
+    cat ./build.yaml
     exit 1
+fi
+
+if [ "$PREV_WEBHOOK_VERSION_SHORT" = "$NEW_WEBHOOK_VERSION_SHORT" ]; then
+    echo "Previous and new webhook version are the same: $NEW_WEBHOOK_VERSION, but must be different"
+    exit 1
+fi
+
+if echo "$PREV_WEBHOOK_VERSION_SHORT" | grep -q '\-rc'; then
+    is_prev_rc=true
+else
+    is_prev_rc=false
 fi
 
 # Get the chart version (eg: 104.0.0)
@@ -42,7 +73,12 @@ if ! PREV_CHART_VERSION=$(yq -r '.webhookVersion' ./build.yaml | cut -d+ -f1); t
     cat ./build.yaml
     exit 1
 fi
-NEW_CHART_VERSION=$PREV_CHART_VERSION
+
+if [ "$is_prev_rc" = "false" ]; then
+    NEW_CHART_VERSION=$(bump_patch "$PREV_CHART_VERSION")
+else
+    NEW_CHART_VERSION=$PREV_CHART_VERSION
+fi
 
 yq --inplace ".webhookVersion = \"${NEW_CHART_VERSION}+up${NEW_WEBHOOK_VERSION_SHORT}\"" ./build.yaml
 

--- a/.github/workflows/scripts/release-against-rancher.sh
+++ b/.github/workflows/scripts/release-against-rancher.sh
@@ -6,10 +6,10 @@
 #   ./release-against-rancher.sh <path to rancher repo> <new webhook release>
 #
 # Example:
-# ./release-against-charts.sh "${GITHUB_WORKSPACE}" "0.5.0-rc.14"
+# ./release-against-charts.sh "${GITHUB_WORKSPACE}" "v0.5.0-rc.14"
 
 RANCHER_DIR=$1
-NEW_WEBHOOK_VERSION=$2   # e.g. 0.5.2-rc.3
+NEW_WEBHOOK_VERSION=$2   # e.g. v0.5.2-rc.3
 
 usage() {
     cat <<EOF
@@ -23,13 +23,16 @@ if [ -z "$RANCHER_DIR" ] || [ -z "$NEW_WEBHOOK_VERSION" ]; then
     exit 1
 fi
 
+# Remove the prefix v because the chart version doesn't contain it
+NEW_WEBHOOK_VERSION_SHORT=$(echo "$NEW_WEBHOOK_VERSION" | sed 's|^v||')  # e.g. 0.5.2-rc.3
+
 set -ue
 
 pushd "${RANCHER_DIR}" > /dev/null
 
 # Validate the given webhook version (eg: 0.5.0-rc.13)
-if grep -q "${NEW_WEBHOOK_VERSION}" ./build.yaml; then
-    echo "build.yaml already at version v${NEW_WEBHOOK_VERSION}"
+if grep -q "${NEW_WEBHOOK_VERSION_SHORT}" ./build.yaml; then
+    echo "build.yaml already at version ${NEW_WEBHOOK_VERSION}"
     exit 1
 fi
 
@@ -41,7 +44,7 @@ if ! PREV_CHART_VERSION=$(yq -r '.webhookVersion' ./build.yaml | cut -d+ -f1); t
 fi
 NEW_CHART_VERSION=$PREV_CHART_VERSION
 
-yq --inplace ".webhookVersion = \"${NEW_CHART_VERSION}+up${NEW_WEBHOOK_VERSION}\"" ./build.yaml
+yq --inplace ".webhookVersion = \"${NEW_CHART_VERSION}+up${NEW_WEBHOOK_VERSION_SHORT}\"" ./build.yaml
 
 # Downloads dapper
 make .dapper
@@ -51,6 +54,6 @@ DAPPER_MODE=bind ./.dapper go generate ./... || true
 DAPPER_MODE=bind ./.dapper rm -rf go
 
 git add .
-git commit -m "Bump webhook to ${NEW_CHART_VERSION}+up${NEW_WEBHOOK_VERSION}"
+git commit -m "Bump webhook to ${NEW_CHART_VERSION}+up${NEW_WEBHOOK_VERSION_SHORT}"
 
 popd > /dev/null

--- a/.github/workflows/scripts/release-message.sh
+++ b/.github/workflows/scripts/release-message.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+PREV_WEBHOOK_VERSION=$1   # e.g. 0.5.2-rc.3
+NEW_WEBHOOK_VERSION=$2
+GITHUB_TRIGGERING_ACTOR=${GITHUB_TRIGGERING_ACTOR:-}
+
+usage() {
+    cat <<EOF
+Usage:
+  $0 <prev webhook release> <new webhook release>
+EOF
+}
+
+if [ -z "$PREV_WEBHOOK_VERSION" ] || [ -z "$NEW_WEBHOOK_VERSION" ]; then
+    usage
+    exit 1
+fi
+
+set -ue
+
+# XXX: That's wasteful but doing it by caching the response in a var was giving
+# me unicode error.
+url=$(gh release view --repo rancher/webhook --json url "v${NEW_WEBHOOK_VERSION}" --jq '.url')
+body=$(gh release view --repo rancher/webhook --json body "v${NEW_WEBHOOK_VERSION}" --jq '.body')
+
+generated_by=""
+if [ -n "$GITHUB_TRIGGERING_ACTOR" ]; then
+    generated_by=$(cat <<EOF
+# About this PR
+
+The workflow was triggered by $GITHUB_TRIGGERING_ACTOR.
+EOF
+)
+fi
+
+cat <<EOF
+# Release note for [v${NEW_WEBHOOK_VERSION}]($url)
+
+$body
+
+# Useful links
+
+- Commit comparison: https://github.com/rancher/webhook/compare/v${PREV_WEBHOOK_VERSION}...v${NEW_WEBHOOK_VERSION}
+- Release v${PREV_WEBHOOK_VERSION}: https://github.com/rancher/webhook/releases/tag/v${PREV_WEBHOOK_VERSION}
+
+$generated_by
+EOF

--- a/.github/workflows/scripts/release-message.sh
+++ b/.github/workflows/scripts/release-message.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-PREV_WEBHOOK_VERSION=$1   # e.g. 0.5.2-rc.3
-NEW_WEBHOOK_VERSION=$2
+PREV_WEBHOOK_VERSION=$1   # e.g. v0.5.2-rc.3
+NEW_WEBHOOK_VERSION=$2    # e.g. v0.5.2-rc.4
 GITHUB_TRIGGERING_ACTOR=${GITHUB_TRIGGERING_ACTOR:-}
 
 usage() {
@@ -20,8 +20,8 @@ set -ue
 
 # XXX: That's wasteful but doing it by caching the response in a var was giving
 # me unicode error.
-url=$(gh release view --repo rancher/webhook --json url "v${NEW_WEBHOOK_VERSION}" --jq '.url')
-body=$(gh release view --repo rancher/webhook --json body "v${NEW_WEBHOOK_VERSION}" --jq '.body')
+url=$(gh release view --repo rancher/webhook --json url "${NEW_WEBHOOK_VERSION}" --jq '.url')
+body=$(gh release view --repo rancher/webhook --json body "${NEW_WEBHOOK_VERSION}" --jq '.body')
 
 generated_by=""
 if [ -n "$GITHUB_TRIGGERING_ACTOR" ]; then
@@ -34,14 +34,14 @@ EOF
 fi
 
 cat <<EOF
-# Release note for [v${NEW_WEBHOOK_VERSION}]($url)
+# Release note for [${NEW_WEBHOOK_VERSION}]($url)
 
 $body
 
 # Useful links
 
-- Commit comparison: https://github.com/rancher/webhook/compare/v${PREV_WEBHOOK_VERSION}...v${NEW_WEBHOOK_VERSION}
-- Release v${PREV_WEBHOOK_VERSION}: https://github.com/rancher/webhook/releases/tag/v${PREV_WEBHOOK_VERSION}
+- Commit comparison: https://github.com/rancher/webhook/compare/${PREV_WEBHOOK_VERSION}...${NEW_WEBHOOK_VERSION}
+- Release ${PREV_WEBHOOK_VERSION}: https://github.com/rancher/webhook/releases/tag/${PREV_WEBHOOK_VERSION}
 
 $generated_by
 EOF

--- a/.github/workflows/scripts/release-message.sh
+++ b/.github/workflows/scripts/release-message.sh
@@ -1,4 +1,13 @@
 #!/bin/sh
+#
+# Automatically generates a message for a new release of webhook with some useful
+# links and embedded release notes.
+#
+# Usage:
+#   ./release-message.sh <prev webhook release> <new webhook release>
+#
+# Example:
+# ./release-message.sh "v0.5.2-rc.3" "v0.5.2-rc.4"
 
 PREV_WEBHOOK_VERSION=$1   # e.g. v0.5.2-rc.3
 NEW_WEBHOOK_VERSION=$2    # e.g. v0.5.2-rc.4


### PR DESCRIPTION
# Issue https://github.com/rancher/rancher/issues/46704

# What is this

This adds two workflows that can be triggered manually to bump webhook RCs to rancher/charts and rancher/rancher.

Creating a new release in rancher/charts and rancher/rancher will be simple:
1. Go to the rancher/webhook repo
2. Click on the `Actions` tab
3. On the left sidebar, click on the workflow that you want to run.
4. Enter the necessary input. Example in the image below.
![image](https://github.com/user-attachments/assets/0dae490d-f7e1-4c21-9f80-6fd08619fd49)
5. Click `Run workflow`

This will do the following.

**charts**

Create a new branch off of the branch you input, make some changes to bump webhook, push to rancher/charts directly (more details below), create a pull request to the target branch. You can see an example here: https://github.com/rancher/charts/pull/4211.

**rancher**

Create a new branch off of the branch you input, update webhook version in build.yaml, run go generate, push rancher/rancher, create a pull request to the target branch. You can see an example here: https://github.com/tomleb/rancher-rancher/pull/8.

# Support

Currently, this supports the following:
- Bumping from one RC to another
- Bumping from one RC to unRC

It does not yet support adding an entirely new version of webhook. I'd be okay with implementing it for this PR if asked. 

# Benefits

- No need to open a terminal to do this work (tedious)
- Faster to create PRs: I made sure to include some relevant information to the PR description when they are opened. Here's an example:
![image](https://github.com/user-attachments/assets/0883e24d-86d3-40d2-929c-dd661d23ead1). I'm lazy so I'd rather not have to fetch this information every time like I've been doing and it should make it easier for reviewer as well to review this.
- Easier to review due to the above PRs containing lots of information and links
- This will also mean that we're going to need only 2 people for an RC bump because the PR will be created by the bot. So the person running the workflow + another person will be enough to review a bump.

# Pushing to rancher/charts & rancher/rancher

EIO provided us with a GH app that can be used (through vault) to create tokens for rancher/rancher and rancher/charts. This allows us to push to those repositories directly and create PRs.

# Credits

A lot of it was taken from the fleet team:
- https://github.com/rancher/fleet/blob/main/.github/workflows/release-against-charts.yml
- https://github.com/rancher/fleet/blob/main/.github/workflows/release-against-rancher.yml
- https://github.com/rancher/fleet/blob/main/.github/scripts/release-against-charts.sh
- https://github.com/rancher/fleet/blob/main/.github/scripts/release-against-rancher.sh

Some notable changes:
- Removed support from unRC and creating a new release entirely. Mostly to simplify, let's start with just bumping RCs which is what we end up spending most of our times on.
- Removed the need to input the chart version number (`104.0.0` in `104.0.0+up0.5.0-rc13`). Instead, we just reuse the one for that release.
- Removed the usage of the [peter-evans/create-pull-request action](https://github.com/peter-evans/create-pull-request). This has been explicitly rejected by the security team so we're not allowed to use it. Instead, using `gh` cli tool is good enough.
- More information in the PR description generated as mentioned above.