### PR TITLE
feat(setting): add validation for auth-user-session-idle-ttl-minutes

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -418,6 +418,7 @@ When settings are created or updated, the following common checks take place:
 - If set, `user-last-login-default` must be a date time according to RFC3339 (e.g. `2023-11-29T00:00:00Z`).
 - If set, `user-retention-cron` must be a valid standard cron expression (e.g. `0 0 * * 0`).
 - The `auth-user-session-ttl-minutes` must be a positive integer and can't be greater than `disable-inactive-user-after` or `delete-inactive-user-after` if those values are set.
+- The `auth-user-session-idle-ttl-minutes` must be a positive integer and can't be greater than `auth-user-session-ttl-minutes`.
 
 #### Update
 

--- a/pkg/resources/management.cattle.io/v3/setting/Setting.md
+++ b/pkg/resources/management.cattle.io/v3/setting/Setting.md
@@ -9,7 +9,7 @@ When settings are created or updated, the following common checks take place:
 - If set, `user-last-login-default` must be a date time according to RFC3339 (e.g. `2023-11-29T00:00:00Z`).
 - If set, `user-retention-cron` must be a valid standard cron expression (e.g. `0 0 * * 0`).
 - The `auth-user-session-ttl-minutes` must be a positive integer and can't be greater than `disable-inactive-user-after` or `delete-inactive-user-after` if those values are set.
-- The `auth-user-session-idle-ttl-minutes` must be a positive integer and can't be greater than `auth-user-session-ttl-minutes` and has to be >= 1 minute.
+- The `auth-user-session-idle-ttl-minutes` must be a positive integer and can't be greater than `auth-user-session-ttl-minutes`.
 
 ### Update
 

--- a/pkg/resources/management.cattle.io/v3/setting/Setting.md
+++ b/pkg/resources/management.cattle.io/v3/setting/Setting.md
@@ -9,6 +9,7 @@ When settings are created or updated, the following common checks take place:
 - If set, `user-last-login-default` must be a date time according to RFC3339 (e.g. `2023-11-29T00:00:00Z`).
 - If set, `user-retention-cron` must be a valid standard cron expression (e.g. `0 0 * * 0`).
 - The `auth-user-session-ttl-minutes` must be a positive integer and can't be greater than `disable-inactive-user-after` or `delete-inactive-user-after` if those values are set.
+- The `auth-user-session-idle-ttl-minutes` must be a positive integer and can't be greater than `auth-user-session-ttl-minutes` and has to be >= 1 minute.
 
 ### Update
 

--- a/pkg/resources/management.cattle.io/v3/setting/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/setting/validator_test.go
@@ -1275,6 +1275,12 @@ func (s *SettingSuite) validateAuthUserSessionTTLIdleMinutes(op v1.Operation, t 
 			allowed:   false,
 		},
 		{
+			name:      "value cannot be 0.5",
+			value:     "0.5",
+			mockSetup: func() {},
+			allowed:   false,
+		},
+		{
 			name:      "value cannot be a char",
 			value:     "A",
 			mockSetup: func() {},


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/45931
This depends on: https://github.com/rancher/rancher/pull/48778 to be merged and refers to the following RFC: https://docs.google.com/document/d/1jN2faXl9FEb2E_9Ohm7uBrrVwuwnIj4HORiL4Wb9Udw/edit?tab=t.0
This PR adds validation functionality to the webhook, for a new user attribute: `auth-user-session-idle-ttl-minutes`.
This parameter differs from the existing `auth-user-session-ttl-minutes` as the former tracks UI activity such as mouse clicks and keystrokes, while the latter is a timer for user session.

## Problem
Rancher has `auth-user-session-ttl-minutes` to set a max length a UI session (16hrs) can last, where has user is idle for a specific time and come back still session is valid now. i.e., There is no configurable parameter to set the idle session timeout.

## Solution
For rancher/webhook I developed the validation function to be added to the validating webhook.
This will validate the user input for `auth-user-session-idle-ttl-minutes`, the new configurable parameter to set the idle session duration on the UI.

## How to test it
Prerequisites: k3d running, with rancher instance up.
Build the branch:
```
make
```
Setup ngrok as follow:
```
ngrok http https://localhost:9443
```
Export the variables needed by the webhook and run it:
```
export KUBECONFIG=<rancher_kube_config>
export CATTLE_WEBHOOK_URL="https://<NGROK_URL>.ngrok.io"
./bin/webhook
```
Check with `kubectl` that the webhook is behaving in the right way, by changing the `value` field randomly:
```
kubectl edit settings auth-user-session-idle-ttl-minutes
```
## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [x] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [x] Docs