### PR TITLE
Add checks for annotation to opt out of cluster owner RBAC

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -56,7 +56,7 @@ and the secret has roles or role bindings dependent on it.
 For all secrets of type `provisioning.cattle.io/cloud-credential`, 
 places a `field.cattle.io/creatorId` annotation with the name of the user as the value.
 
-If `field.cattle.io/noCreatorRBAC` annotation is set, `field.cattle.io/creatorId` does not get set.
+If `field.cattle.io/no-creator-rbac` annotation is set, `field.cattle.io/creatorId` does not get set.
 
 #### On delete
 
@@ -75,7 +75,7 @@ When a cluster is created and `field.cattle.io/creator-principal-name` annotatio
 
 When a cluster is updated `field.cattle.io/creator-principal-name` and `field.cattle.io/creatorId` annotations must stay the same or removed.
 
-If `field.cattle.io/noCreatorRBAC` annotation is set, `field.cattle.io/creatorId` cannot be set.
+If `field.cattle.io/no-creator-rbac` annotation is set, `field.cattle.io/creatorId` cannot be set.
 
 ## ClusterProxyConfig 
 
@@ -399,7 +399,7 @@ When a UserAttribute is updated, the following checks take place:
 
 The annotation `field.cattle.io/creatorId` must be set to the Username of the User that initiated the request.
 
-If `field.cattle.io/noCreatorRBAC` annotation is set, `field.cattle.io/creatorId` cannot be set.
+If `field.cattle.io/no-creator-rbac` annotation is set, `field.cattle.io/creatorId` cannot be set.
 
 ##### Data Directories
 
@@ -418,7 +418,7 @@ following:
 
 The annotation `field.cattle.io/creatorId` is cannot be changed, but it can be removed.
 
-If `field.cattle.io/noCreatorRBAC` annotation is set, `field.cattle.io/creatorId` cannot be set.
+If `field.cattle.io/no-creator-rbac` annotation is set, `field.cattle.io/creatorId` cannot be set.
 
 ##### Data Directories
 
@@ -434,7 +434,7 @@ kubernetes distro (RKE2/K3s), and CAPR components is also prohibited.
 
 When a cluster is created `field.cattle.io/creatorId` is set to the Username from the request.
 
-If `field.cattle.io/noCreatorRBAC` annotation is set, `field.cattle.io/creatorId` does not get set.
+If `field.cattle.io/no-creator-rbac` annotation is set, `field.cattle.io/creatorId` does not get set.
 
 #### On Update
 
@@ -491,7 +491,7 @@ The annotation `field.cattle.io/creatorId` must be set to the Username of the Us
 
 The annotation `field.cattle.io/creatorId` is cannot be changed, but it can be removed.
 
-If `field.cattle.io/noCreatorRBAC` annotation is set, `field.cattle.io/creatorId` cannot be set.
+If `field.cattle.io/no-creator-rbac` annotation is set, `field.cattle.io/creatorId` cannot be set.
 
 ### Mutation Checks
 
