### PR TITLE
[v0.7|main] Make admission rejection message more useful for namespace creation

### DIFF
--- a/pkg/resources/core/v1/namespace/projectannotations.go
+++ b/pkg/resources/core/v1/namespace/projectannotations.go
@@ -87,10 +87,13 @@ func (p *projectNamespaceAdmitter) Admit(request *admission.Request) (*admission
 		return response, nil
 	}
 
+	constructedReason := fmt.Sprintf("User %q does not have permission %q on project %q",
+		request.UserInfo.Username, manageNSVerb, projectName)
+
 	response.Allowed = false
 	response.Result = &metav1.Status{
 		Status:  "Failure",
-		Message: sarResponse.Status.Reason,
+		Message: constructedReason,
 		Reason:  metav1.StatusReasonUnauthorized,
 		Code:    http.StatusForbidden,
 	}

--- a/pkg/resources/core/v1/namespace/projectannotations_test.go
+++ b/pkg/resources/core/v1/namespace/projectannotations_test.go
@@ -27,6 +27,7 @@ func TestValidateProjectNamespaceAnnotations(t *testing.T) {
 		includeProjectAnnotation  bool
 		targetProject             string
 		userCanAccessProject      bool
+		rejectMessage             string
 		sarError                  bool
 		wantError                 bool
 		wantAllowed               bool
@@ -72,6 +73,7 @@ func TestValidateProjectNamespaceAnnotations(t *testing.T) {
 			includeProjectAnnotation: true,
 			targetProject:            "p-123xyz",
 			userCanAccessProject:     false,
+			rejectMessage:            "User \"test-user\" does not have permission \"manage-namespaces\" on project \"p-123xyz\"",
 			sarError:                 false,
 			wantError:                false,
 			wantAllowed:              false,
@@ -220,6 +222,9 @@ func TestValidateProjectNamespaceAnnotations(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, test.wantAllowed, response.Allowed)
+				if test.rejectMessage != "" {
+					assert.Equal(t, test.rejectMessage, response.Result.Message)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from other PRs, link them here and describe why they are needed for your solution section. -->
https://github.com/rancher/rancher/issues/47585

## Problem
<!-- Describe the root cause of the issue you are resolving. 
This may include what behavior is observed and why it is not desirable. If this is a new feature, describe why we need it and how it will be used. -->
Webhook rejection message was not useful in this situation

## Solution
<!-- Describe what you changed to fix the issue. 
Relate your changes to the original bug/feature and explain why this addresses the issue. -->
Include user, verb, resource in the rejection message.


## Testing notes
To make this situation show up, you can create a roletemplate like the one below

```
apiVersion: management.cattle.io/v3
builtin: false
context: project
description: ""
displayName: nomanagenamespace
external: false
hidden: false
kind: RoleTemplate
metadata:
  generateName: rt-
rules:
- apiGroups:
  - ""
  resources:
  - namespaces
  verbs:
  - '*'
- apiGroups:
  - management.cattle.io
  resources:
  - projects
  verbs:
  - get
  - list
  - watch
  - updatepsa

```
Then you can create a clusterroletemplatebinding to bind that role to a user that has no other permissions on a given cluster.

With that in place, login as the user to which the crtb was bound and navigate to the cluster and try to create a namespace in a project.

Prior to this fix, the error message provided just said "Unauthorized".
After this fix, the error message will look like:  `admission webhook "rancher.cattle.io.namespaces.create-non-kubesystem" denied the request: User "u-7qhg2" does not have permission "manage-namespaces" on project "p-w7252"`
