### PR TITLE
Ensure go telemetry files aren't added to the commit

### DIFF
--- a/.github/workflows/scripts/release-against-rancher.sh
+++ b/.github/workflows/scripts/release-against-rancher.sh
@@ -87,7 +87,7 @@ make .dapper
 
 # DAPPER_MODE=bind will make sure we output everything that changed
 DAPPER_MODE=bind ./.dapper go generate ./... || true
-DAPPER_MODE=bind ./.dapper rm -rf go
+DAPPER_MODE=bind ./.dapper rm -rf go .config
 
 git add .
 git commit -m "Bump webhook to ${NEW_CHART_VERSION}+up${NEW_WEBHOOK_VERSION_SHORT}"


### PR DESCRIPTION
Go telemetry in go 1.23 are written to `$HOME/.config/go/` (or xdg config). Rancher's dapper config points `$HOME` to the root of the repo, so running the `go generate`  command creates telemetry files which are then added with `git add .`. 

Since we don't want those files in the commit, we remove them before staging the files.