### PR TITLE
[main/2.10.2] Add resource request and limit validation when creating a namespace

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -60,6 +60,10 @@ The following labels are considered relevant for PSA enforcement:
 - pod-security.kubernetes.io/warn
 - pod-security.kubernetes.io/warn-version
 
+#### Namespace resource limit validation
+
+Validation ensures that the limits for cpu/memory must not be less than the requests for cpu/memory.
+
 ## Secret
 
 ### Validation Checks

--- a/pkg/resources/core/v1/namespace/Namespace.md
+++ b/pkg/resources/core/v1/namespace/Namespace.md
@@ -20,3 +20,6 @@ The following labels are considered relevant for PSA enforcement:
 - pod-security.kubernetes.io/warn
 - pod-security.kubernetes.io/warn-version
 
+### Namespace resource limit validation
+
+Validation ensures that the limits for cpu/memory must not be less than the requests for cpu/memory.

--- a/pkg/resources/core/v1/namespace/requestlimits.go
+++ b/pkg/resources/core/v1/namespace/requestlimits.go
@@ -3,6 +3,7 @@ package namespace
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/rancher/webhook/pkg/admission"
 	objectsv1 "github.com/rancher/webhook/pkg/generated/objects/core/v1"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -38,9 +39,9 @@ func (r *requestLimitAdmitter) Admit(request *admission.Request) (*admissionv1.A
 }
 
 type ResourceLimits struct {
-	LimitsCpu      string `json:"limitsCpu"`
+	LimitsCPU      string `json:"limitsCpu"`
 	LimitsMemory   string `json:"limitsMemory"`
-	RequestsCpu    string `json:"requestsCpu"`
+	RequestsCPU    string `json:"requestsCpu"`
 	RequestsMemory string `json:"requestsMemory"`
 }
 