@@ -499,4 +499,4 @@ If `field.cattle.io/noCreatorRBAC` annotation is set, `field.cattle.io/creatorId
 
 When a cluster is created `field.cattle.io/creatorId` is set to the Username from the request.
 
-If `field.cattle.io/noCreatorRBAC` annotation is set, `field.cattle.io/creatorId` does not get set.
+If `field.cattle.io/no-creator-rbac` annotation is set, `field.cattle.io/creatorId` does not get set.

--- a/docs.md
+++ b/docs.md
@@ -56,6 +56,8 @@ and the secret has roles or role bindings dependent on it.
 For all secrets of type `provisioning.cattle.io/cloud-credential`, 
 places a `field.cattle.io/creatorId` annotation with the name of the user as the value.
 
+If `field.cattle.io/noCreatorRBAC` annotation is set, `field.cattle.io/creatorId` does not get set.
+
 #### On delete
 
 Checks if there are any RoleBindings owned by this secret which provide access to a role granting access to this secret.
@@ -72,6 +74,8 @@ If yes, the webhook redacts the role, so that it only grants a deletion permissi
 When a cluster is created and `field.cattle.io/creator-principal-name` annotation is set then `field.cattle.io/creatorId` annotation must be set as well. The value of `field.cattle.io/creator-principal-name` should match the creator's user principal id.
 
 When a cluster is updated `field.cattle.io/creator-principal-name` and `field.cattle.io/creatorId` annotations must stay the same or removed.
+
+If `field.cattle.io/noCreatorRBAC` annotation is set, `field.cattle.io/creatorId` cannot be set.
 
 ## ClusterProxyConfig 
 
@@ -391,6 +395,12 @@ When a UserAttribute is updated, the following checks take place:
 
 #### On Create
 
+##### Creator ID Annotation
+
+The annotation `field.cattle.io/creatorId` must be set to the Username of the User that initiated the request.
+
+If `field.cattle.io/noCreatorRBAC` annotation is set, `field.cattle.io/creatorId` cannot be set.
+
 ##### Data Directories
 
 Prevent the creation of new objects with an env var (under `spec.agentEnvVars`) with a name of `CATTLE_AGENT_VAR_DIR`.
@@ -404,6 +414,12 @@ following:
 
 #### On Update
 
+##### Creator ID Annotation
+
+The annotation `field.cattle.io/creatorId` is cannot be changed, but it can be removed.
+
+If `field.cattle.io/noCreatorRBAC` annotation is set, `field.cattle.io/creatorId` cannot be set.
+
 ##### Data Directories
 
 On update, prevent new env vars with this name from being added but allow them to be removed. Rancher will perform 
@@ -413,6 +429,12 @@ from the one chosen during cluster creation. Additionally, the changing of a dat
 kubernetes distro (RKE2/K3s), and CAPR components is also prohibited.
 
 ### Mutation Checks
+
+#### On Create
+
+When a cluster is created `field.cattle.io/creatorId` is set to the Username from the request.
+
+If `field.cattle.io/noCreatorRBAC` annotation is set, `field.cattle.io/creatorId` does not get set.
 
 #### On Update
 
@@ -456,3 +478,25 @@ Users cannot update or remove the following label after it has been added:
 #### Invalid Fields - Update
 Users cannot update or remove the following label after it has been added:
 - authz.management.cattle.io/grb-owner
+
+# rke-machine-config.cattle.io/v1 
+
+## MachineConfig 
+
+### Validation Checks
+
+#### Creator ID Annotation
+
+The annotation `field.cattle.io/creatorId` must be set to the Username of the User that initiated the request.
+
+The annotation `field.cattle.io/creatorId` is cannot be changed, but it can be removed.
+
+If `field.cattle.io/noCreatorRBAC` annotation is set, `field.cattle.io/creatorId` cannot be set.
+
+### Mutation Checks
+
+#### Creator ID Annotion
+
+When a cluster is created `field.cattle.io/creatorId` is set to the Username from the request.
+
+If `field.cattle.io/noCreatorRBAC` annotation is set, `field.cattle.io/creatorId` does not get set.

--- a/docs.md
+++ b/docs.md
@@ -253,6 +253,8 @@ When a project is created and `field.cattle.io/creator-principal-name` annotatio
 
 When a project is updated `field.cattle.io/creator-principal-name` and `field.cattle.io/creatorId` annotations must stay the same or removed.
 
+If `field.cattle.io/no-creator-rbac` annotation is set, `field.cattle.io/creatorId` cannot be set.
+
 ### Mutations
 
 #### On create
@@ -416,7 +418,7 @@ following:
 
 ##### Creator ID Annotation
 
-The annotation `field.cattle.io/creatorId` is cannot be changed, but it can be removed.
+The annotation `field.cattle.io/creatorId` cannot be changed, but it can be removed.
 
 If `field.cattle.io/no-creator-rbac` annotation is set, `field.cattle.io/creatorId` cannot be set.
 
@@ -489,7 +491,7 @@ Users cannot update or remove the following label after it has been added:
 
 The annotation `field.cattle.io/creatorId` must be set to the Username of the User that initiated the request.
 
-The annotation `field.cattle.io/creatorId` is cannot be changed, but it can be removed.
+The annotation `field.cattle.io/creatorId` cannot be changed, but it can be removed.
 
 If `field.cattle.io/no-creator-rbac` annotation is set, `field.cattle.io/creatorId` cannot be set.
 

--- a/pkg/auth/escalation.go
+++ b/pkg/auth/escalation.go
@@ -19,13 +19,6 @@ import (
 	"k8s.io/kubernetes/pkg/registry/rbac/validation"
 )
 
-const (
-	// CreatorIDAnn is an annotation key for the id of the creator.
-	CreatorIDAnn = "field.cattle.io/creatorId"
-	// CreatorPrincipalNameAnn is an annotation key for the principal name of the creator.
-	CreatorPrincipalNameAnn = "field.cattle.io/creator-principal-name"
-)
-
 // RequestUserHasVerb checks if the user associated with the context has a given verb on a given gvr for a specified name/namespace
 func RequestUserHasVerb(request *admission.Request, gvr schema.GroupVersionResource, sar authorizationv1.SubjectAccessReviewInterface, verb, name, namespace string) (bool, error) {
 	extras := map[string]v1.ExtraValue{}

--- a/pkg/resources/common/common.go
+++ b/pkg/resources/common/common.go
@@ -12,6 +12,13 @@ import (
 	"k8s.io/kubernetes/pkg/registry/rbac/validation"
 )
 
+const (
+	// CreatorIDAnn is an annotation key for the id of the creator.
+	CreatorIDAnn = "field.cattle.io/creatorId"
+	// CreatorPrincipalNameAnn is an annotation key for the principal name of the creator.
+	CreatorPrincipalNameAnn = "field.cattle.io/creator-principal-name"
+)
+
 // ConvertAuthnExtras converts authnv1 type extras to authzv1 extras. Technically these are both
 // type alias to string, so the conversion is straightforward
 func ConvertAuthnExtras(extra map[string]authnv1.ExtraValue) map[string]authzv1.ExtraValue {

--- a/pkg/resources/common/common.go
+++ b/pkg/resources/common/common.go
@@ -17,6 +17,8 @@ const (
 	CreatorIDAnn = "field.cattle.io/creatorId"
 	// CreatorPrincipalNameAnn is an annotation key for the principal name of the creator.
 	CreatorPrincipalNameAnn = "field.cattle.io/creator-principal-name"
+	// NoCreatorRBACAnn is an annotation key to indicate that a cluster doesn't need
+	NoCreatorRBACAnn = "field.cattle.io/noCreatorRBAC"
 )
 
 // ConvertAuthnExtras converts authnv1 type extras to authzv1 extras. Technically these are both

--- a/pkg/resources/common/common.go
+++ b/pkg/resources/common/common.go
@@ -18,7 +18,7 @@ const (
 	// CreatorPrincipalNameAnn is an annotation key for the principal name of the creator.
 	CreatorPrincipalNameAnn = "field.cattle.io/creator-principal-name"
 	// NoCreatorRBACAnn is an annotation key to indicate that a cluster doesn't need
-	NoCreatorRBACAnn = "field.cattle.io/noCreatorRBAC"
+	NoCreatorRBACAnn = "field.cattle.io/no-creator-rbac"
 )
 
 // ConvertAuthnExtras converts authnv1 type extras to authzv1 extras. Technically these are both

--- a/pkg/resources/common/mutation.go
+++ b/pkg/resources/common/mutation.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/rancher/webhook/pkg/admission"
-	"github.com/rancher/webhook/pkg/auth"
 	"github.com/rancher/webhook/pkg/patch"
 	v1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,7 +16,7 @@ func SetCreatorIDAnnotation(request *admission.Request, response *v1.AdmissionRe
 	if annotations == nil {
 		annotations = map[string]string{}
 	}
-	annotations[auth.CreatorIDAnn] = request.UserInfo.Username
+	annotations[CreatorIDAnn] = request.UserInfo.Username
 	newObj.SetAnnotations(annotations)
 	if err := patch.CreatePatch(obj.Raw, newObj, response); err != nil {
 		return fmt.Errorf("failed to create patch: %w", err)

--- a/pkg/resources/common/mutation.go
+++ b/pkg/resources/common/mutation.go
@@ -1,25 +1,23 @@
 package common
 
 import (
-	"fmt"
-
 	"github.com/rancher/webhook/pkg/admission"
-	"github.com/rancher/webhook/pkg/patch"
-	v1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // SetCreatorIDAnnotation sets the creatorID Annotation on the newObj based  on the user specified in the request.
-func SetCreatorIDAnnotation(request *admission.Request, response *v1.AdmissionResponse, obj runtime.RawExtension, newObj metav1.Object) error {
+// If the noCreatorRBAC annotation is set, don't set the creator
+func SetCreatorIDAnnotation(request *admission.Request, newObj metav1.Object) {
 	annotations := newObj.GetAnnotations()
 	if annotations == nil {
 		annotations = map[string]string{}
 	}
+
+	// NoCreatorRBACAnn indicates we want to opt out of the CreatorIDAnn
+	if _, ok := annotations[NoCreatorRBACAnn]; ok {
+		return
+	}
+
 	annotations[CreatorIDAnn] = request.UserInfo.Username
 	newObj.SetAnnotations(annotations)
-	if err := patch.CreatePatch(obj.Raw, newObj, response); err != nil {
-		return fmt.Errorf("failed to create patch: %w", err)
-	}
-	return nil
 }

--- a/pkg/resources/common/mutation.go
+++ b/pkg/resources/common/mutation.go
@@ -7,8 +7,8 @@ import (
 
 // SetCreatorIDAnnotation sets the creatorID Annotation on the newObj based  on the user specified in the request.
 // If the noCreatorRBAC annotation is set, don't set the creator
-func SetCreatorIDAnnotation(request *admission.Request, newObj metav1.Object) {
-	annotations := newObj.GetAnnotations()
+func SetCreatorIDAnnotation(request *admission.Request, obj metav1.Object) {
+	annotations := obj.GetAnnotations()
 	if annotations == nil {
 		annotations = map[string]string{}
 	}
@@ -19,5 +19,5 @@ func SetCreatorIDAnnotation(request *admission.Request, newObj metav1.Object) {
 	}
 
 	annotations[CreatorIDAnn] = request.UserInfo.Username
-	newObj.SetAnnotations(annotations)
+	obj.SetAnnotations(annotations)
 }

--- a/pkg/resources/common/mutation_test.go
+++ b/pkg/resources/common/mutation_test.go
@@ -1,0 +1,72 @@
+package common
+
+import (
+	"testing"
+
+	v1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	"github.com/rancher/webhook/pkg/admission"
+	"github.com/stretchr/testify/assert"
+	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSetCreatorIDAnnotation(t *testing.T) {
+	tests := []struct {
+		name        string
+		username    string
+		cluster     v1.Cluster
+		annotations map[string]string
+	}{
+		{
+			name:     "add creatorID to nil annotations",
+			username: "testUser",
+			cluster:  v1.Cluster{},
+			annotations: map[string]string{
+				CreatorIDAnn: "testUser",
+			},
+		},
+		{
+			name:     "add creatorID to existing annotations",
+			username: "testUser",
+			cluster: v1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"existingAnno": "test",
+					},
+				},
+			},
+			annotations: map[string]string{
+				"existingAnno": "test",
+				CreatorIDAnn:   "testUser",
+			},
+		},
+		{
+			name:     "don't add creatorID if noCreatorRBAC is set",
+			username: "testUser",
+			cluster: v1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						NoCreatorRBACAnn: "true",
+					},
+				},
+			},
+			annotations: map[string]string{
+				NoCreatorRBACAnn: "true",
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UserInfo: authenticationv1.UserInfo{
+						Username: test.username,
+					},
+				},
+			}
+			SetCreatorIDAnnotation(&req, &test.cluster)
+			assert.Equal(t, test.annotations, test.cluster.GetAnnotations())
+		})
+	}
+}

--- a/pkg/resources/common/validation.go
+++ b/pkg/resources/common/validation.go
@@ -27,9 +27,9 @@ func CheckCreatorID(request *admission.Request, oldObj, newObj metav1.Object) *m
 	newAnnotations := newObj.GetAnnotations()
 
 	if _, ok := newAnnotations[NoCreatorRBACAnn]; ok {
-		// if the NoCreatorRBAC annotation exists, the creatorID annotation must not exist
+		// if the no-creator-rbac annotation exists, the creatorID annotation must not exist
 		if _, ok := newAnnotations[CreatorIDAnn]; ok {
-			status.Message = "cannot have creatorID annotation when noCreatorRBAC is set"
+			status.Message = "cannot have creatorID annotation when no-creator-rbac is set"
 			return status
 		}
 		return nil
@@ -121,5 +121,18 @@ func CheckCreatorAnnotationsOnUpdate(oldObj, newObj metav1.Object) *field.Error 
 		}
 	}
 
+	return nil
+}
+
+// CheckCreatorIDAndNoCreatorRBAC checks that only one of no-creator-rbac or creatorID annotation is set
+func CheckCreatorIDAndNoCreatorRBAC(obj metav1.Object) *field.Error {
+	annotations := obj.GetAnnotations()
+
+	if _, ok := annotations[NoCreatorRBACAnn]; ok {
+		// if the no-creator-rbac annotation exists, the creatorID annotation must not exist
+		if _, ok := annotations[CreatorIDAnn]; ok {
+			return field.Forbidden(annotationsFieldPath, fmt.Sprintf("cannot have both %s and %s annotation set", NoCreatorRBACAnn, CreatorIDAnn))
+		}
+	}
 	return nil
 }

--- a/pkg/resources/common/validation.go
+++ b/pkg/resources/common/validation.go
@@ -105,14 +105,14 @@ func CheckCreatorPrincipalName(userCache controllerv3.UserCache, obj metav1.Obje
 	return field.Invalid(annotationsFieldPath, CreatorPrincipalNameAnn, fmt.Sprintf("creator user %s doesn't have principal %s", creatorID, principalName)), nil
 }
 
-// CheckCreatorAnnotationsOnUpdate checks that the creatorId and creator-principal-name annotations are immutable.
+// CheckCreatorAnnotationsOnUpdate checks that the creatorId, creator-principal-name, and no-creator-rbac annotations are immutable.
 // The only allowed update is removing the annotations.
 // This function should only be called for the update operation.
 func CheckCreatorAnnotationsOnUpdate(oldObj, newObj metav1.Object) *field.Error {
 	oldAnnotations := oldObj.GetAnnotations()
 	newAnnotations := newObj.GetAnnotations()
 
-	for _, annotation := range []string{CreatorIDAnn, CreatorPrincipalNameAnn} {
+	for _, annotation := range []string{CreatorIDAnn, CreatorPrincipalNameAnn, NoCreatorRBACAnn} {
 		if _, ok := newAnnotations[annotation]; ok {
 			// If the annotation exists on the new object it must be the same as on the old object.
 			if oldAnnotations[annotation] != newAnnotations[annotation] {

--- a/pkg/resources/common/validation_test.go
+++ b/pkg/resources/common/validation_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
-	"github.com/rancher/webhook/pkg/auth"
 	"github.com/rancher/wrangler/v3/pkg/generic/fake"
 	"github.com/stretchr/testify/require"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -164,10 +163,10 @@ func TestCheckCreatorPrincipalName(t *testing.T) {
 
 			annotations := map[string]string{}
 			if test.creatorID != "" {
-				annotations[auth.CreatorIDAnn] = test.creatorID
+				annotations[CreatorIDAnn] = test.creatorID
 			}
 			if test.principalName != "" {
-				annotations[auth.CreatorPrincipalNameAnn] = test.principalName
+				annotations[CreatorPrincipalNameAnn] = test.principalName
 			}
 
 			fieldErr, err := CheckCreatorPrincipalName(userCache, &v3.Project{
@@ -200,16 +199,16 @@ func TestCheckCreatorAnnotationsOnUpdate(t *testing.T) {
 			oldObj: &v3.Project{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						auth.CreatorIDAnn:            "u-12345",
-						auth.CreatorPrincipalNameAnn: "keycloak_user://12345",
+						CreatorIDAnn:            "u-12345",
+						CreatorPrincipalNameAnn: "keycloak_user://12345",
 					},
 				},
 			},
 			newObj: &v3.Project{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						auth.CreatorIDAnn:            "u-12345",
-						auth.CreatorPrincipalNameAnn: "keycloak_user://12345",
+						CreatorIDAnn:            "u-12345",
+						CreatorPrincipalNameAnn: "keycloak_user://12345",
 					},
 				},
 			},
@@ -219,8 +218,8 @@ func TestCheckCreatorAnnotationsOnUpdate(t *testing.T) {
 			oldObj: &v3.Project{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						auth.CreatorIDAnn:            "u-12345",
-						auth.CreatorPrincipalNameAnn: "keycloak_user://12345",
+						CreatorIDAnn:            "u-12345",
+						CreatorPrincipalNameAnn: "keycloak_user://12345",
 					},
 				},
 			},
@@ -231,14 +230,14 @@ func TestCheckCreatorAnnotationsOnUpdate(t *testing.T) {
 			oldObj: &v3.Project{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						auth.CreatorIDAnn: "u-12345",
+						CreatorIDAnn: "u-12345",
 					},
 				},
 			},
 			newObj: &v3.Project{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						auth.CreatorIDAnn: "u-12346",
+						CreatorIDAnn: "u-12346",
 					},
 				},
 			},
@@ -249,14 +248,14 @@ func TestCheckCreatorAnnotationsOnUpdate(t *testing.T) {
 			oldObj: &v3.Project{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						auth.CreatorPrincipalNameAnn: "keycloak_user://12345",
+						CreatorPrincipalNameAnn: "keycloak_user://12345",
 					},
 				},
 			},
 			newObj: &v3.Project{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						auth.CreatorPrincipalNameAnn: "keycloak_user://12346",
+						CreatorPrincipalNameAnn: "keycloak_user://12346",
 					},
 				},
 			},

--- a/pkg/resources/common/validation_test.go
+++ b/pkg/resources/common/validation_test.go
@@ -393,6 +393,7 @@ func TestCheckCreatorAnnotationsOnUpdate(t *testing.T) {
 					Annotations: map[string]string{
 						CreatorIDAnn:            "u-12345",
 						CreatorPrincipalNameAnn: "keycloak_user://12345",
+						NoCreatorRBACAnn:        "true",
 					},
 				},
 			},
@@ -401,6 +402,7 @@ func TestCheckCreatorAnnotationsOnUpdate(t *testing.T) {
 					Annotations: map[string]string{
 						CreatorIDAnn:            "u-12345",
 						CreatorPrincipalNameAnn: "keycloak_user://12345",
+						NoCreatorRBACAnn:        "true",
 					},
 				},
 			},
@@ -412,6 +414,7 @@ func TestCheckCreatorAnnotationsOnUpdate(t *testing.T) {
 					Annotations: map[string]string{
 						CreatorIDAnn:            "u-12345",
 						CreatorPrincipalNameAnn: "keycloak_user://12345",
+						NoCreatorRBACAnn:        "true",
 					},
 				},
 			},
@@ -448,6 +451,24 @@ func TestCheckCreatorAnnotationsOnUpdate(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						CreatorPrincipalNameAnn: "keycloak_user://12346",
+					},
+				},
+			},
+			fieldErr: true,
+		},
+		{
+			desc: "no creator rbac changed",
+			oldObj: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						NoCreatorRBACAnn: "true",
+					},
+				},
+			},
+			newObj: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						NoCreatorRBACAnn: "false",
 					},
 				},
 			},

--- a/pkg/resources/core/v1/secret/Secret.md
+++ b/pkg/resources/core/v1/secret/Secret.md
@@ -10,6 +10,8 @@ and the secret has roles or role bindings dependent on it.
 For all secrets of type `provisioning.cattle.io/cloud-credential`, 
 places a `field.cattle.io/creatorId` annotation with the name of the user as the value.
 
+If `field.cattle.io/noCreatorRBAC` annotation is set, `field.cattle.io/creatorId` does not get set.
+
 ### On delete
 
 Checks if there are any RoleBindings owned by this secret which provide access to a role granting access to this secret.

--- a/pkg/resources/core/v1/secret/Secret.md
+++ b/pkg/resources/core/v1/secret/Secret.md
@@ -10,7 +10,7 @@ and the secret has roles or role bindings dependent on it.
 For all secrets of type `provisioning.cattle.io/cloud-credential`, 
 places a `field.cattle.io/creatorId` annotation with the name of the user as the value.
 
-If `field.cattle.io/noCreatorRBAC` annotation is set, `field.cattle.io/creatorId` does not get set.
+If `field.cattle.io/no-creator-rbac` annotation is set, `field.cattle.io/creatorId` does not get set.
 
 ### On delete
 

--- a/pkg/resources/core/v1/secret/mutator.go
+++ b/pkg/resources/core/v1/secret/mutator.go
@@ -110,11 +110,8 @@ func (m *Mutator) admitCreate(secret *corev1.Secret, request *admission.Request)
 	logrus.Debugf("[secret-mutation] adding creatorID %v to secret: %v", request.UserInfo.Username, secret.Name)
 	newSecret := secret.DeepCopy()
 
-	if newSecret.Annotations == nil {
-		newSecret.Annotations = make(map[string]string)
-	}
+	common.SetCreatorIDAnnotation(request, newSecret)
 
-	newSecret.Annotations[common.CreatorIDAnn] = request.UserInfo.Username
 	response := &admissionv1.AdmissionResponse{}
 	if err := patch.CreatePatch(request.Object.Raw, newSecret, response); err != nil {
 		return nil, fmt.Errorf("failed to create patch: %w", err)

--- a/pkg/resources/core/v1/secret/mutator.go
+++ b/pkg/resources/core/v1/secret/mutator.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 
 	"github.com/rancher/webhook/pkg/admission"
-	"github.com/rancher/webhook/pkg/auth"
 	objectsv1 "github.com/rancher/webhook/pkg/generated/objects/core/v1"
 	"github.com/rancher/webhook/pkg/patch"
+	"github.com/rancher/webhook/pkg/resources/common"
 	v1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/rbac/v1"
 	"github.com/sirupsen/logrus"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -114,7 +114,7 @@ func (m *Mutator) admitCreate(secret *corev1.Secret, request *admission.Request)
 		newSecret.Annotations = make(map[string]string)
 	}
 
-	newSecret.Annotations[auth.CreatorIDAnn] = request.UserInfo.Username
+	newSecret.Annotations[common.CreatorIDAnn] = request.UserInfo.Username
 	response := &admissionv1.AdmissionResponse{}
 	if err := patch.CreatePatch(request.Object.Raw, newSecret, response); err != nil {
 		return nil, fmt.Errorf("failed to create patch: %w", err)

--- a/pkg/resources/management.cattle.io/v3/cluster/Cluster.md
+++ b/pkg/resources/management.cattle.io/v3/cluster/Cluster.md
@@ -5,3 +5,5 @@
 When a cluster is created and `field.cattle.io/creator-principal-name` annotation is set then `field.cattle.io/creatorId` annotation must be set as well. The value of `field.cattle.io/creator-principal-name` should match the creator's user principal id.
 
 When a cluster is updated `field.cattle.io/creator-principal-name` and `field.cattle.io/creatorId` annotations must stay the same or removed.
+
+If `field.cattle.io/noCreatorRBAC` annotation is set, `field.cattle.io/creatorId` cannot be set.

--- a/pkg/resources/management.cattle.io/v3/cluster/Cluster.md
+++ b/pkg/resources/management.cattle.io/v3/cluster/Cluster.md
@@ -6,4 +6,4 @@ When a cluster is created and `field.cattle.io/creator-principal-name` annotatio
 
 When a cluster is updated `field.cattle.io/creator-principal-name` and `field.cattle.io/creatorId` annotations must stay the same or removed.
 
-If `field.cattle.io/noCreatorRBAC` annotation is set, `field.cattle.io/creatorId` cannot be set.
+If `field.cattle.io/no-creator-rbac` annotation is set, `field.cattle.io/creatorId` cannot be set.

--- a/pkg/resources/management.cattle.io/v3/cluster/validator.go
+++ b/pkg/resources/management.cattle.io/v3/cluster/validator.go
@@ -107,7 +107,12 @@ func (a *admitter) Admit(request *admission.Request) (*admissionv1.AdmissionResp
 	}
 
 	if request.Operation == admissionv1.Create || request.Operation == admissionv1.Update {
-		// no need to validate the local cluster, or imported cluster which represents a KEv2 cluster (GKE/EKS/AKS) or v1 Provisioning Cluster
+		if fieldErr := common.CheckCreatorIDAndNoCreatorRBAC(newCluster); fieldErr != nil {
+			return admission.ResponseBadRequest(fieldErr.Error()), nil
+		}
+
+		// no need to validate the PodSecurityAdmissionConfigurationTemplate on a local cluster,
+		// or imported cluster which represents a KEv2 cluster (GKE/EKS/AKS) or v1 Provisioning Cluster
 		if newCluster.Name == "local" || newCluster.Spec.RancherKubernetesEngineConfig == nil {
 			return admission.ResponseAllowed(), nil
 		}

--- a/pkg/resources/management.cattle.io/v3/cluster/validator.go
+++ b/pkg/resources/management.cattle.io/v3/cluster/validator.go
@@ -92,6 +92,9 @@ func (a *admitter) Admit(request *admission.Request) (*admissionv1.AdmissionResp
 	if a.userCache != nil {
 		// The following checks don't make sense for downstream clusters (userCache == nil)
 		if request.Operation == admissionv1.Create {
+			if fieldErr := common.CheckCreatorIDAndNoCreatorRBAC(newCluster); fieldErr != nil {
+				return admission.ResponseBadRequest(fieldErr.Error()), nil
+			}
 			fieldErr, err := common.CheckCreatorPrincipalName(a.userCache, newCluster)
 			if err != nil {
 				return nil, fmt.Errorf("error checking creator principal: %w", err)
@@ -107,10 +110,6 @@ func (a *admitter) Admit(request *admission.Request) (*admissionv1.AdmissionResp
 	}
 
 	if request.Operation == admissionv1.Create || request.Operation == admissionv1.Update {
-		if fieldErr := common.CheckCreatorIDAndNoCreatorRBAC(newCluster); fieldErr != nil {
-			return admission.ResponseBadRequest(fieldErr.Error()), nil
-		}
-
 		// no need to validate the PodSecurityAdmissionConfigurationTemplate on a local cluster,
 		// or imported cluster which represents a KEv2 cluster (GKE/EKS/AKS) or v1 Provisioning Cluster
 		if newCluster.Name == "local" || newCluster.Spec.RancherKubernetesEngineConfig == nil {

--- a/pkg/resources/management.cattle.io/v3/cluster/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/cluster/validator_test.go
@@ -223,6 +223,75 @@ func TestAdmit(t *testing.T) {
 			operation:     admissionv1.Delete,
 			expectAllowed: true,
 		},
+		{
+			name:      "Create with no-creator-rbac annotation",
+			operation: admissionv1.Create,
+			newCluster: v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "c-2bmj5",
+					Annotations: map[string]string{
+						common.NoCreatorRBACAnn: "true",
+					},
+				},
+			},
+			expectAllowed: true,
+		},
+		{
+			name:      "Create with no-creator-rbac and creatorID annotation",
+			operation: admissionv1.Create,
+			newCluster: v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "c-2bmj5",
+					Annotations: map[string]string{
+						common.NoCreatorRBACAnn: "true",
+						common.CreatorIDAnn:     "u-12345",
+					},
+				},
+			},
+			expectAllowed:  false,
+			expectedReason: metav1.StatusReasonBadRequest,
+		},
+		{
+			name:      "Update with no-creator-rbac annotation",
+			operation: admissionv1.Create,
+			oldCluster: v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "c-2bmj5",
+				},
+			},
+			newCluster: v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "c-2bmj5",
+					Annotations: map[string]string{
+						common.NoCreatorRBACAnn: "true",
+					},
+				},
+			},
+			expectAllowed: true,
+		},
+		{
+			name:      "Update with no-creator-rbac and creatorID annotation",
+			operation: admissionv1.Create,
+			oldCluster: v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "c-2bmj5",
+					Annotations: map[string]string{
+						common.CreatorIDAnn: "u-12345",
+					},
+				},
+			},
+			newCluster: v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "c-2bmj5",
+					Annotations: map[string]string{
+						common.NoCreatorRBACAnn: "true",
+						common.CreatorIDAnn:     "u-12345",
+					},
+				},
+			},
+			expectAllowed:  false,
+			expectedReason: metav1.StatusReasonBadRequest,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/resources/management.cattle.io/v3/cluster/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/cluster/validator_test.go
@@ -253,10 +253,13 @@ func TestAdmit(t *testing.T) {
 		},
 		{
 			name:      "Update with no-creator-rbac annotation",
-			operation: admissionv1.Create,
+			operation: admissionv1.Update,
 			oldCluster: v3.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "c-2bmj5",
+					Annotations: map[string]string{
+						common.NoCreatorRBACAnn: "true",
+					},
 				},
 			},
 			newCluster: v3.Cluster{
@@ -270,14 +273,11 @@ func TestAdmit(t *testing.T) {
 			expectAllowed: true,
 		},
 		{
-			name:      "Update with no-creator-rbac and creatorID annotation",
-			operation: admissionv1.Create,
+			name:      "Update modifying no-creator-rbac annotation",
+			operation: admissionv1.Update,
 			oldCluster: v3.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "c-2bmj5",
-					Annotations: map[string]string{
-						common.CreatorIDAnn: "u-12345",
-					},
 				},
 			},
 			newCluster: v3.Cluster{
@@ -285,11 +285,28 @@ func TestAdmit(t *testing.T) {
 					Name: "c-2bmj5",
 					Annotations: map[string]string{
 						common.NoCreatorRBACAnn: "true",
-						common.CreatorIDAnn:     "u-12345",
 					},
 				},
 			},
-			expectAllowed:  false,
+			expectAllowed: false,
+		},
+		{
+			name:      "Update removing no-creator-rbac",
+			operation: admissionv1.Create,
+			oldCluster: v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "c-2bmj5",
+					Annotations: map[string]string{
+						common.NoCreatorRBACAnn: "true",
+					},
+				},
+			},
+			newCluster: v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "c-2bmj5",
+				},
+			},
+			expectAllowed:  true,
 			expectedReason: metav1.StatusReasonBadRequest,
 		},
 	}

--- a/pkg/resources/management.cattle.io/v3/cluster/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/cluster/validator_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/golang/mock/gomock"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/webhook/pkg/admission"
-	"github.com/rancher/webhook/pkg/auth"
+	"github.com/rancher/webhook/pkg/resources/common"
 	"github.com/rancher/wrangler/v3/pkg/generic/fake"
 	"github.com/stretchr/testify/assert"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -71,8 +71,8 @@ func TestAdmit(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "c-2bmj5",
 					Annotations: map[string]string{
-						auth.CreatorIDAnn:            "u-12345",
-						auth.CreatorPrincipalNameAnn: "keycloak_user://12345",
+						common.CreatorIDAnn:            "u-12345",
+						common.CreatorPrincipalNameAnn: "keycloak_user://12345",
 					},
 				},
 			},
@@ -85,7 +85,7 @@ func TestAdmit(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "c-2bmj5",
 					Annotations: map[string]string{
-						auth.CreatorPrincipalNameAnn: "keycloak_user://12345",
+						common.CreatorPrincipalNameAnn: "keycloak_user://12345",
 					},
 				},
 			},
@@ -99,8 +99,8 @@ func TestAdmit(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "c-2bmj5",
 					Annotations: map[string]string{
-						auth.CreatorIDAnn:            "u-12346",
-						auth.CreatorPrincipalNameAnn: "keycloak_user://12345",
+						common.CreatorIDAnn:            "u-12346",
+						common.CreatorPrincipalNameAnn: "keycloak_user://12345",
 					},
 				},
 			},
@@ -135,7 +135,7 @@ func TestAdmit(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "c-2bmj5",
 					Annotations: map[string]string{
-						auth.CreatorIDAnn: "u-12345",
+						common.CreatorIDAnn: "u-12345",
 					},
 				},
 			},
@@ -143,7 +143,7 @@ func TestAdmit(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "c-2bmj5",
 					Annotations: map[string]string{
-						auth.CreatorIDAnn: "u-12346",
+						common.CreatorIDAnn: "u-12346",
 					},
 				},
 			},
@@ -157,7 +157,7 @@ func TestAdmit(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "c-2bmj5",
 					Annotations: map[string]string{
-						auth.CreatorPrincipalNameAnn: "keycloak_user://12345",
+						common.CreatorPrincipalNameAnn: "keycloak_user://12345",
 					},
 				},
 			},
@@ -165,7 +165,7 @@ func TestAdmit(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "c-2bmj5",
 					Annotations: map[string]string{
-						auth.CreatorPrincipalNameAnn: "keycloak_user://12346",
+						common.CreatorPrincipalNameAnn: "keycloak_user://12346",
 					},
 				},
 			},
@@ -179,8 +179,8 @@ func TestAdmit(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "c-2bmj5",
 					Annotations: map[string]string{
-						auth.CreatorIDAnn:            "u-12345",
-						auth.CreatorPrincipalNameAnn: "keycloak_user://12345",
+						common.CreatorIDAnn:            "u-12345",
+						common.CreatorPrincipalNameAnn: "keycloak_user://12345",
 					},
 				},
 			},
@@ -199,8 +199,8 @@ func TestAdmit(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "c-2bmj5",
 					Annotations: map[string]string{
-						auth.CreatorIDAnn:            "u-12345",
-						auth.CreatorPrincipalNameAnn: "keycloak_user://12345",
+						common.CreatorIDAnn:            "u-12345",
+						common.CreatorPrincipalNameAnn: "keycloak_user://12345",
 					},
 				},
 			},
@@ -208,8 +208,8 @@ func TestAdmit(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "c-2bmj5",
 					Annotations: map[string]string{
-						auth.CreatorIDAnn:            "u-12345",
-						auth.CreatorPrincipalNameAnn: "keycloak_user://12345",
+						common.CreatorIDAnn:            "u-12345",
+						common.CreatorPrincipalNameAnn: "keycloak_user://12345",
 					},
 				},
 			},

--- a/pkg/resources/management.cattle.io/v3/project/Project.md
+++ b/pkg/resources/management.cattle.io/v3/project/Project.md
@@ -25,6 +25,8 @@ When a project is created and `field.cattle.io/creator-principal-name` annotatio
 
 When a project is updated `field.cattle.io/creator-principal-name` and `field.cattle.io/creatorId` annotations must stay the same or removed.
 
+If `field.cattle.io/no-creator-rbac` annotation is set, `field.cattle.io/creatorId` cannot be set.
+
 ## Mutations
 
 ### On create

--- a/pkg/resources/management.cattle.io/v3/project/validator.go
+++ b/pkg/resources/management.cattle.io/v3/project/validator.go
@@ -141,6 +141,10 @@ func (a *admitter) admitUpdate(oldProject, newProject *v3.Project) (*admissionv1
 }
 
 func (a *admitter) admitCommonCreateUpdate(oldProject, newProject *v3.Project) (*admissionv1.AdmissionResponse, error) {
+	if fieldErr := common.CheckCreatorIDAndNoCreatorRBAC(newProject); fieldErr != nil {
+		return admission.ResponseBadRequest(fieldErr.Error()), nil
+	}
+
 	projectQuota := newProject.Spec.ResourceQuota
 	nsQuota := newProject.Spec.NamespaceDefaultResourceQuota
 	containerLimit := newProject.Spec.ContainerDefaultResourceLimit

--- a/pkg/resources/management.cattle.io/v3/project/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/project/validator_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/golang/mock/gomock"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/webhook/pkg/admission"
-	"github.com/rancher/webhook/pkg/auth"
+	"github.com/rancher/webhook/pkg/resources/common"
 	"github.com/rancher/wrangler/v3/pkg/generic/fake"
 	"github.com/stretchr/testify/assert"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -415,8 +415,8 @@ func TestProjectValidation(t *testing.T) {
 					Name:      "test",
 					Namespace: "testcluster",
 					Annotations: map[string]string{
-						auth.CreatorPrincipalNameAnn: "keycloak_user://12345",
-						auth.CreatorIDAnn:            "u-12345",
+						common.CreatorPrincipalNameAnn: "keycloak_user://12345",
+						common.CreatorIDAnn:            "u-12345",
 					},
 				},
 				Spec: v3.ProjectSpec{
@@ -446,7 +446,7 @@ func TestProjectValidation(t *testing.T) {
 					Name:      "test",
 					Namespace: "testcluster",
 					Annotations: map[string]string{
-						auth.CreatorPrincipalNameAnn: "keycloak_user://12345",
+						common.CreatorPrincipalNameAnn: "keycloak_user://12345",
 					},
 				},
 				Spec: v3.ProjectSpec{
@@ -471,8 +471,8 @@ func TestProjectValidation(t *testing.T) {
 					Name:      "test",
 					Namespace: "testcluster",
 					Annotations: map[string]string{
-						auth.CreatorPrincipalNameAnn: "keycloak_user://12346",
-						auth.CreatorIDAnn:            "u-12345",
+						common.CreatorPrincipalNameAnn: "keycloak_user://12346",
+						common.CreatorIDAnn:            "u-12345",
 					},
 				},
 				Spec: v3.ProjectSpec{
@@ -502,8 +502,8 @@ func TestProjectValidation(t *testing.T) {
 					Name:      "test",
 					Namespace: "testcluster",
 					Annotations: map[string]string{
-						auth.CreatorPrincipalNameAnn: "keycloak_user://12346",
-						auth.CreatorIDAnn:            "u-12345",
+						common.CreatorPrincipalNameAnn: "keycloak_user://12346",
+						common.CreatorIDAnn:            "u-12345",
 					},
 				},
 				Spec: v3.ProjectSpec{
@@ -528,8 +528,8 @@ func TestProjectValidation(t *testing.T) {
 					Name:      "test",
 					Namespace: "testcluster",
 					Annotations: map[string]string{
-						auth.CreatorPrincipalNameAnn: "keycloak_user://12346",
-						auth.CreatorIDAnn:            "u-12345",
+						common.CreatorPrincipalNameAnn: "keycloak_user://12346",
+						common.CreatorIDAnn:            "u-12345",
 					},
 				},
 				Spec: v3.ProjectSpec{
@@ -1027,7 +1027,7 @@ func TestProjectValidation(t *testing.T) {
 					Name:      "test",
 					Namespace: "testcluster",
 					Annotations: map[string]string{
-						auth.CreatorIDAnn: "u-12345",
+						common.CreatorIDAnn: "u-12345",
 					},
 				},
 				Spec: v3.ProjectSpec{
@@ -1039,7 +1039,7 @@ func TestProjectValidation(t *testing.T) {
 					Name:      "test",
 					Namespace: "tescluster",
 					Annotations: map[string]string{
-						auth.CreatorIDAnn: "u-12346",
+						common.CreatorIDAnn: "u-12346",
 					},
 				},
 				Spec: v3.ProjectSpec{
@@ -1056,7 +1056,7 @@ func TestProjectValidation(t *testing.T) {
 					Name:      "test",
 					Namespace: "testcluster",
 					Annotations: map[string]string{
-						auth.CreatorPrincipalNameAnn: "keycloak_user://12345",
+						common.CreatorPrincipalNameAnn: "keycloak_user://12345",
 					},
 				},
 				Spec: v3.ProjectSpec{
@@ -1068,7 +1068,7 @@ func TestProjectValidation(t *testing.T) {
 					Name:      "test",
 					Namespace: "tescluster",
 					Annotations: map[string]string{
-						auth.CreatorPrincipalNameAnn: "keycloak_user://12346",
+						common.CreatorPrincipalNameAnn: "keycloak_user://12346",
 					},
 				},
 				Spec: v3.ProjectSpec{
@@ -1085,8 +1085,8 @@ func TestProjectValidation(t *testing.T) {
 					Name:      "test",
 					Namespace: "testcluster",
 					Annotations: map[string]string{
-						auth.CreatorIDAnn:            "u-12345",
-						auth.CreatorPrincipalNameAnn: "keycloak_user://12345",
+						common.CreatorIDAnn:            "u-12345",
+						common.CreatorPrincipalNameAnn: "keycloak_user://12345",
 					},
 				},
 				Spec: v3.ProjectSpec{
@@ -1112,8 +1112,8 @@ func TestProjectValidation(t *testing.T) {
 					Name:      "test",
 					Namespace: "testcluster",
 					Annotations: map[string]string{
-						auth.CreatorIDAnn:            "u-12345",
-						auth.CreatorPrincipalNameAnn: "keycloak_user://12345",
+						common.CreatorIDAnn:            "u-12345",
+						common.CreatorPrincipalNameAnn: "keycloak_user://12345",
 					},
 				},
 				Spec: v3.ProjectSpec{
@@ -1125,8 +1125,8 @@ func TestProjectValidation(t *testing.T) {
 					Name:      "test",
 					Namespace: "tescluster",
 					Annotations: map[string]string{
-						auth.CreatorIDAnn:            "u-12345",
-						auth.CreatorPrincipalNameAnn: "keycloak_user://12345",
+						common.CreatorIDAnn:            "u-12345",
+						common.CreatorPrincipalNameAnn: "keycloak_user://12345",
 					},
 				},
 				Spec: v3.ProjectSpec{

--- a/pkg/resources/management.cattle.io/v3/project/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/project/validator_test.go
@@ -408,6 +408,111 @@ func TestProjectValidation(t *testing.T) {
 			wantAllowed: false,
 		},
 		{
+			name:      "create with no-creator-rbac annotation",
+			operation: admissionv1.Create,
+			newProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+					Annotations: map[string]string{
+						common.NoCreatorRBACAnn: "true",
+					},
+				},
+				Spec: v3.ProjectSpec{
+					ClusterName: "testcluster",
+				},
+			},
+			stateSetup: func(state *testState) {
+				state.clusterCache.EXPECT().Get("testcluster").Return(&v3.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testcluster",
+					},
+				}, nil)
+			},
+			wantAllowed: true,
+		},
+		{
+			name:      "create with no-creator-rbac and creatorID annotation",
+			operation: admissionv1.Create,
+			newProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+					Annotations: map[string]string{
+						common.NoCreatorRBACAnn: "true",
+						common.CreatorIDAnn:     "u-12345",
+					},
+				},
+				Spec: v3.ProjectSpec{
+					ClusterName: "testcluster",
+				},
+			},
+			stateSetup: func(state *testState) {
+				state.clusterCache.EXPECT().Get("testcluster").Return(&v3.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testcluster",
+					},
+				}, nil)
+			},
+			wantAllowed: false,
+		},
+		{
+			name:      "update with no-creator-rbac annotation",
+			operation: admissionv1.Update,
+			oldProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+				Spec: v3.ProjectSpec{
+					ClusterName: "testcluster",
+				},
+			},
+			newProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+					Annotations: map[string]string{
+						common.NoCreatorRBACAnn: "true",
+					},
+				},
+				Spec: v3.ProjectSpec{
+					ClusterName: "testcluster",
+				},
+			},
+			wantAllowed: true,
+		},
+		{
+			name:      "update with no-creator-rbac and creatorID annotation",
+			operation: admissionv1.Update,
+			oldProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+					Annotations: map[string]string{
+						common.CreatorIDAnn: "u-12345",
+					},
+				},
+				Spec: v3.ProjectSpec{
+					ClusterName: "testcluster",
+				},
+			},
+			newProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+					Annotations: map[string]string{
+						common.NoCreatorRBACAnn: "true",
+						common.CreatorIDAnn:     "u-12345",
+					},
+				},
+				Spec: v3.ProjectSpec{
+					ClusterName: "testcluster",
+				},
+			},
+			wantAllowed: false,
+		},
+		{
 			name:      "create with principal name annotation",
 			operation: admissionv1.Create,
 			newProject: &v3.Project{

--- a/pkg/resources/management.cattle.io/v3/project/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/project/validator_test.go
@@ -463,6 +463,9 @@ func TestProjectValidation(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
 					Namespace: "testcluster",
+					Annotations: map[string]string{
+						common.NoCreatorRBACAnn: "true",
+					},
 				},
 				Spec: v3.ProjectSpec{
 					ClusterName: "testcluster",
@@ -483,15 +486,12 @@ func TestProjectValidation(t *testing.T) {
 			wantAllowed: true,
 		},
 		{
-			name:      "update with no-creator-rbac and creatorID annotation",
+			name:      "update adding no-creator-rbac",
 			operation: admissionv1.Update,
 			oldProject: &v3.Project{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
 					Namespace: "testcluster",
-					Annotations: map[string]string{
-						common.CreatorIDAnn: "u-12345",
-					},
 				},
 				Spec: v3.ProjectSpec{
 					ClusterName: "testcluster",
@@ -503,7 +503,6 @@ func TestProjectValidation(t *testing.T) {
 					Namespace: "testcluster",
 					Annotations: map[string]string{
 						common.NoCreatorRBACAnn: "true",
-						common.CreatorIDAnn:     "u-12345",
 					},
 				},
 				Spec: v3.ProjectSpec{
@@ -511,6 +510,61 @@ func TestProjectValidation(t *testing.T) {
 				},
 			},
 			wantAllowed: false,
+		},
+		{
+			name:      "update modifying no-creator-rbac",
+			operation: admissionv1.Update,
+			oldProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+					Annotations: map[string]string{
+						common.NoCreatorRBACAnn: "true",
+					},
+				},
+				Spec: v3.ProjectSpec{
+					ClusterName: "testcluster",
+				},
+			},
+			newProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+					Annotations: map[string]string{
+						common.NoCreatorRBACAnn: "false",
+					},
+				},
+				Spec: v3.ProjectSpec{
+					ClusterName: "testcluster",
+				},
+			},
+			wantAllowed: false,
+		},
+		{
+			name:      "update removing no-creator-rbac",
+			operation: admissionv1.Update,
+			oldProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+					Annotations: map[string]string{
+						common.NoCreatorRBACAnn: "true",
+					},
+				},
+				Spec: v3.ProjectSpec{
+					ClusterName: "testcluster",
+				},
+			},
+			newProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+				Spec: v3.ProjectSpec{
+					ClusterName: "testcluster",
+				},
+			},
+			wantAllowed: true,
 		},
 		{
 			name:      "create with principal name annotation",

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/Cluster.md
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/Cluster.md
@@ -6,7 +6,7 @@
 
 The annotation `field.cattle.io/creatorId` must be set to the Username of the User that initiated the request.
 
-If `field.cattle.io/noCreatorRBAC` annotation is set, `field.cattle.io/creatorId` cannot be set.
+If `field.cattle.io/no-creator-rbac` annotation is set, `field.cattle.io/creatorId` cannot be set.
 
 #### Data Directories
 
@@ -25,7 +25,7 @@ following:
 
 The annotation `field.cattle.io/creatorId` is cannot be changed, but it can be removed.
 
-If `field.cattle.io/noCreatorRBAC` annotation is set, `field.cattle.io/creatorId` cannot be set.
+If `field.cattle.io/no-creator-rbac` annotation is set, `field.cattle.io/creatorId` cannot be set.
 
 #### Data Directories
 
@@ -41,7 +41,7 @@ kubernetes distro (RKE2/K3s), and CAPR components is also prohibited.
 
 When a cluster is created `field.cattle.io/creatorId` is set to the Username from the request.
 
-If `field.cattle.io/noCreatorRBAC` annotation is set, `field.cattle.io/creatorId` does not get set.
+If `field.cattle.io/no-creator-rbac` annotation is set, `field.cattle.io/creatorId` does not get set.
 
 ### On Update
 

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/Cluster.md
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/Cluster.md
@@ -2,6 +2,12 @@
 
 ### On Create
 
+#### Creator ID Annotation
+
+The annotation `field.cattle.io/creatorId` must be set to the Username of the User that initiated the request.
+
+If `field.cattle.io/noCreatorRBAC` annotation is set, `field.cattle.io/creatorId` cannot be set.
+
 #### Data Directories
 
 Prevent the creation of new objects with an env var (under `spec.agentEnvVars`) with a name of `CATTLE_AGENT_VAR_DIR`.
@@ -15,6 +21,12 @@ following:
 
 ### On Update
 
+#### Creator ID Annotation
+
+The annotation `field.cattle.io/creatorId` is cannot be changed, but it can be removed.
+
+If `field.cattle.io/noCreatorRBAC` annotation is set, `field.cattle.io/creatorId` cannot be set.
+
 #### Data Directories
 
 On update, prevent new env vars with this name from being added but allow them to be removed. Rancher will perform 
@@ -24,6 +36,12 @@ from the one chosen during cluster creation. Additionally, the changing of a dat
 kubernetes distro (RKE2/K3s), and CAPR components is also prohibited.
 
 ## Mutation Checks
+
+### On Create
+
+When a cluster is created `field.cattle.io/creatorId` is set to the Username from the request.
+
+If `field.cattle.io/noCreatorRBAC` annotation is set, `field.cattle.io/creatorId` does not get set.
 
 ### On Update
 

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/Cluster.md
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/Cluster.md
@@ -23,7 +23,7 @@ following:
 
 #### Creator ID Annotation
 
-The annotation `field.cattle.io/creatorId` is cannot be changed, but it can be removed.
+The annotation `field.cattle.io/creatorId` cannot be changed, but it can be removed.
 
 If `field.cattle.io/no-creator-rbac` annotation is set, `field.cattle.io/creatorId` cannot be set.
 

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/mutator.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/mutator.go
@@ -14,11 +14,11 @@ import (
 	v1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/webhook/pkg/admission"
-	"github.com/rancher/webhook/pkg/auth"
 	v3 "github.com/rancher/webhook/pkg/generated/controllers/management.cattle.io/v3"
 	objectsv1 "github.com/rancher/webhook/pkg/generated/objects/provisioning.cattle.io/v1"
 	"github.com/rancher/webhook/pkg/patch"
 	psa "github.com/rancher/webhook/pkg/podsecurityadmission"
+	"github.com/rancher/webhook/pkg/resources/common"
 	"github.com/rancher/wrangler/v3/pkg/data/convert"
 	corecontroller "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/sirupsen/logrus"
@@ -122,7 +122,7 @@ func (m *ProvisioningClusterMutator) Admit(request *admission.Request) (*admissi
 		if annotations == nil {
 			annotations = map[string]string{}
 		}
-		annotations[auth.CreatorIDAnn] = request.UserInfo.Username
+		annotations[common.CreatorIDAnn] = request.UserInfo.Username
 		cluster.SetAnnotations(annotations)
 	}
 

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/mutator.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/mutator.go
@@ -117,13 +117,7 @@ func (m *ProvisioningClusterMutator) Admit(request *admission.Request) (*admissi
 	}
 
 	if request.Operation == admissionv1.Create {
-		// Set Annotation on the cluster
-		annotations := cluster.GetAnnotations()
-		if annotations == nil {
-			annotations = map[string]string{}
-		}
-		annotations[common.CreatorIDAnn] = request.UserInfo.Username
-		cluster.SetAnnotations(annotations)
+		common.SetCreatorIDAnnotation(request, cluster)
 	}
 
 	response, err := m.handlePSACT(request, cluster)

--- a/pkg/resources/rke-machine-config.cattle.io/v1/machineconfig/MachineConfig.md
+++ b/pkg/resources/rke-machine-config.cattle.io/v1/machineconfig/MachineConfig.md
@@ -1,0 +1,17 @@
+## Validation Checks
+
+### Creator ID Annotation
+
+The annotation `field.cattle.io/creatorId` must be set to the Username of the User that initiated the request.
+
+The annotation `field.cattle.io/creatorId` is cannot be changed, but it can be removed.
+
+If `field.cattle.io/noCreatorRBAC` annotation is set, `field.cattle.io/creatorId` cannot be set.
+
+## Mutation Checks
+
+### Creator ID Annotion
+
+When a cluster is created `field.cattle.io/creatorId` is set to the Username from the request.
+
+If `field.cattle.io/noCreatorRBAC` annotation is set, `field.cattle.io/creatorId` does not get set.

--- a/pkg/resources/rke-machine-config.cattle.io/v1/machineconfig/MachineConfig.md
+++ b/pkg/resources/rke-machine-config.cattle.io/v1/machineconfig/MachineConfig.md
@@ -4,7 +4,7 @@
 
 The annotation `field.cattle.io/creatorId` must be set to the Username of the User that initiated the request.
 
-The annotation `field.cattle.io/creatorId` is cannot be changed, but it can be removed.
+The annotation `field.cattle.io/creatorId` cannot be changed, but it can be removed.
 
 If `field.cattle.io/no-creator-rbac` annotation is set, `field.cattle.io/creatorId` cannot be set.
 

--- a/pkg/resources/rke-machine-config.cattle.io/v1/machineconfig/MachineConfig.md
+++ b/pkg/resources/rke-machine-config.cattle.io/v1/machineconfig/MachineConfig.md
@@ -6,7 +6,7 @@ The annotation `field.cattle.io/creatorId` must be set to the Username of the Us
 
 The annotation `field.cattle.io/creatorId` is cannot be changed, but it can be removed.
 
-If `field.cattle.io/noCreatorRBAC` annotation is set, `field.cattle.io/creatorId` cannot be set.
+If `field.cattle.io/no-creator-rbac` annotation is set, `field.cattle.io/creatorId` cannot be set.
 
 ## Mutation Checks
 
@@ -14,4 +14,4 @@ If `field.cattle.io/noCreatorRBAC` annotation is set, `field.cattle.io/creatorId
 
 When a cluster is created `field.cattle.io/creatorId` is set to the Username from the request.
 
