### PR TITLE
Add sync deps workflow

### DIFF
--- a/.github/workflows/scripts/sync-deps.sh
+++ b/.github/workflows/scripts/sync-deps.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+set -e
+
+RANCHER_REPO_DIR=$1
+
+DEPS_TO_SYNC="
+  github.com/rancher/dynamiclistener
+  github.com/rancher/lasso
+  github.com/rancher/wrangler
+  github.com/rancher/wrangler/v2
+  github.com/rancher/wrangler/v3
+"
+
+rancher_deps=$(cd "$RANCHER_REPO_DIR" && go mod graph)
+webhook_deps=$(go mod graph)
+
+rancher_ref=$(cd "$RANCHER_REPO_DIR" && git rev-parse HEAD)
+rancher_ref_version=$(go mod download -json "github.com/rancher/rancher/pkg/apis@$rancher_ref" | jq -r '.Version')
+echo "Syncing github.com/rancher/rancher/pkg/apis"
+go mod edit "-require=github.com/rancher/rancher/pkg/apis@$rancher_ref_version"
+
+for dep in $DEPS_TO_SYNC; do
+  if ! rancher_version=$(echo "$rancher_deps" | grep "^$dep@\w*\S"); then
+    continue
+  fi
+
+  if ! webhook_version=$(echo "$webhook_deps" | grep "^$dep@\w*\S"); then
+    continue
+  fi
+
+  rancher_version=$(echo "$rancher_version" | head -n 1 | cut -d' ' -f1 | cut -d@ -f2)
+  webhook_version=$(echo "$webhook_version" | head -n 1 | cut -d' ' -f1 | cut -d@ -f2)
+  if [ "$rancher_version" = "$webhook_version" ]; then
+    continue
+  fi
+
+  echo "Version mismatch for $dep (rancher=$rancher_version, webhook=$webhook_version) detected"
+  go mod edit -require=$dep@$rancher_version
+done
+
+echo "Running go mod tidy"
+go mod tidy

--- a/.github/workflows/scripts/sync-deps.sh
+++ b/.github/workflows/scripts/sync-deps.sh
@@ -3,7 +3,10 @@
 set -e
 
 RANCHER_REPO_DIR=$1
+# File to write the changes to
+CHANGES_FILE=${2:-/dev/null}
 
+PKG_APIS="github.com/rancher/rancher/pkg/apis"
 DEPS_TO_SYNC="
   github.com/rancher/dynamiclistener
   github.com/rancher/lasso
@@ -12,13 +15,26 @@ DEPS_TO_SYNC="
   github.com/rancher/wrangler/v3
 "
 
+update_dep() {
+  module=$1
+  old_version=$2
+  new_version=$3
+
+  echo "Version mismatch for $module (rancher=$new_version, webhook=$old_version) detected"
+  go mod edit -require="$module@$new_version"
+  echo "Updated $module ($old_version => $new_version)" >> "$CHANGES_FILE"
+}
+
 rancher_deps=$(cd "$RANCHER_REPO_DIR" && go mod graph)
 webhook_deps=$(go mod graph)
 
 rancher_ref=$(cd "$RANCHER_REPO_DIR" && git rev-parse HEAD)
-rancher_ref_version=$(go mod download -json "github.com/rancher/rancher/pkg/apis@$rancher_ref" | jq -r '.Version')
-echo "Syncing github.com/rancher/rancher/pkg/apis"
-go mod edit "-require=github.com/rancher/rancher/pkg/apis@$rancher_ref_version"
+rancher_pkg_apis_version=$(go mod download -json "github.com/rancher/rancher/pkg/apis@$rancher_ref" | jq -r '.Version')
+webhook_pkg_apis_version=$(echo "$webhook_deps" | grep "^$PKG_APIS@\w*\S" | head -n 1 | cut -d' ' -f1 | cut -d@ -f2)
+
+if [ "$rancher_pkg_apis_version" != "$webhook_pkg_apis_version" ]; then
+  update_dep "$PKG_APIS" "$webhook_pkg_apis_version" "$rancher_pkg_apis_version"
+fi
 
 for dep in $DEPS_TO_SYNC; do
   if ! rancher_version=$(echo "$rancher_deps" | grep "^$dep@\w*\S"); then
@@ -35,8 +51,7 @@ for dep in $DEPS_TO_SYNC; do
     continue
   fi
 
-  echo "Version mismatch for $dep (rancher=$rancher_version, webhook=$webhook_version) detected"
-  go mod edit -require=$dep@$rancher_version
+  update_dep "$dep" "$webhook_version" "$rancher_version"
 done
 
 echo "Running go mod tidy"

--- a/.github/workflows/scripts/sync-deps.sh
+++ b/.github/workflows/scripts/sync-deps.sh
@@ -33,7 +33,7 @@ update_dep() {
 
   echo "Version mismatch for $module (rancher=$new_version, webhook=$old_version) detected"
   go mod edit -require="$module@$new_version"
-  echo "Updated $module ($old_version => $new_version)" >> "$CHANGES_FILE"
+  printf '**%s**\n`%s` => `%s`' "$module" "$old_version" "$new_version" >> "$CHANGES_FILE"
 }
 
 rancher_deps=$(cd "$RANCHER_REPO_DIR" && go mod graph)

