### PR TITLE
Don't error if external-rules feature flag is not found

### DIFF
--- a/pkg/auth/roleTemplate.go
+++ b/pkg/auth/roleTemplate.go
@@ -7,6 +7,7 @@ import (
 	v3 "github.com/rancher/webhook/pkg/generated/controllers/management.cattle.io/v3"
 	v1 "github.com/rancher/wrangler/v2/pkg/generated/controllers/rbac/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 const ExternalRulesFeature = "external-rules"
@@ -109,6 +110,9 @@ func (r *RoleTemplateResolver) gatherRules(roleTemplate *rancherv3.RoleTemplate,
 func (r *RoleTemplateResolver) isExternalRulesFeatureFlagEnabled() (bool, error) {
 	f, err := r.features.Get(ExternalRulesFeature)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
 		return false, err
 	}
 	if f.Spec.Value == nil {


### PR DESCRIPTION
Forwardport of rancher/webhook#398 to the release/v0.4 line. 

## Issue: <!-- link the issue or issues this PR resolves here -->
For users running Rancher with an unpinned webhook version, rancher/rancher#46254 may occur.

## Problem
N/A - see rancher/webhook#398.

## Solution
<!-- Describe what you changed to fix the issue. 
N/A - see rancher/webhook#398.

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [ ] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [ ] Docs