### PR TITLE
Prevent deletion of `local` cluster

### DIFF
--- a/pkg/resources/common/psa-validation.go
+++ b/pkg/resources/common/psa-validation.go
@@ -23,7 +23,7 @@ var psaLabels = []string{
 
 // IsUpdatingPSAConfig will indicate whether or not the labels being passed in
 // are attempting to update PSA-related configuration.
-func IsUpdatingPSAConfig(old map[string]string, new map[string]string) bool {
+func IsUpdatingPSAConfig(old, new map[string]string) bool {
 	for _, label := range psaLabels {
 		if old[label] != new[label] {
 			return true

--- a/pkg/resources/core/v1/namespace/projectannotations.go
+++ b/pkg/resources/core/v1/namespace/projectannotations.go
@@ -15,6 +15,8 @@ import (
 )
 
 const (
+	fleetLocalNs        = "fleet-local"
+	localNs             = "local"
 	manageNSVerb        = "manage-namespaces"
 	projectNSAnnotation = "field.cattle.io/projectId"
 )
@@ -23,8 +25,10 @@ type projectNamespaceAdmitter struct {
 	sar authorizationv1.SubjectAccessReviewInterface
 }
 
-// Admit ensures that the user has permission to change the namespace annotation for
-// project membership, effectively moving a project from one namespace to another.
+// Admit ensures that the:
+//   - user has permission to change the namespace annotation for project membership, effectively moving a project from
+//     one namespace to another.
+//   - deletion of `local` and `fleet-local` namespace is not allowed
 func (p *projectNamespaceAdmitter) Admit(request *admission.Request) (*admissionv1.AdmissionResponse, error) {
 	listTrace := trace.New("Namespace Admit", trace.Field{Key: "user", Value: request.UserInfo.Username})
 	defer listTrace.LogIfLong(admission.SlowTraceDuration)
@@ -36,6 +40,11 @@ func (p *projectNamespaceAdmitter) Admit(request *admission.Request) (*admission
 		return nil, fmt.Errorf("failed to decode namespace from request: %w", err)
 	}
 
+	if request.Operation == admissionv1.Delete {
+		if oldNs.Name == localNs || oldNs.Name == fleetLocalNs {
+			return admission.ResponseBadRequest(fmt.Sprintf("deletion of namespace %q is not allowed\n", request.Name)), nil
+		}
+	}
 	projectAnnoValue, ok := newNs.Annotations[projectNSAnnotation]
 	if !ok {
 		// this namespace doesn't belong to a project, let standard RBAC handle it

--- a/pkg/resources/core/v1/namespace/validator.go
+++ b/pkg/resources/core/v1/namespace/validator.go
@@ -49,6 +49,7 @@ func (v *Validator) Operations() []admissionv1.OperationType {
 	return []admissionv1.OperationType{
 		admissionv1.Update,
 		admissionv1.Create,
+		admissionv1.Delete,
 	}
 }
 
@@ -87,7 +88,10 @@ func (v *Validator) ValidatingWebhook(clientConfig admissionv1.WebhookClientConf
 	}
 	kubeSystemCreateWebhook.FailurePolicy = admission.Ptr(admissionv1.Ignore)
 
-	return []admissionv1.ValidatingWebhook{*standardWebhook, *createWebhook, *kubeSystemCreateWebhook}
+	deleteWebhook := admission.NewDefaultValidatingWebhook(v, clientConfig, admissionv1.ClusterScope, []admissionv1.OperationType{admissionv1.Delete})
+	deleteWebhook.Name = admission.CreateWebhookName(v, "delete-only")
+
+	return []admissionv1.ValidatingWebhook{*standardWebhook, *createWebhook, *kubeSystemCreateWebhook, *deleteWebhook}
 }
 
 // Admitters returns the psaAdmitter and the projectNamespaceAdmitter for namespaces.

--- a/pkg/resources/core/v1/namespace/validator_test.go
+++ b/pkg/resources/core/v1/namespace/validator_test.go
@@ -20,7 +20,7 @@ func TestGVR(t *testing.T) {
 func TestOperations(t *testing.T) {
 	validator := NewValidator(nil)
 	operations := validator.Operations()
-	assert.Len(t, operations, 2)
+	assert.Len(t, operations, 3)
 	assert.Contains(t, operations, v1.Update)
 	assert.Contains(t, operations, v1.Create)
 }
@@ -56,7 +56,7 @@ func TestValidatingWebhook(t *testing.T) {
 	wantURL := "test.cattle.io/namespaces"
 	validator := NewValidator(nil)
 	webhooks := validator.ValidatingWebhook(clientConfig)
-	assert.Len(t, webhooks, 3)
+	assert.Len(t, webhooks, 4)
 	hasAllUpdateWebhook := false
 	hasCreateNonKubeSystemWebhook := false
 	hasCreateKubeSystemWebhook := false
@@ -71,7 +71,7 @@ func TestValidatingWebhook(t *testing.T) {
 		operation := operations[0]
 		assert.Equal(t, v1.ClusterScope, *rule.Scope)
 
-		assert.Contains(t, []v1.OperationType{v1.Create, v1.Update}, operation, "only expected webhooks for create and update")
+		assert.Contains(t, []v1.OperationType{v1.Create, v1.Update, v1.Delete}, operation, "only expected webhooks for create, update and delete")
 		if operation == v1.Update {
 			assert.False(t, hasAllUpdateWebhook, "had more than one webhook validating update calls, exepcted only one")
 			hasAllUpdateWebhook = true
@@ -81,7 +81,7 @@ func TestValidatingWebhook(t *testing.T) {
 				// failure policy defaults to fail, but if we specify one it needs to be fail
 				assert.Equal(t, v1.Fail, *webhook.FailurePolicy)
 			}
-		} else {
+		} else if operation == v1.Create {
 			assert.NotNil(t, webhook.NamespaceSelector)
 			matchExpressions := webhook.NamespaceSelector.MatchExpressions
 			assert.Len(t, matchExpressions, 1)

--- a/pkg/resources/management.cattle.io/v3/cluster/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/cluster/validator_test.go
@@ -309,6 +309,16 @@ func TestAdmit(t *testing.T) {
 			expectAllowed:  true,
 			expectedReason: metav1.StatusReasonBadRequest,
 		},
+		{
+			name:      "Delete local cluster where Rancher is deployed",
+			operation: admissionv1.Delete,
+			oldCluster: v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "local",
+				},
+			},
+			expectAllowed: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from other PRs, link them here and describe why they are needed for your solution section. -->

https://github.com/rancher/rancher/issues/32745
https://github.com/rancher/rancher/issues/48303

## Problem
<!-- Describe the root cause of the issue you are resolving. 
This may include what behavior is observed and why it is not desirable. If this is a new feature, describe why we need it and how it will be used. -->

Presently, it's possible to delete the `local` cluster using:
```sh
$ k delete cluster.management.cattle.io local
```

Other ways the `local` cluster, one on which Rancher is deployed, could be corrupted are mentioned in https://github.com/rancher/rancher/issues/48303.

## Solution
<!-- Describe what you changed to fix the issue. 
Relate your changes to the original bug/feature and explain why this addresses the issue. -->

* Prevent `local` cluster deletion:

  ```sh
  $  k delete cluster.management.cattle.io local
  Error from server (BadRequest): admission webhook "rancher.cattle.io.clusters.management.cattle.io" denied the request: cannot delete the local cluster
  ```

* Prevent deletion of `local` and `fleet-local` namespaces:
  ```sh
  $ k delete ns local
  Error from server (BadRequest): admission webhook "rancher.cattle.io.namespaces" denied the request: deletion of namespace "local" is not allowed

  $ k delete ns fleet-local
  Error from server (BadRequest): admission webhook "rancher.cattle.io.namespaces" denied the request: deletion of namespace "fleet-local" is not allowed
  ```

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [x] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [x] Docs