### PR TITLE
Stop testing the 'ok' part of a map access.

### DIFF
--- a/pkg/resources/management.cattle.io/v3/setting/validator.go
+++ b/pkg/resources/management.cattle.io/v3/setting/validator.go
@@ -135,7 +135,7 @@ func (a *admitter) validateAgentTLSMode(oldSetting, newSetting v3.Setting) error
 		return nil
 	}
 	if effectiveValue(oldSetting) == "system-store" && effectiveValue(newSetting) == "strict" {
-		if _, force := newSetting.Annotations["cattle.io/force"]; force {
+		if force := newSetting.Annotations["cattle.io/force"]; force == "true" {
 			return nil
 		}
 		clusters, err := a.clusterCache.List(labels.NewSelector())


### PR DESCRIPTION
Verify that the actual value of the annotation is string "true" when checking that it's ok to change the tls-mode from `system-store` to `strict`.

Related to issue [#46189](https://github.com/rancher/rancher/issues/46189)