--- a/.github/workflows/sync-deps.yaml
+++ b/.github/workflows/sync-deps.yaml
@@ -53,16 +53,23 @@ jobs:
           BRANCH="sync-deps-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
           git checkout -b "$BRANCH"
-          ./.github/workflows/scripts/sync-deps.sh ../rancher 
-          git add go.mod go.sum
-          git commit -m "Sync dependencies"
-          git push origin "$BRANCH"
+          ./.github/workflows/scripts/sync-deps.sh ../rancher "changes.txt"
+          if [ -f changes.txt ]; then
+            git add go.mod go.sum
+            git commit -m "Sync dependencies"
+            git push origin "$BRANCH"
+          fi
 
       - name: Create PR
+        # Only create the PR if changes were detected
+        if: ${{ hashFiles('webhook/changes.txt') != '' }}
         run: |
           cd webhook
+          changes=$(cat changes.txt)
           body=$(cat <<EOF
           # Sync with Rancher
+
+          $changes
 
           The workflow was triggered by $GITHUB_TRIGGERING_ACTOR.
           EOF

--- a/.github/workflows/sync-deps.yaml
+++ b/.github/workflows/sync-deps.yaml
@@ -1,0 +1,78 @@
+name: Sync dependencies
+
+on:
+  workflow_dispatch:
+    inputs:
+      rancher_ref:
+        description: "Version of rancher/rancher to compare"
+        required: true
+        default: "main"
+      rancher_repository:
+        description: "Repository for rancher/rancher"
+        required: true
+        default: "rancher/rancher"
+
+env:
+  RANCHER_REF: "${{ github.event.inputs.rancher_ref }}"
+  WEBHOOK_REF: "${{ github.ref_name }}"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    name: Sync dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name : Checkout webhook repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: "${{ env.WEBHOOK_REF }}"
+          path: webhook
+
+      - name : Checkout rancher repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          repository: "${{ github.event.inputs.rancher_repository }}"
+          ref: "${{ env.RANCHER_REF }}"
+          path: rancher
+
+      - name: Install dependencies
+        run: sudo snap install yq --channel=v4/stable
+
+      - name: Configure the committer
+        run: |
+          cd webhook
+          git config --global user.name "Webhook Sync Bot"
+          git config --global user.email "webhooksyncbot@users.noreply.github.com"
+
+      - name: Run sync-deps script
+        run: |
+          cd webhook
+          BRANCH="sync-deps-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
+          git checkout -b "$BRANCH"
+          ./.github/workflows/scripts/sync-deps.sh ../rancher 
+          git add go.mod go.sum
+          git commit -m "Sync dependencies"
+          git push origin "$BRANCH"
+
+      - name: Create PR
+        run: |
+          cd webhook
+          body=$(cat <<EOF
+          # Sync with Rancher
+
+          The workflow was triggered by $GITHUB_TRIGGERING_ACTOR.
+          EOF
+          )
+          gh pr create \
+            --title "[$WEBHOOK_REF] Sync webhook dependencies" \
+            --body "$body" \
+            --reviewer "$GITHUB_TRIGGERING_ACTOR" \
+            --repo "${{ github.repository }}" \
+            --head "${{ github.repository_owner }}:$BRANCH" \
+            --base "$WEBHOOK_REF"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-deps.yaml
+++ b/.github/workflows/sync-deps.yaml
@@ -53,8 +53,8 @@ jobs:
           BRANCH="sync-deps-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
           git checkout -b "$BRANCH"
-          ./.github/workflows/scripts/sync-deps.sh ../rancher "changes.txt"
-          if [ -f changes.txt ]; then
+          ./.github/workflows/scripts/sync-deps.sh ../rancher "changes.md"
+          if [ -f changes.md ]; then
             git add go.mod go.sum
             git commit -m "Sync dependencies"
             git push origin "$BRANCH"
@@ -62,10 +62,10 @@ jobs:
 
       - name: Create PR
         # Only create the PR if changes were detected
-        if: ${{ hashFiles('webhook/changes.txt') != '' }}
+        if: ${{ hashFiles('webhook/changes.md') != '' }}
         run: |
           cd webhook
-          changes=$(cat changes.txt)
+          changes=$(cat changes.md)
           body=$(cat <<EOF
           # Sync with Rancher
 


### PR DESCRIPTION
# Issue: https://github.com/rancher/rancher/issues/47852

Automates syncing webhook and rancher dependencies. Simply go to actions tab, click on "Sync dependencies" workflow, click on "Run workflow", specify the webhook branch and the rancher branch and run.

The GHA workflow will compare the two dependency list (for specific dependencies) and will ensure webhook has the same. It will then create a PR and assign you to the PR. You can then review the PR.

Here's an example workflow run https://github.com/tomleb/rancher-webhook/actions/runs/12319259499 with its associated opened PR: https://github.com/tomleb/rancher-webhook/pull/19.