### PR TITLE
[46452] [2.9] validate data directories

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -361,12 +361,24 @@ When a UserAttribute is updated, the following checks take place:
 
 ### Validation Checks
 
+#### On Create
+
+##### Data Directories
+
+Prevent the creation of new objects with an env var (under `spec.agentEnvVars`) with a name of `CATTLE_AGENT_VAR_DIR`.
+Prevent the creation of new objects with an invalid data directory. An invalid data directory is defined as the 
+following:
+- Is not an absolute path (i.e. does not start with `/`)
+- Attempts to include environment variables (e.g. `$VARIABLE` or `${VARIABLE}`)
+- Attempts to include shell expressions (e.g. `$(command)` or `` `command` ``)
+- Equal to another data directory
+- Attempts to nest another data directory
+
 #### On Update
 
 ##### Data Directories
 
-Prevent the creation of new objects with an env var (under `spec.agentEnvVars`) with a name of `CATTLE_AGENT_VAR_DIR`. 
-On update, also prevent new env vars with this name from being added but allow them to be removed. Rancher will perform 
+On update, prevent new env vars with this name from being added but allow them to be removed. Rancher will perform 
 a one-time migration to move the system-agent data dir definition to the top level field from the `AgentEnvVars` 
 section. A secondary validator will ensure that the effective data directory for the `system-agent` is not different 
 from the one chosen during cluster creation. Additionally, the changing of a data directory for the `system-agent`, 

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/Cluster.md
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/Cluster.md
@@ -1,11 +1,23 @@
 ## Validation Checks
 
+### On Create
+
+#### Data Directories
+
+Prevent the creation of new objects with an env var (under `spec.agentEnvVars`) with a name of `CATTLE_AGENT_VAR_DIR`.
+Prevent the creation of new objects with an invalid data directory. An invalid data directory is defined as the 
+following:
+- Is not an absolute path (i.e. does not start with `/`)
+- Attempts to include environment variables (e.g. `$VARIABLE` or `${VARIABLE}`)
+- Attempts to include shell expressions (e.g. `$(command)` or `` `command` ``)
+- Equal to another data directory
+- Attempts to nest another data directory
+
 ### On Update
 
 #### Data Directories
 
-Prevent the creation of new objects with an env var (under `spec.agentEnvVars`) with a name of `CATTLE_AGENT_VAR_DIR`. 
-On update, also prevent new env vars with this name from being added but allow them to be removed. Rancher will perform 
+On update, prevent new env vars with this name from being added but allow them to be removed. Rancher will perform 
 a one-time migration to move the system-agent data dir definition to the top level field from the `AgentEnvVars` 
 section. A secondary validator will ensure that the effective data directory for the `system-agent` is not different 
 from the one chosen during cluster creation. Additionally, the changing of a data directory for the `system-agent`, 

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/validator_test.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/validator_test.go
@@ -656,12 +656,145 @@ func TestValidateDataDirectories(t *testing.T) {
 					AgentEnvVars: []rkev1.EnvVar{
 						{
 							Name:  "CATTLE_AGENT_VAR_DIR",
-							Value: "a",
+							Value: "/a",
 						},
 					},
 				},
 			},
 			oldCluster:    nil,
