### PR TITLE
[v0.4] Prevent dropping unknown cluster fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22.0
 toolchain go1.22.7
 
 replace (
+	github.com/rancher/rke => github.com/rancher/rke v1.5.13
 	k8s.io/api => k8s.io/api v0.28.6
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.28.6
 	k8s.io/apimachinery => k8s.io/apimachinery v0.28.6

--- a/pkg/resources/management.cattle.io/v3/cluster/mutator_test.go
+++ b/pkg/resources/management.cattle.io/v3/cluster/mutator_test.go
@@ -1,0 +1,46 @@
+package cluster
+
+import (
+	"encoding/json"
+	"testing"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/webhook/pkg/admission"
+	data2 "github.com/rancher/wrangler/v2/pkg/data"
+	"github.com/stretchr/testify/assert"
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestAdmitPreserveUnknownFields(t *testing.T) {
+	cluster := &v3.Cluster{}
+	data, err := data2.Convert(cluster)
+	assert.Nil(t, err)
+
+	data.SetNested("test", "spec", "rancherKubernetesEngineConfig", "network", "aciNetworkProvider", "apicUserKeyTest")
+	raw, err := json.Marshal(data)
+	assert.Nil(t, err)
+
+	request := &admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Object: runtime.RawExtension{
+				Raw: raw,
+			},
+			OldObject: runtime.RawExtension{
+				Raw: raw,
+			},
+		},
+	}
+
+	m := ManagementClusterMutator{}
+
+	request.Operation = admissionv1.Create
+	response, err := m.Admit(request)
+	assert.Nil(t, err)
+	assert.Nil(t, response.Patch)
+
+	request.Operation = admissionv1.Update
+	response, err = m.Admit(request)
+	assert.Nil(t, err)
+	assert.Nil(t, response.Patch)
+}


### PR DESCRIPTION
Backport PR for https://github.com/rancher/webhook/pull/515. 

Note: This PR uses `github.com/rancher/wrangler/v2/` vs the original PR uses `github.com/rancher/wrangler/v3/`. 

Issue: https://github.com/rancher/rancher/issues/47202 