### PR TITLE
[v0.4] bump rke to v1.5.14 and update pkg/apis to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.22.7
 
 replace (
-	github.com/rancher/rke => github.com/rancher/rke v1.5.13
+	github.com/rancher/rke => github.com/rancher/rke v1.5.14
 	k8s.io/api => k8s.io/api v0.28.6
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.28.6
 	k8s.io/apimachinery => k8s.io/apimachinery v0.28.6
@@ -43,8 +43,8 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/rancher/dynamiclistener v0.4.0
 	github.com/rancher/lasso v0.0.0-20240123150939-7055397d6dfa
-	github.com/rancher/rancher/pkg/apis v0.0.0-20240918012012-216d520308b3
-	github.com/rancher/rke v1.5.13
+	github.com/rancher/rancher/pkg/apis v0.0.0-20241022021555-ec68dc665010
+	github.com/rancher/rke v1.5.14
 	github.com/rancher/wrangler/v2 v2.1.4
 	github.com/robfig/cron v1.2.0
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -299,10 +299,10 @@ github.com/rancher/lasso v0.0.0-20240123150939-7055397d6dfa h1:eRhvQJjIpPxJunlS3
 github.com/rancher/lasso v0.0.0-20240123150939-7055397d6dfa/go.mod h1:utdskbIL7kdVvPCUFPEJQDWJwPHGFpUCRfVkX2G2Xxg=
 github.com/rancher/norman v0.0.0-20240206180703-6eda4bc94b4c h1:ayqZqJ4AYYVaZGlBztLBij81z/QRsSFbQfxs9bzA+Tg=
 github.com/rancher/norman v0.0.0-20240206180703-6eda4bc94b4c/go.mod h1:WbNpu/HwChwKk54W0rWBdioxYVVZwVVz//UX84m/NvY=
-github.com/rancher/rancher/pkg/apis v0.0.0-20240918012012-216d520308b3 h1:tqbXMqpT8B3aa3OF3HRZZQvy1eVAe6dItldxKuUfVsQ=
-github.com/rancher/rancher/pkg/apis v0.0.0-20240918012012-216d520308b3/go.mod h1:kFe1jGv3zR5nBSCB3MT2KwdOWHKMcsCtOWFs0eEgPJk=
-github.com/rancher/rke v1.5.13 h1:Y7e3qI0G2HbU3Vm5k3Sqeq+UR2w114K5yY6wT9VFKcY=
-github.com/rancher/rke v1.5.13/go.mod h1:/z9oyKqYpFwgRBV9rfLxqUdjydz/VMCTcjld4uUt7uM=
+github.com/rancher/rancher/pkg/apis v0.0.0-20241022021555-ec68dc665010 h1:qE+WJrS+yXqNvNDE8iSPcvvmOCGdMPNtEJdP9xwt+po=
+github.com/rancher/rancher/pkg/apis v0.0.0-20241022021555-ec68dc665010/go.mod h1:WBJOAGPrJoLU7+4CNa6ta0TZrQk1NGPcThnEDUq5wKI=
+github.com/rancher/rke v1.5.14 h1:sQlSyfV7dtjjK9ouWAkakblXD8lrg3MwxmH017yePfo=
+github.com/rancher/rke v1.5.14/go.mod h1:/z9oyKqYpFwgRBV9rfLxqUdjydz/VMCTcjld4uUt7uM=
 github.com/rancher/wrangler/v2 v2.1.4 h1:ohov0i6A9dJHHO6sjfsH4Dqv93ZTdm5lIJVJdPzVdQc=
 github.com/rancher/wrangler/v2 v2.1.4/go.mod h1:af5OaGU/COgreQh1mRbKiUI64draT2NN34uk+PALFY8=
 github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=


### PR DESCRIPTION
bump `rke` module to v1.5.14 and `rancher/rancher/pkg/apis` to the latest of the release/2.8 branch