### PR TITLE
Prevent dropping unknown cluster fields 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22.0
 toolchain go1.22.7
 
 replace (
+	github.com/rancher/rke => github.com/rancher/rke v1.6.2
 	k8s.io/api => k8s.io/api v0.30.1
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.30.1
 	k8s.io/apimachinery => k8s.io/apimachinery v0.30.1

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,8 @@ github.com/rancher/norman v0.0.0-20240822182819-60ccfabc4ac5 h1:Z34NXcW0ymdpVBfd
 github.com/rancher/norman v0.0.0-20240822182819-60ccfabc4ac5/go.mod h1:dyjfXBsNiroPWOdUZe7diUOUSLf6HQ/r2kEpwH/8zas=
 github.com/rancher/rancher/pkg/apis v0.0.0-20240903164338-21e4787cd0b3 h1:KCO+g13mukOPpaYFUMmr3oMULltsFbp6H8rp4NV02jI=
 github.com/rancher/rancher/pkg/apis v0.0.0-20240903164338-21e4787cd0b3/go.mod h1:V1RX7d/ziNUUD0RRz/HDf3xaCZdJPdbXRQLArExtg+U=
-github.com/rancher/rke v1.6.0 h1:fHdygmtPF1cWXuiYXfwgG4hKvt0n4l57SwCxquRJSfs=
-github.com/rancher/rke v1.6.0/go.mod h1:5xRbf3L8PxqJRhABjYRfaBqbpVqAnqyH3maUNQEuwvk=
+github.com/rancher/rke v1.6.2 h1:ttGk77t5oe7bsiS7s7SOFmAl3PALYI5M2SQQenjKevk=
+github.com/rancher/rke v1.6.2/go.mod h1:5xRbf3L8PxqJRhABjYRfaBqbpVqAnqyH3maUNQEuwvk=
 github.com/rancher/wrangler/v3 v3.0.0 h1:IHHCA+vrghJDPxjtLk4fmeSCFhNe9fFzLFj3m2B0YpA=
 github.com/rancher/wrangler/v3 v3.0.0/go.mod h1:Dfckuuq7MJk2JWVBDywRlZXMxEyPxHy4XqGrPEzu5Eg=
 github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=

--- a/pkg/resources/management.cattle.io/v3/cluster/mutator_test.go
+++ b/pkg/resources/management.cattle.io/v3/cluster/mutator_test.go
@@ -1,0 +1,46 @@
+package cluster
+
+import (
+	"encoding/json"
+	"testing"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/webhook/pkg/admission"
+	data2 "github.com/rancher/wrangler/v3/pkg/data"
+	"github.com/stretchr/testify/assert"
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestAdmitPreserveUnknownFields(t *testing.T) {
+	cluster := &v3.Cluster{}
+	data, err := data2.Convert(cluster)
+	assert.Nil(t, err)
+
+	data.SetNested("test", "spec", "rancherKubernetesEngineConfig", "network", "aciNetworkProvider", "apicUserKeyTest")
+	raw, err := json.Marshal(data)
+	assert.Nil(t, err)
+
+	request := &admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Object: runtime.RawExtension{
+				Raw: raw,
+			},
+			OldObject: runtime.RawExtension{
+				Raw: raw,
+			},
+		},
+	}
+
+	m := ManagementClusterMutator{}
+
+	request.Operation = admissionv1.Create
+	response, err := m.Admit(request)
+	assert.Nil(t, err)
+	assert.Nil(t, response.Patch)
+
+	request.Operation = admissionv1.Update
+	response, err = m.Admit(request)
+	assert.Nil(t, err)
+	assert.Nil(t, response.Patch)
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from other PRs, link them here and describe why they are needed for your solution section. -->

https://github.com/rancher/rancher/issues/47200

## Problem
<!-- Describe the root cause of the issue you are resolving. 
This may include what behavior is observed and why it is not desirable. If this is a new feature, describe why we need it and how it will be used. -->

Presently mutating webhook drops fields not present in `Cluster` struct in RKE1. This creates problem for the users of ACI CNI provider.

## Solution
<!-- Describe what you changed to fix the issue. 
Relate your changes to the original bug/feature and explain why this addresses the issue. -->

We pass the marshaled `newCluster` object created by the function `ClusterOldAndNewFromRequest` instead of current approach of using `request.Object.Raw`.

## Note 
This PR cherry-picks changes from @dharmit's https://github.com/rancher/webhook/pull/513 and adds tests as suggested in https://github.com/rancher/webhook/pull/513#pullrequestreview-2343698310. Also updated go.mod to add RKE in replace section per https://github.com/rancher/webhook/pull/513#issuecomment-2389665184. 
