### PR TITLE
Stop testing the 'ok' part of a map access.

### DIFF
--- a/pkg/resources/management.cattle.io/v3/setting/validator.go
+++ b/pkg/resources/management.cattle.io/v3/setting/validator.go
@@ -135,7 +135,7 @@ func (a *admitter) validateAgentTLSMode(oldSetting, newSetting v3.Setting) error
 		return nil
 	}
 	if effectiveValue(oldSetting) == "system-store" && effectiveValue(newSetting) == "strict" {
-		if _, force := newSetting.Annotations["cattle.io/force"]; force {
+		if force := newSetting.Annotations["cattle.io/force"]; force == "true" {
 			return nil
 		}
 		clusters, err := a.clusterCache.List(labels.NewSelector())

--- a/pkg/resources/management.cattle.io/v3/setting/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/setting/validator_test.go
@@ -312,6 +312,40 @@ func TestValidateAgentTLSMode(t *testing.T) {
 			operation: v1.Update,
 			allowed:   true,
 		},
+		"update forbidden without cluster status and non-true force annotation": {
+			oldSetting: v3.Setting{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "agent-tls-mode",
+				},
+				Default: "system-store",
+			},
+			newSetting: v3.Setting{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "agent-tls-mode",
+					Annotations: map[string]string{
+						"cattle.io/force": "false",
+					},
+				},
+				Default: "strict",
+			},
+			clusters: []*v3.Cluster{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster-1",
+					},
+					Status: v3.ClusterStatus{
+						Conditions: []v3.ClusterCondition{
+							{
+								Type:   "AgentTlsStrictCheck",
+								Status: "False",
+							},
+						},
+					},
+				},
+			},
+			operation: v1.Update,
+			allowed:   false,
+		},
 		"update allowed with cluster status and force annotation": {
 			oldSetting: v3.Setting{
 				ObjectMeta: metav1.ObjectMeta{
@@ -582,8 +616,8 @@ func TestValidateAgentTLSMode(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
 			clusterCache := fake.NewMockNonNamespacedCacheInterface[*v3.Cluster](ctrl)
-			_, force := tc.newSetting.Annotations["cattle.io/force"]
-			if tc.operation == v1.Update && !force && len(tc.clusters) > 0 {
+			force := tc.newSetting.Annotations["cattle.io/force"]
+			if tc.operation == v1.Update && force != "true" && len(tc.clusters) > 0 {
 				clusterCache.EXPECT().List(gomock.Any()).Return(tc.clusters, nil)
 			}
 			if tc.clusterListerFails {


### PR DESCRIPTION
Verify that the actual value of the annotation is string "true" when checking that it's ok to change the tls-mode from `system-store` to `strict`.

Forward port of #456 - see that PR for details.

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [x] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [x] Docs