@@ -72,18 +73,18 @@ func (r *requestLimitAdmitter) admitCommonCreateUpdate(_, newNamespace *v1.Names
 // validateResourceLimitsWithUnits takes a set of cpu/memory requests/limits and will return an error if the requests are
 // malformed or greater than the limits.
 func validateResourceLimitsWithUnits(limits ResourceLimits) error {
-	requestsCpu, err := resource.ParseQuantity(limits.RequestsCpu)
+	requestsCPU, err := resource.ParseQuantity(limits.RequestsCPU)
 	if err != nil {
 		return fmt.Errorf("invalid requestsCpu value: %v", err)
 	}
 
-	limitsCpu, err := resource.ParseQuantity(limits.LimitsCpu)
+	limitsCPU, err := resource.ParseQuantity(limits.LimitsCPU)
 	if err != nil {
 		return fmt.Errorf("invalid limitsCpu value: %v", err)
 	}
 
-	if requestsCpu.Cmp(limitsCpu) > 0 {
-		return fmt.Errorf("requestsCpu (%s) cannot be greater than limitsCpu (%s)", requestsCpu.String(), limitsCpu.String())
+	if requestsCPU.Cmp(limitsCPU) > 0 {
+		return fmt.Errorf("requestsCpu (%s) cannot be greater than limitsCpu (%s)", requestsCPU.String(), limitsCPU.String())
 	}
 
 	requestsMemory, err := resource.ParseQuantity(limits.RequestsMemory)

--- a/pkg/resources/core/v1/namespace/requestlimits.go
+++ b/pkg/resources/core/v1/namespace/requestlimits.go
@@ -54,7 +54,7 @@ func (r *requestLimitAdmitter) admitCommonCreateUpdate(_, newNamespace *v1.Names
 	}
 
 	resourceLimitJSON, exists := annotations[resourceLimitAnnotation]
-	if !exists {
+	if !exists || resourceLimitJSON == "{}" {
 		return admission.ResponseAllowed(), nil
 	}
 

--- a/pkg/resources/core/v1/namespace/requestlimits.go
+++ b/pkg/resources/core/v1/namespace/requestlimits.go
@@ -1,0 +1,104 @@
+package namespace
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/rancher/webhook/pkg/admission"
+	objectsv1 "github.com/rancher/webhook/pkg/generated/objects/core/v1"
+	admissionv1 "k8s.io/api/admission/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/utils/trace"
+)
+
+const resourceLimitAnnotation = "field.cattle.io/containerDefaultResourceLimit"
+
+type requestLimitAdmitter struct{}
+
+// Admit ensures that the resource requests are within the limits.
+func (r *requestLimitAdmitter) Admit(request *admission.Request) (*admissionv1.AdmissionResponse, error) {
+	listTrace := trace.New("Namespace Admit", trace.Field{Key: "user", Value: request.UserInfo.Username})
+	defer listTrace.LogIfLong(admission.SlowTraceDuration)
+
+	switch request.Operation {
+	case admissionv1.Create:
+		ns, err := objectsv1.NamespaceFromRequest(&request.AdmissionRequest)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode namespace from request: %w", err)
+		}
+		return r.admitCommonCreateUpdate(nil, ns)
+	case admissionv1.Update:
+		oldns, ns, err := objectsv1.NamespaceOldAndNewFromRequest(&request.AdmissionRequest)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode namespace from request: %w", err)
+		}
+		return r.admitCommonCreateUpdate(oldns, ns)
+	}
+	return admission.ResponseAllowed(), nil
+}
+
+type ResourceLimits struct {
+	LimitsCpu      string `json:"limitsCpu"`
+	LimitsMemory   string `json:"limitsMemory"`
+	RequestsCpu    string `json:"requestsCpu"`
+	RequestsMemory string `json:"requestsMemory"`
+}
+
+// admitCommonCreateUpdate will extract the annotation values that contain the resource limits and will call
+// the validateResourceLimitsWithUnits function to determine whether or not the request is valid.
+func (r *requestLimitAdmitter) admitCommonCreateUpdate(_, newNamespace *v1.Namespace) (*admissionv1.AdmissionResponse, error) {
+	annotations := newNamespace.Annotations
+	if annotations == nil {
+		return admission.ResponseAllowed(), nil
+	}
+
+	resourceLimitJSON, exists := annotations[resourceLimitAnnotation]
+	if !exists {
+		return admission.ResponseAllowed(), nil
+	}
+
+	var resourceLimits ResourceLimits
+	if err := json.Unmarshal([]byte(resourceLimitJSON), &resourceLimits); err != nil {
+		return admission.ResponseBadRequest(fmt.Sprintf("invalid resource limits annotation: %v", err)), nil
+	}
+
+	if err := validateResourceLimitsWithUnits(resourceLimits); err != nil {
+		return admission.ResponseBadRequest(err.Error()), nil
+	}
+
+	return admission.ResponseAllowed(), nil
+}
+
+// validateResourceLimitsWithUnits takes a set of cpu/memory requests/limits and will return an error if the requests are
+// malformed or greater than the limits.
+func validateResourceLimitsWithUnits(limits ResourceLimits) error {
+	requestsCpu, err := resource.ParseQuantity(limits.RequestsCpu)
+	if err != nil {
+		return fmt.Errorf("invalid requestsCpu value: %v", err)
+	}
+
+	limitsCpu, err := resource.ParseQuantity(limits.LimitsCpu)
+	if err != nil {
+		return fmt.Errorf("invalid limitsCpu value: %v", err)
+	}
+
+	if requestsCpu.Cmp(limitsCpu) > 0 {
+		return fmt.Errorf("requestsCpu (%s) cannot be greater than limitsCpu (%s)", requestsCpu.String(), limitsCpu.String())
+	}
+
+	requestsMemory, err := resource.ParseQuantity(limits.RequestsMemory)
+	if err != nil {
+		return fmt.Errorf("invalid requestsMemory value: %v", err)
+	}
+
+	limitsMemory, err := resource.ParseQuantity(limits.LimitsMemory)
+	if err != nil {
+		return fmt.Errorf("invalid limitsMemory value: %v", err)
+	}
+
+	if requestsMemory.Cmp(limitsMemory) > 0 {
+		return fmt.Errorf("requestsMemory (%s) cannot be greater than limitsMemory (%s)", requestsMemory.String(), limitsMemory.String())
+	}
+
+	return nil
+}

--- a/pkg/resources/core/v1/namespace/requestlimits_test.go
+++ b/pkg/resources/core/v1/namespace/requestlimits_test.go
@@ -1,0 +1,119 @@
+package namespace
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/rancher/webhook/pkg/admission"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const testNs = "test-ns"
+
+func TestRequestLimitAdmitter(t *testing.T) {
+	tests := []struct {
+		name             string
+		operationType    v1.Operation
+		limitsAnnotation string
+		wantAllowed      bool
+	}{
+		{
+			name:             "create ns within resource limits",
+			operationType:    v1.Create,
+			limitsAnnotation: `{"limitsCpu": "500m", "requestsCpu": "100m", "limitsMemory": "128Mi", "requestsMemory": "64Mi"}`,
+			wantAllowed:      true,
+		},
+		{
+			name:             "create ns exceeds resource limits",
+			operationType:    v1.Create,
+			limitsAnnotation: `{"limitsCpu": "200m", "limitsMemory": "256Mi", "requestsCpu": "1", "requestsMemory": "1Gi"}`,
+			wantAllowed:      false,
+		},
+		{
+			name:             "create ns invalid JSON in annotation",
+			operationType:    v1.Create,
+			limitsAnnotation: `invalid-json`,
+			wantAllowed:      false,
+		},
+		{
+			name:             "create ns no request annotation",
+			operationType:    v1.Create,
+			limitsAnnotation: "",
+			wantAllowed:      true,
+		},
+		{
+			name:             "update ns within resource limits",
+			operationType:    v1.Update,
+			limitsAnnotation: `{"limitsCpu": "500m", "requestsCpu": "100m", "limitsMemory": "128Mi", "requestsMemory": "64Mi"}`,
+			wantAllowed:      true,
+		},
+		{
+			name:             "update ns exceeds resource limits",
+			operationType:    v1.Update,
+			limitsAnnotation: `{"limitsCpu": "200m", "limitsMemory": "256Mi", "requestsCpu": "1", "requestsMemory": "1Gi"}`,
+			wantAllowed:      false,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			admitter := requestLimitAdmitter{}
+			request, err := createRequestLimitRequest(test.limitsAnnotation, test.operationType)
+			if test.operationType == v1.Update {
+				request.AdmissionRequest.OldObject.Raw, err = json.Marshal(corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testNs,
+					},
+				})
+			}
+			assert.NoError(t, err)
+			response, err := admitter.Admit(request)
+			assert.NoError(t, err)
+			assert.Equal(t, test.wantAllowed, response.Allowed)
+		})
+	}
+}
+
+func createRequestLimitRequest(limitsAnnotation string, operation v1.Operation) (*admission.Request, error) {
+	gvk := metav1.GroupVersionKind{Version: "v1", Kind: "Namespace"}
+	gvr := metav1.GroupVersionResource{Version: "v1", Resource: "namespace"}
+
+	ns := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testNs,
+		},
+	}
+	if limitsAnnotation != "" {
+		ns.Annotations = map[string]string{
+			resourceLimitAnnotation: limitsAnnotation,
+		}
+	}
+
+	req := &admission.Request{
+		AdmissionRequest: v1.AdmissionRequest{
+			UID:             "",
+			Kind:            gvk,
+			Resource:        gvr,
+			RequestKind:     &gvk,
+			RequestResource: &gvr,
+			Name:            ns.Name,
+			Operation:       operation,
+			UserInfo:        authenticationv1.UserInfo{Username: "test-user", UID: ""},
+		},
+		Context: context.Background(),
+	}
+
+	var err error
+	req.Object.Raw, err = json.Marshal(ns)
+	if err != nil {
+		return nil, err
+	}
+	return req, nil
+}

