### PR TITLE
Remove the race condition on the ClusterProxyConfig integration test (for release/v0.5)

### DIFF
--- a/tests/integration/clusterProxyConfig_test.go
+++ b/tests/integration/clusterProxyConfig_test.go
@@ -17,7 +17,8 @@ func (m *IntegrationSuite) TestClusterProxyConfig() {
 		Version: "v3",
 		Kind:    "ClusterProxyConfig",
 	}
-	validCreateObj := getObjectToCreate("testclusterproxyconfig")
+	cpcName := "testclusterproxyconfig"
+	validCreateObj := getObjectToCreate(cpcName)
 	client, err := m.clientFactory.ForKind(objGVK)
 	m.Require().NoError(err, "Failed to create client")
 	result := &v3.ClusterProxyConfig{}
@@ -26,6 +27,22 @@ func (m *IntegrationSuite) TestClusterProxyConfig() {
 	// Creating the first CPC should succeed
 	err = client.Create(ctx, validCreateObj.Namespace, validCreateObj, result, metav1.CreateOptions{})
 	m.NoError(err, "Error returned during the creation of a valid clusterProxyConfig")
+
+	// Verify the API knows about the first object before we try to create a second one.
+	// Wait 5 minutes for the object to be created (should be more than ample time)
+	timeout := int64(5 * time.Minute)
+	listOptions := metav1.ListOptions{
+		Watch:          true,
+		TimeoutSeconds: &timeout,
+	}
+	watcher, err := client.Watch(ctx, validCreateObj.Namespace, listOptions)
+	m.Require().NoError(err, "Error returned trying to watch the clusterProxyConfig")
+	defer watcher.Stop()
+
+	receivedEvent, ok := <-watcher.ResultChan()
+	m.Require().True(ok, "The CPC watcher closed before it sent any notifications")
+	m.Require().EqualValues(receivedEvent.Object.GetObjectKind().GroupVersionKind().Kind, "ClusterProxyConfig")
+
 	secondCPC := getObjectToCreate("anotherclusterproxyconfig")
 	// Attempting to create another CPC in the same namespace should fail
 	err = client.Create(ctx, validCreateObj.Namespace, secondCPC, result, metav1.CreateOptions{})


### PR DESCRIPTION
Backport PR 469 from `main`