+			shouldSucceed: false,
+		},
+		{
+			name:    "CREATE distro data dir is relative",
+			request: &admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{Operation: admissionv1.Create}},
+			cluster: &v1.Cluster{
+				Spec: v1.ClusterSpec{
+					RKEConfig: &v1.RKEConfig{
+						RKEClusterSpecCommon: rkev1.RKEClusterSpecCommon{
+							DataDirectories: rkev1.DataDirectories{
+								K8sDistro: "a",
+							},
+						},
+					},
+				},
+			},
+			shouldSucceed: false,
+		},
+		{
+			name:    "CREATE provisioning data dir is relative",
+			request: &admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{Operation: admissionv1.Create}},
+			cluster: &v1.Cluster{
+				Spec: v1.ClusterSpec{
+					RKEConfig: &v1.RKEConfig{
+						RKEClusterSpecCommon: rkev1.RKEClusterSpecCommon{
+							DataDirectories: rkev1.DataDirectories{
+								Provisioning: "a",
+							},
+						},
+					},
+				},
+			},
+			shouldSucceed: false,
+		},
+		{
+			name:    "CREATE system agent data dir is relative",
+			request: &admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{Operation: admissionv1.Create}},
+			cluster: &v1.Cluster{
+				Spec: v1.ClusterSpec{
+					RKEConfig: &v1.RKEConfig{
+						RKEClusterSpecCommon: rkev1.RKEClusterSpecCommon{
+							DataDirectories: rkev1.DataDirectories{
+								SystemAgent: "a",
+							},
+						},
+					},
+				},
+			},
+			shouldSucceed: false,
+		},
+		{
+			name:    "CREATE distro data dir == provisioning data dir",
+			request: &admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{Operation: admissionv1.Create}},
+			cluster: &v1.Cluster{
+				Spec: v1.ClusterSpec{
+					RKEConfig: &v1.RKEConfig{
+						RKEClusterSpecCommon: rkev1.RKEClusterSpecCommon{
+							DataDirectories: rkev1.DataDirectories{
+								K8sDistro:    "/a",
+								Provisioning: "/a",
+							},
+						},
+					},
+				},
+			},
+			shouldSucceed: false,
+		},
+		{
+			name:    "CREATE distro data dir == system agent data dir",
+			request: &admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{Operation: admissionv1.Create}},
+			cluster: &v1.Cluster{
+				Spec: v1.ClusterSpec{
+					RKEConfig: &v1.RKEConfig{
+						RKEClusterSpecCommon: rkev1.RKEClusterSpecCommon{
+							DataDirectories: rkev1.DataDirectories{
+								K8sDistro:   "/a",
+								SystemAgent: "/a",
+							},
+						},
+					},
+				},
+			},
+			shouldSucceed: false,
+		},
+		{
+			name:    "CREATE provisioning data dir == system agent data dir",
+			request: &admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{Operation: admissionv1.Create}},
+			cluster: &v1.Cluster{
+				Spec: v1.ClusterSpec{
+					RKEConfig: &v1.RKEConfig{
+						RKEClusterSpecCommon: rkev1.RKEClusterSpecCommon{
+							DataDirectories: rkev1.DataDirectories{
+								Provisioning: "/a",
+								SystemAgent:  "/a",
+							},
+						},
+					},
+				},
+			},
+			shouldSucceed: false,
+		},
+		{
+			name:    "CREATE distro data dir contains provisioning data dir",
+			request: &admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{Operation: admissionv1.Create}},
+			cluster: &v1.Cluster{
+				Spec: v1.ClusterSpec{
+					RKEConfig: &v1.RKEConfig{
+						RKEClusterSpecCommon: rkev1.RKEClusterSpecCommon{
+							DataDirectories: rkev1.DataDirectories{
+								K8sDistro:    "/a",
+								Provisioning: "/a/b",
+							},
+						},
+					},
+				},
+			},
+			shouldSucceed: false,
+		},
+		{
+			name:    "CREATE provisioning data dir contains distro data dir",
+			request: &admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{Operation: admissionv1.Create}},
+			cluster: &v1.Cluster{
+				Spec: v1.ClusterSpec{
+					RKEConfig: &v1.RKEConfig{
+						RKEClusterSpecCommon: rkev1.RKEClusterSpecCommon{
+							DataDirectories: rkev1.DataDirectories{
+								K8sDistro:    "/a/b",
+								Provisioning: "/a",
+							},
+						},
+					},
+				},
+			},
 			shouldSucceed: false,
 		},
 		{
@@ -673,7 +806,7 @@ func TestValidateDataDirectories(t *testing.T) {
 					AgentEnvVars: []rkev1.EnvVar{
 						{
 							Name:  "CATTLE_AGENT_VAR_DIR",
-							Value: "a",
+							Value: "/a",
 						},
 					},
 				},
@@ -714,7 +847,7 @@ func TestValidateDataDirectories(t *testing.T) {
 					AgentEnvVars: []rkev1.EnvVar{
 						{
 							Name:  "CATTLE_AGENT_VAR_DIR",
-							Value: "a",
+							Value: "/a",
 						},
 					},
 				},
@@ -725,7 +858,7 @@ func TestValidateDataDirectories(t *testing.T) {
 					AgentEnvVars: []rkev1.EnvVar{
 						{
 							Name:  "CATTLE_AGENT_VAR_DIR",
-							Value: "a",
+							Value: "/a",
 						},
 					},
 				},
@@ -741,7 +874,7 @@ func TestValidateDataDirectories(t *testing.T) {
 					AgentEnvVars: []rkev1.EnvVar{
 						{
 							Name:  "CATTLE_AGENT_VAR_DIR",
-							Value: "a",
+							Value: "/a",
 						},
 					},
 				},
@@ -752,7 +885,7 @@ func TestValidateDataDirectories(t *testing.T) {
 					AgentEnvVars: []rkev1.EnvVar{
 						{
 							Name:  "CATTLE_AGENT_VAR_DIR",
-							Value: "b",
+							Value: "/b",
 						},
 					},
 				},
@@ -767,7 +900,7 @@ func TestValidateDataDirectories(t *testing.T) {
 					RKEConfig: &v1.RKEConfig{
 						RKEClusterSpecCommon: rkev1.RKEClusterSpecCommon{
 							DataDirectories: rkev1.DataDirectories{
-								SystemAgent: "a",
+								SystemAgent: "/a",
 							},
 						},
 					},
@@ -779,7 +912,7 @@ func TestValidateDataDirectories(t *testing.T) {
 					AgentEnvVars: []rkev1.EnvVar{
 						{
 							Name:  "CATTLE_AGENT_VAR_DIR",
-							Value: "a",
+							Value: "/a",
 						},
 					},
 				},
@@ -794,7 +927,7 @@ func TestValidateDataDirectories(t *testing.T) {
 					RKEConfig: &v1.RKEConfig{
 						RKEClusterSpecCommon: rkev1.RKEClusterSpecCommon{
 							DataDirectories: rkev1.DataDirectories{
-								SystemAgent: "a",
+								SystemAgent: "/a",
 							},
 						},
 					},
@@ -805,7 +938,7 @@ func TestValidateDataDirectories(t *testing.T) {
 					RKEConfig: &v1.RKEConfig{
 						RKEClusterSpecCommon: rkev1.RKEClusterSpecCommon{
 							DataDirectories: rkev1.DataDirectories{
-								SystemAgent: "b",
+								SystemAgent: "/b",
 							},
 						},
 					},
@@ -821,7 +954,7 @@ func TestValidateDataDirectories(t *testing.T) {
 					RKEConfig: &v1.RKEConfig{
 						RKEClusterSpecCommon: rkev1.RKEClusterSpecCommon{
 							DataDirectories: rkev1.DataDirectories{
-								Provisioning: "a",
+								Provisioning: "/a",
 							},
 						},
 					},
@@ -832,7 +965,7 @@ func TestValidateDataDirectories(t *testing.T) {
 					RKEConfig: &v1.RKEConfig{
 						RKEClusterSpecCommon: rkev1.RKEClusterSpecCommon{
 							DataDirectories: rkev1.DataDirectories{
-								Provisioning: "b",
+								Provisioning: "/b",
 							},
 						},
 					},
@@ -848,7 +981,7 @@ func TestValidateDataDirectories(t *testing.T) {
 					RKEConfig: &v1.RKEConfig{
 						RKEClusterSpecCommon: rkev1.RKEClusterSpecCommon{
 							DataDirectories: rkev1.DataDirectories{
-								K8sDistro: "a",
+								K8sDistro: "/a",
 							},
 						},
 					},
@@ -859,7 +992,7 @@ func TestValidateDataDirectories(t *testing.T) {
 					RKEConfig: &v1.RKEConfig{
 						RKEClusterSpecCommon: rkev1.RKEClusterSpecCommon{
 							DataDirectories: rkev1.DataDirectories{
-								K8sDistro: "b",
+								K8sDistro: "/b",
 							},
 						},
 					},
@@ -1246,6 +1379,129 @@ func Test_validateAgentDeploymentCustomization(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := validateAgentDeploymentCustomization(tt.args.customization, tt.args.path)
 			tt.validateFunc(t, got)
+		})
+	}
+}
+
+func TestValidateDataDirectoryFormat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		dir      string
+		expected bool
+	}{
+		{
+			name:     "relative",
+			dir:      "home",
+			expected: false,
+		},
+		{
+			name:     "trailing slash",
+			dir:      "/home/",
+			expected: false,
+		},
+		{
+			name:     "env var",
+			dir:      "/$HOME",
+			expected: false,
+		},
+		{
+			name:     "env var",
+			dir:      "/${HOME}",
+			expected: false,
+		},
+		{
+			name:     "expr",
+			dir:      "/`pwd`",
+			expected: false,
+		},
+		{
+			name:     "expr",
+			dir:      "/$(pwd)",
+			expected: false,
+		},
+		{
+			name:     "current directory",
+			dir:      "/./tmp",
+			expected: false,
+		},
+		{
+			name:     "current directory",
+			dir:      "/tmp/.",
+			expected: false,
+		},
+		{
+			name:     "parent directory",
+			dir:      "/tmp/../tmp",
+			expected: false,
+		},
+		{
+			name:     "current directory",
+			dir:      "/tmp/..",
+			expected: false,
+		},
+		{
+			name:     "valid",
+			dir:      "/tmp",
+			expected: true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			response := validateDataDirectoryFormat(tt.dir, "Test")
+			assert.Equal(t, tt.expected, response.Allowed)
+		})
+	}
+}
+
+func TestValidateDataDirectoryHierarchy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		dataDirs map[string]string
+		expected bool
+	}{
+		{
+			name: "equal paths",
+			dataDirs: map[string]string{
+				"a": "/a",
+				"b": "/a",
+			},
+			expected: false,
+		},
+		{
+			name: "nested paths",
+			dataDirs: map[string]string{
+				"a": "/a",
+				"b": "/a/b",
+			},
+			expected: false,
+		},
+		{
+			name: "nested paths",
+			dataDirs: map[string]string{
+				"a": "/a/b",
+				"b": "/a",
+			},
+			expected: false,
+		},
+		{
+			name: "distinct paths",
+			dataDirs: map[string]string{
+				"a": "/a",
+				"b": "/b",
+			},
+			expected: true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			response := validateDataDirectoryHierarchy(tt.dataDirs)
+			assert.Equal(t, tt.expected, response.Allowed)
 		})
 	}
 }


### PR DESCRIPTION
Backport of https://github.com/rancher/webhook/pull/474

## Issue: <!-- link the issue or issues this PR resolves here --> rancher/rancher#46452
<!-- If your PR depends on changes from other PRs, link them here and describe why they are needed for your solution section. -->
## Problem
<!-- Describe the root cause of the issue you are resolving. 
This may include what behavior is observed and why it is not desirable. If this is a new feature, describe why we need it and how it will be used. -->

Data directories were not validated on creation. The should be validated based on the following criteria:
- Absolute paths (start with /)
- Clean (not contain env vars, shell expressions, ., or ..)
- Not set to the same path (no duplicates are allowed between any pairs of paths out of 3 configurable)
- Not nested one within another

## Solution
<!-- Describe what you changed to fix the issue. 
Relate your changes to the original bug/feature and explain why this addresses the issue. -->

Implement the above checks with the provisioning cluster validator

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [x] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [x] Docs