### PR TITLE
[v0.5] Use the proper config when fetching mutating webhook configuration

### DIFF
--- a/.github/workflows/scripts/integration-test-ci
+++ b/.github/workflows/scripts/integration-test-ci
@@ -40,6 +40,9 @@ set -e
 echo "Shutting down core rancher"
 kubectl scale deploy rancher -n cattle-system --replicas=0
 kubectl wait pods -l app=rancher --for=delete -n cattle-system
+# Make sure the webhook recreates configurations on startup
+kubectl delete validatingwebhookconfiguration rancher.cattle.io
+kubectl delete mutatingwebhookconfiguration rancher.cattle.io
 
 echo "Uploading new webhook image"
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -262,9 +262,9 @@ func (s *secretHandler) ensureWebhookConfiguration(validatingConfig *v1.Validati
 		}
 	}
 
-	currMutation, err := s.mutatingController.Get(validatingConfig.Name, metav1.GetOptions{})
+	currMutation, err := s.mutatingController.Get(mutatingConfig.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		_, err = s.mutatingController.Create(currMutation)
+		_, err = s.mutatingController.Create(mutatingConfig)
 		if err != nil {
 			return fmt.Errorf("failed to create mutating configuration: %w", err)
 		}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,0 +1,75 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/rancher/wrangler/v3/pkg/generic/fake"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestSecretHandlerEnsureWebhookConfigurationCreate(t *testing.T) {
+	configName := "rancher.cattle.io"
+
+	var (
+		storedValidatingConfig *v1.ValidatingWebhookConfiguration
+		storedMutatingConfig   *v1.MutatingWebhookConfiguration
+	)
+
+	ctrl := gomock.NewController(t)
+	validatingController := fake.NewMockNonNamespacedClientInterface[*v1.ValidatingWebhookConfiguration, *v1.ValidatingWebhookConfigurationList](ctrl)
+	validatingController.EXPECT().Get(configName, gomock.Any()).Return(nil, errors.NewNotFound(schema.GroupResource{Group: v1.GroupName, Resource: "validatingwebhookconfiguration"}, configName)).Times(1)
+	validatingController.EXPECT().Create(gomock.Any()).DoAndReturn(func(obj *v1.ValidatingWebhookConfiguration) (*v1.ValidatingWebhookConfiguration, error) {
+		storedValidatingConfig = obj.DeepCopy()
+		return obj, nil
+	}).Times(1)
+
+	mutatingController := fake.NewMockNonNamespacedClientInterface[*v1.MutatingWebhookConfiguration, *v1.MutatingWebhookConfigurationList](ctrl)
+	mutatingController.EXPECT().Get(configName, gomock.Any()).Return(nil, errors.NewNotFound(schema.GroupResource{Group: v1.GroupName, Resource: "mutatingwebhookconfiguration"}, configName)).Times(1)
+	mutatingController.EXPECT().Create(gomock.Any()).DoAndReturn(func(obj *v1.MutatingWebhookConfiguration) (*v1.MutatingWebhookConfiguration, error) {
+		storedMutatingConfig = obj.DeepCopy()
+		return obj, nil
+	}).Times(1)
+
+	handler := &secretHandler{
+		validatingController: validatingController,
+		mutatingController:   mutatingController,
+	}
+
+	validatingConfig := &v1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: configName,
+		},
+		Webhooks: []v1.ValidatingWebhook{
+			{
+				Name: "rancher.cattle.io.features.management.cattle.io",
+			},
+		},
+	}
+	mutatingConfig := &v1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: configName,
+		},
+		Webhooks: []v1.MutatingWebhook{
+			{
+				Name: "rancher.cattle.io.clusters.provisioning.cattle.io",
+			},
+		},
+	}
+
+	err := handler.ensureWebhookConfiguration(validatingConfig, mutatingConfig)
+	require.NoError(t, err)
+
+	require.NotNil(t, storedValidatingConfig)
+	require.Len(t, storedValidatingConfig.Webhooks, 1)
+	assert.Equal(t, validatingConfig.Webhooks[0].Name, storedValidatingConfig.Webhooks[0].Name)
+
+	require.NotNil(t, storedMutatingConfig)
+	require.Len(t, storedMutatingConfig.Webhooks, 1)
+	assert.Equal(t, mutatingConfig.Webhooks[0].Name, storedMutatingConfig.Webhooks[0].Name)
+}

--- a/scripts/ci
+++ b/scripts/ci
@@ -3,10 +3,10 @@ set -e
 
 cd $(dirname $0)
 
-./validate
-./validate-ci
 ./build
 ./test
+./validate
+./validate-ci
 ./package
 ./package-helm
 ./test-helm

--- a/scripts/ci
+++ b/scripts/ci
@@ -3,10 +3,10 @@ set -e
 
 cd $(dirname $0)
 
-./build
-./test
 ./validate
 ./validate-ci
+./build
+./test
 ./package
 ./package-helm
 ./test-helm


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from other PRs, link them here and describe why they are needed for your solution section. -->
https://github.com/rancher/rancher/issues/42611

## Problem
<!-- Describe the root cause of the issue you are resolving. 
This may include what behavior is observed and why it is not desirable. If this is a new feature, describe why we need it and how it will be used. -->

A wrong variable is used when fetching the mutating webhook configuration, that may lead to the following errors on startup:
```
time="2024-07-18T14:01:43Z" level=error msg="Failed to ensure configuration: failed to create mutating configuration: MutatingWebhookConfiguration.admissionregistration.k8s.io \"\" is invalid: metadata.name: Required value: name or generateName is required"
time="2024-07-18T14:01:43Z" level=error msg="error syncing 'cattle-system/cattle-webhook-ca': handler secrets: failed to create mutating configuration: MutatingWebhookConfiguration.admissionregistration.k8s.io \"\" is invalid: metadata.name: Required value: name or generateName is required, requeuing"
```

## Solution
<!-- Describe what you changed to fix the issue. 
Relate your changes to the original bug/feature and explain why this addresses the issue. -->

Use the right/intended variable.

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [x] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [ ] Docs