### PR TITLE
Fix release charts and release rancher GHA workflow again

### DIFF
--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -78,7 +78,7 @@ jobs:
           BRANCH="bump-webhook-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
           git checkout -b "$BRANCH" "$CHARTS_REF"
-          ./webhook/.github/workflows/scripts/release-against-charts.sh . "$PREV_WEBHOOK" "$NEW_WEBHOOK"
+          ../webhook/.github/workflows/scripts/release-against-charts.sh . "$PREV_WEBHOOK" "$NEW_WEBHOOK"
 
       - name: Push and create pull request
         env:

--- a/.github/workflows/release-rancher.yaml
+++ b/.github/workflows/release-rancher.yaml
@@ -78,7 +78,7 @@ jobs:
           BRANCH="bump-webhook-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
           git checkout -b "$BRANCH" "$RANCHER_REF"
-          ./webhook/.github/workflows/scripts/release-against-rancher.sh . "$NEW_WEBHOOK"
+          ../webhook/.github/workflows/scripts/release-against-rancher.sh . "$NEW_WEBHOOK"
 
       - name: Push and create pull request
         env:


### PR DESCRIPTION
The path was wrong because we're in `charts` so the script should be `../webhook/....`