### PR TITLE
Current dev work is now for rancher 2.10

### DIFF
--- a/charts/rancher-webhook/Chart.yaml
+++ b/charts/rancher-webhook/Chart.yaml
@@ -10,5 +10,5 @@ annotations:
   catalog.cattle.io/release-name: rancher-webhook
   catalog.cattle.io/os: linux
   catalog.cattle.io/permits-os: linux,windows
-  catalog.cattle.io/rancher-version: ">= 2.9.0-0 < 2.10.0-0"
+  catalog.cattle.io/rancher-version: ">= 2.10.0-0 < 2.11.0-0"
   catalog.cattle.io/kube-version: "< 1.31.0-0"


### PR DESCRIPTION
## Issue: 

No related issue. Now that we're doing trunk-based development, the version in the trunk has to specify the version that current trunk work is targeting.