--- a/pkg/resources/core/v1/namespace/requestlimits_test.go
+++ b/pkg/resources/core/v1/namespace/requestlimits_test.go
@@ -59,22 +59,46 @@ func TestRequestLimitAdmitter(t *testing.T) {
 			wantAllowed:      false,
 		},
 		{
-			name:             "create ns within incomplete resource limits",
+			name:             "create ns within only cpu req and limit",
 			operationType:    v1.Create,
 			limitsAnnotation: `{"limitsCpu": "500m", "requestsCpu": "100m"}`,
+			wantAllowed:      true,
+		},
+		{
+			name:             "create ns within invalid cpu req and limit",
+			operationType:    v1.Create,
+			limitsAnnotation: `{"limitsCpu": "100m", "requestsCpu": "500m"}`,
 			wantAllowed:      false,
 		},
 		{
-			name:             "update ns within incomplete resource limits",
-			operationType:    v1.Create,
+			name:             "update ns within only memory resource req and limit",
+			operationType:    v1.Update,
 			limitsAnnotation: `{"limitsCpu": "500m", "requestsCpu": "100m"}`,
-			wantAllowed:      false,
+			wantAllowed:      true,
+		},
+		{
+			name:             "create ns within only memory req and cpu limit",
+			operationType:    v1.Create,
+			limitsAnnotation: `{"limitsMemory": "256Mi", "limitssCpu": "100m"}`,
+			wantAllowed:      true,
 		},
 		{
 			name:             "create ns within empty resource limits",
 			operationType:    v1.Create,
 			limitsAnnotation: `{}`,
 			wantAllowed:      true,
+		},
+		{
+			name:             "create ns within invalid cpu limits",
+			operationType:    v1.Create,
+			limitsAnnotation: `{"limitsCpu": "25invalid"}`,
+			wantAllowed:      false,
+		},
+		{
+			name:             "update ns within invalid memory limits",
+			operationType:    v1.Update,
+			limitsAnnotation: `{"limitsMemory": "77foobar"}`,
+			wantAllowed:      false,
 		},
 	}
 