-If `field.cattle.io/noCreatorRBAC` annotation is set, `field.cattle.io/creatorId` does not get set.
+If `field.cattle.io/no-creator-rbac` annotation is set, `field.cattle.io/creatorId` does not get set.

--- a/pkg/resources/rke-machine-config.cattle.io/v1/machineconfig/mutator.go
+++ b/pkg/resources/rke-machine-config.cattle.io/v1/machineconfig/mutator.go
@@ -49,10 +49,10 @@ func (m *Mutator) Admit(request *admission.Request) (*admissionv1.AdmissionRespo
 		return nil, fmt.Errorf("failed to get object from request: %w", err)
 	}
 
-	common.SetCreatorIDAnnotation(request, config.DeepCopy())
+	common.SetCreatorIDAnnotation(request, config)
 
 	response := &admissionv1.AdmissionResponse{}
-	if err := patch.CreatePatch(request.Object.Raw, config.DeepCopy(), response); err != nil {
+	if err := patch.CreatePatch(request.Object.Raw, config, response); err != nil {
 		return nil, fmt.Errorf("failed to create patch: %w", err)
 	}
 	response.Allowed = true

--- a/tests/integration/provCluster_test.go
+++ b/tests/integration/provCluster_test.go
@@ -2,7 +2,7 @@ package integration_test
 
 import (
 	provisioningv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
-	"github.com/rancher/webhook/pkg/auth"
+	"github.com/rancher/webhook/pkg/resources/common"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -21,7 +21,7 @@ func (m *IntegrationSuite) TestProvisioningCluster() {
 	}
 	invalidUpdate := func(created *provisioningv1.Cluster) *provisioningv1.Cluster {
 		invalidUpdateObj := created.DeepCopy()
-		invalidUpdateObj.Annotations = map[string]string{auth.CreatorIDAnn: "foobar"}
+		invalidUpdateObj.Annotations = map[string]string{common.CreatorIDAnn: "foobar"}
 		return invalidUpdateObj
 	}
 	validUpdate := func(created *provisioningv1.Cluster) *provisioningv1.Cluster {

--- a/tests/integration/rkeMachineConfig_test.go
+++ b/tests/integration/rkeMachineConfig_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/rancher/webhook/pkg/auth"
+	"github.com/rancher/webhook/pkg/resources/common"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -27,7 +27,7 @@ func (m *IntegrationSuite) TestRKEMachineConfig() {
 	validCreateObj.SetGroupVersionKind(objGVK)
 	invalidUpdate := func(_ *unstructured.Unstructured) *unstructured.Unstructured {
 		invalidUpdateObj := validCreateObj.DeepCopy()
-		invalidUpdateObj.SetAnnotations(map[string]string{auth.CreatorIDAnn: "foobar"})
+		invalidUpdateObj.SetAnnotations(map[string]string{common.CreatorIDAnn: "foobar"})
 		return invalidUpdateObj
 	}
 	validUpdate := func(created *unstructured.Unstructured) *unstructured.Unstructured {

--- a/tests/integration/secret_test.go
+++ b/tests/integration/secret_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/rancher/webhook/pkg/auth"
+	"github.com/rancher/webhook/pkg/resources/common"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -30,7 +30,7 @@ func (m *IntegrationSuite) TestSecret() {
 	defer cancel()
 	err = client.Create(ctx, validCreateObj.Namespace, validCreateObj, result, metav1.CreateOptions{})
 	m.NoError(err, "Error returned during the creation of a valid Object")
-	m.Contains(result.Annotations, auth.CreatorIDAnn)
+	m.Contains(result.Annotations, common.CreatorIDAnn)
 	err = client.Delete(ctx, validCreateObj.Namespace, validCreateObj.Name, metav1.DeleteOptions{})
 	m.NoError(err, "Error returned during the deletion of a valid Object")
 }


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/45591
Requires rancher/rancher changes: https://github.com/rancher/rancher/pull/47259

## Problem
When a service account creates a cluster, the project handler and cluster handler both attempt to create ClusterOwner and ProjectOwner roles and bind those roles to the service account. The problem is that we don't support those roles for service accounts, so the logs get flooded with errors as it keeps retrying to add those roles.

## Solution
To avoid the errors and the re-queuing, we have added a new annotation `field.cattle.io/no-creator-rbac`. When it is set the webhook does not set the `field.cattle.io/creatorId` annotation to clusters because the controllers will no longer be creating RBAC for the creator of the cluster.

I moved some annotations to the `common` package as I felt it was more apt. I also cleaned up some functions in the `common` package to make them more consistent.

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [X] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [X] Docs