### PR TITLE
Add backport GHA workflow

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,0 +1,42 @@
+name: Backport PR
+on:
+  workflow_dispatch:
+    inputs:
+      pull_request:
+        description: "Pull request number (eg: 123) or link to PR (eg: https://github.com/rancher/webhook/pull/123) "
+        required: true
+      cherry_pick:
+        description: "If true, the squashed commit from the PR will be cherry-picked"
+        type: boolean
+        required: true
+        default: "true"
+
+permissions:
+  contents: read
+
+env:
+  PULL_REQUEST: ${{ github.event.inputs.pull_request }}
+  CHERRY_PICK: ${{ github.event.inputs.cherry_pick }}
+  REPO: ${{ github.repository }}
+
+jobs:
+  backport-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: webhook
+          # depth: 0
+
+      - name: Run backport script
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ref=$(echo "$GITHUB_REF" | sed "s|refs/heads/||")
+          cd webhook
+          git config --global user.email "webhook@example.com"
+          git config --global user.name "tomleb webhook Bot"
+          ./.github/workflows/scripts/backport.sh "$PULL_REQUEST" "$ref" "$CHERRY_PICK" "$REPO"

--- a/.github/workflows/scripts/backport.sh
+++ b/.github/workflows/scripts/backport.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+
+set -e
+
+PULL_REQUEST=$1
+TARGET_BRANCH=$2
+CHERRY_PICK=$3
+REPO=$4
+
+if [ -z "$PULL_REQUEST" ] || [ -z "$TARGET_BRANCH" ] || [ -z "$CHERRY_PICK" ] || [ -z "$REPO" ]; then
+	echo "Usage: $0 <PR number> <target branch> <true|false> <owner/repo>" 1>&2
+	exit 1
+fi
+
+GITHUB_TRIGGERING_ACTOR=${GITHUB_TRIGGERING_ACTOR:-}
+
+repo_name=$(echo "$REPO" | cut -d/ -f2)
+repo_owner=$(echo "$REPO" | cut -d/ -f1)
+
+target_slug=$(echo "$TARGET_BRANCH" | sed "s|/|-|")
+branch_name="backport-$PULL_REQUEST-$target_slug-$$"
+
+pr_link=https://github.com/$REPO/pull/$PULL_REQUEST
+pr_number=$PULL_REQUEST
+
+# Separate calls because otherwise it was creating trouble.. can probably be fixed
+state=$(gh pr view "$pr_number" --json state --jq '.state')
+old_title=$(gh pr view "$pr_number" --json title --jq '.title')
+old_body=$(gh pr view "$pr_number" --json body --jq '.body')
+
+if [ $state != "MERGED" ]; then
+	echo "PR $pr_number ($pr_link) not yet merged, cannot backport" 1>&2
+	exit 1
+fi
+
+git fetch origin "$TARGET_BRANCH:$branch_name"
+git switch "$branch_name"
+
+committed_something=""
+
+if [ "$CHERRY_PICK" = "true" ]; then
+	git fetch origin "pull/$pr_number/head:to-cherry-pick"
+	commit=$(git rev-parse to-cherry-pick)
+	if git cherry-pick --allow-empty "$commit"; then
+		committed_something="true"
+	else
+		echo "Cherry-pick failed, skipping" 1>&2
+		git cherry-pick --abort
+	fi
+fi
+
+if [ -z "$committed_something" ]; then
+	# Github won't allow us to create a PR without any changes so we're making an empty commit here
+	git commit --allow-empty -m "Please amend this commit"
+fi
+
+git push -u origin "$branch_name"
+
+generated_by=""
+if [ -n "$GITHUB_TRIGGERING_ACTOR" ]; then
+    generated_by=$(cat <<EOF
+The workflow was triggered by @$GITHUB_TRIGGERING_ACTOR.
+EOF
+)
+fi
+
+title=$(echo "[$TARGET_BRANCH] $old_title")
+body=$(cat <<EOF
+**Backport**
+
+Backport of $pr_link
+
+You can make changes to this PR with the following command:
+
+\`\`\`
+git clone https://github.com/$REPO
+cd $repo_name
+git switch $branch_name
+\`\`\`
+
+$generated_by
+
+---
+
+$old_body
+EOF
+)
+
+gh pr create \
+  --title "$title" \
+  --body "$body" \
+  --repo "$REPO" \
+  --head "$repo_owner:$branch_name" \
+  --base "$TARGET_BRANCH" \
+  --draft


### PR DESCRIPTION
# Context

Backporting PRs to previous branch is pretty tedious. You have to:
- git fetch
- Checkout the target branch
- Create a new backport branch
- Find the commit hash of the merged PR
- cherry-pick the commit
- Fix or adjust the commit if necessary
- git push
- Go to the repository in your browser
- Create a pull request
  - Usually the name of the branch will look something like `[<branch>] <title of PR to backport>`
  - Usually the description will be the same because the changes are the same. A backlink to the original PR is useful for reviewers so personally I add it whenever I think about it.
  - ^This is tedious

# Summary

This PR is just an idea of a workflow that does all of this for us. The idea is you can just click on the `Backport PR` GHA workflow. Here's a screenshot of the workflow where the branch selected would be the target, the user must specify which PR number to backport and whether or not to cherry-pick the commit (the idea here is that we would still gain from everything even if we create an empty commit that can be edited).

![image](https://github.com/user-attachments/assets/37e99eeb-88c2-40c7-b0b0-d7b9fa13c06f)

Here's an example result from just running the script: https://github.com/rancher/webhook/pull/508.

Here's an example result from running in GHA: https://github.com/tomleb/rancher-webhook/pull/11. Pretty much the same thing.

 **Note:** I'd like some input from the team to know whether that's something they'd be interested in. I can totally run this script locally but if the whole team can benefit from it then why not.

**Note:** This could also be in the form of a github bot that reacts to comments, though that involves more work. (eg: Image just having to write `/backport release/v0.4` in a merged PR.

**Note:** The script only supports squash commits. Now that squashed commits are enforced, this shouldn't be an issue in the future.