### PR TITLE
Fix webhook not deployed in CI

### DIFF
--- a/.github/workflows/scripts/start-rancher.sh
+++ b/.github/workflows/scripts/start-rancher.sh
@@ -24,4 +24,17 @@ kubectl rollout status --namespace cert-manager deploy/cert-manager --timeout 1m
 
 # Chart based
 
-helm upgrade --install rancher "$CHART_PATH" --namespace cattle-system --set replicas=1 --set hostname=localhost --wait --timeout=10m --create-namespace --version "$VERSION" --set rancherImage=rancher/rancher --set rancherImageTag="$RANCHER_IMAGE_TAG"
+# Set empty CATTLE_RANCHER_WEBHOOK_VERSION to install any webhook that's in the
+# bundled charts index
+helm upgrade \
+    --install rancher "$CHART_PATH" \
+    --namespace cattle-system \
+    --wait --timeout=10m \
+    --create-namespace \
+    --version "$VERSION" \
+    --set replicas=1 \
+    --set hostname=localhost \
+    --set rancherImage=rancher/rancher \
+    --set rancherImageTag="$RANCHER_IMAGE_TAG" \
+    --set 'extraEnv[0].name=CATTLE_RANCHER_WEBHOOK_VERSION' \
+    --set "extraEnv[0].value="


### PR DESCRIPTION
# Issue https://github.com/rancher/rancher/issues/47062

The deployment logic in r/r is a little complex for webhook.

Rancher has the rancher-webhook charts bundled in its image. Depending on timing and how well our git mirror is doing, Rancher might try to deploy the rancher-webhook chart embedded in the image, or it might deploy the chart pulled from the charts repo.

When it's pulling from the charts repo, then the webhook RC version in `CATTLE_RANCHER_WEBHOOK_VERSION` might be stale compared to the on in the charts repo. This leads to Rancher not being able to deploy webhook.

When using the bundled rancher-webhook chart, there's a very small chance that the bundled repo has a newer version of rancher-webhook than the one set in `CATTLE_RANCHER_WEBHOOK_VERSION`.

For the purpose of setting up Rancher for our tests, we really don't care what webhook version is installed because we'll be deploying the one from the PR anyway. So to eliminate these issues, we simply set `CATTLE_RANCHER_WEBHOOK_VERSION` to empty `""`. Rancher will then deploy the latest version of webhook it can find in the index chart, whether its from bundled or from git mirror.