--- a/pkg/resources/core/v1/namespace/requestlimits_test.go
+++ b/pkg/resources/core/v1/namespace/requestlimits_test.go
@@ -58,6 +58,24 @@ func TestRequestLimitAdmitter(t *testing.T) {
 			limitsAnnotation: `{"limitsCpu": "200m", "limitsMemory": "256Mi", "requestsCpu": "1", "requestsMemory": "1Gi"}`,
 			wantAllowed:      false,
 		},
+		{
+			name:             "create ns within incomplete resource limits",
+			operationType:    v1.Create,
+			limitsAnnotation: `{"limitsCpu": "500m", "requestsCpu": "100m"}`,
+			wantAllowed:      false,
+		},
+		{
+			name:             "update ns within incomplete resource limits",
+			operationType:    v1.Create,
+			limitsAnnotation: `{"limitsCpu": "500m", "requestsCpu": "100m"}`,
+			wantAllowed:      false,
+		},
+		{
+			name:             "create ns within empty resource limits",
+			operationType:    v1.Create,
+			limitsAnnotation: `{}`,
+			wantAllowed:      true,
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/resources/core/v1/namespace/validator.go
+++ b/pkg/resources/core/v1/namespace/validator.go
@@ -18,8 +18,9 @@ var projectsGVR = schema.GroupVersionResource{
 
 // Validator validates the namespace admission request.
 type Validator struct {
-	psaAdmitter              psaLabelAdmitter
-	projectNamespaceAdmitter projectNamespaceAdmitter
+	psaAdmitter                psaLabelAdmitter
+	projectNamespaceAdmitter   projectNamespaceAdmitter
+	requestWithinLimitAdmitter requestLimitAdmitter
 }
 
 // NewValidator returns a new validator used for validation of namespace requests.
@@ -31,6 +32,7 @@ func NewValidator(sar authorizationv1.SubjectAccessReviewInterface) *Validator {
 		projectNamespaceAdmitter: projectNamespaceAdmitter{
 			sar: sar,
 		},
+		requestWithinLimitAdmitter: requestLimitAdmitter{},
 	}
 }
 
@@ -90,5 +92,5 @@ func (v *Validator) ValidatingWebhook(clientConfig admissionv1.WebhookClientConf
 
 // Admitters returns the psaAdmitter and the projectNamespaceAdmitter for namespaces.
 func (v *Validator) Admitters() []admission.Admitter {
-	return []admission.Admitter{&v.psaAdmitter, &v.projectNamespaceAdmitter}
+	return []admission.Admitter{&v.psaAdmitter, &v.projectNamespaceAdmitter, &v.requestWithinLimitAdmitter}
 }

--- a/pkg/resources/core/v1/namespace/validator_test.go
+++ b/pkg/resources/core/v1/namespace/validator_test.go
@@ -28,7 +28,7 @@ func TestOperations(t *testing.T) {
 func TestAdmitters(t *testing.T) {
 	validator := NewValidator(nil)
 	admitters := validator.Admitters()
-	assert.Len(t, admitters, 2)
+	assert.Len(t, admitters, 3)
 	hasPSAAdmitter := false
 	hasProjectNamespaceAdmitter := false
 	for i := range admitters {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
[#44825](https://github.com/rancher/rancher/issues/44825)
<!-- If your PR depends on changes from other PRs, link them here and describe why they are needed for your solution section. -->
## Problem
<!-- Describe the root cause of the issue you are resolving. 
This may include what behavior is observed and why it is not desirable. If this is a new feature, describe why we need it and how it will be used. -->
There is no validation of the cpu/memory request/limits when creating namespaces, which leads to Rancher attempting to create invalid objects.

## Solution
<!-- Describe what you changed to fix the issue. 
Relate your changes to the original bug/feature and explain why this addresses the issue. -->
The webhook now validates cpu/memory request/limits, if provided.
If a request or limit is provided by itself, we just validate that it is indeed a properly formatted value.
If both a cpu request/limit or a memory request/limit pair is provided, we also check to be sure that the request is less than or equal to the limit.
If parsing any of the provided values fails or if a request is greater than the limit, the webhook will refuse the request.

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [x] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [x] Docs