### PR TITLE
Fix release rancher and release charts GHA workflows

### DIFF
--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -5,7 +5,7 @@ on:
       charts_ref:
         description: "Submit PR against the following rancher/charts branch (eg: dev-v2.10)"
         required: true
-        default: "dev-v2.10"
+        default: "dev-v2.11"
       prev_webhook:
         description: "Previous Webhook version (eg: v0.5.0-rc.13)"
         required: true

--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -17,6 +17,7 @@ on:
 
 env:
   CHARTS_REF: ${{ github.event.inputs.charts_ref }}
+  WEBHOOK_REF: "${{ github.ref_name }}"
   PREV_WEBHOOK: ${{ github.event.inputs.prev_webhook }}
   NEW_WEBHOOK: ${{ github.event.inputs.new_webhook }}
 
@@ -30,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.ref }}
+          ref: "${{ env.WEBHOOK_REF }}"
           path: webhook
 
       - uses: rancher-eio/read-vault-secrets@main

--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -51,8 +51,8 @@ jobs:
       - name: Checkout charts repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           repository: ${{ github.repository_owner }}/charts
+          ref: "${{ env.CHARTS_REF }}"
           token: ${{ steps.app-token.outputs.token }}
           path: charts
           # Allow making git push request later on

--- a/.github/workflows/release-rancher.yaml
+++ b/.github/workflows/release-rancher.yaml
@@ -51,8 +51,8 @@ jobs:
       - name: Checkout rancher repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           repository: ${{ github.repository_owner }}/rancher
+          ref: "${{ env.RANCHER_REF }}"
           token: ${{ steps.app-token.outputs.token }}
           path: rancher
           # Allow making git push request later on

--- a/.github/workflows/release-rancher.yaml
+++ b/.github/workflows/release-rancher.yaml
@@ -17,6 +17,7 @@ on:
 
 env:
   RANCHER_REF: ${{ github.event.inputs.rancher_ref }}
+  WEBHOOK_REF: "${{ github.ref_name }}"
   PREV_WEBHOOK: ${{ github.event.inputs.prev_webhook }}
   NEW_WEBHOOK: ${{ github.event.inputs.new_webhook }}
 
@@ -30,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.ref }}
+          ref: "${{ env.WEBHOOK_REF }}"
           path: webhook
 
       - uses: rancher-eio/read-vault-secrets@main


### PR DESCRIPTION
# Issue https://github.com/rancher/rancher/issues/46704

Best review commit by commit.

The changes are:
- The default charts branch for this webhook release should be `dev-v2.11`
- We're pulling r/r and r/charts with `ref:` specified to fix "commit dev-v2.11 does not exist"
- The webhook branch cannot be obtained by `github.event.inputs.ref` so we're also fixing this