### PR TITLE
Support for Version Management on Imported RKE2/K3s Clusters

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -89,6 +89,14 @@ If yes, the webhook redacts the role, so that it only grants a deletion permissi
 
 ## Cluster
 
+
+### Mutation Checks
+
+##### Feature: version management on imported RKE2/K3s cluster 
+
+- When a cluster is created or updated, add the `rancher.io/imported-cluster-version-management: system-default` annotation if the annotation is missing or its value is an empty string.
+
+
 ### Validation Checks
 
 #### Annotations validation
@@ -98,6 +106,14 @@ When a cluster is created and `field.cattle.io/creator-principal-name` annotatio
 When a cluster is updated `field.cattle.io/creator-principal-name` and `field.cattle.io/creatorId` annotations must stay the same or removed.
 
 If `field.cattle.io/no-creator-rbac` annotation is set, `field.cattle.io/creatorId` cannot be set.
+
+
+##### Feature: version management on imported RKE2/K3s cluster
+
+ - When a cluster is created or updated, the `rancher.io/imported-cluster-version-management` annotation must be set with a valid value (true, false, or system-default). 
+ - If the cluster represents other types of clusters and the annotation is present, the webhook will permit the request with a warning that the annotation is intended for imported RKE2/k3s clusters and will not take effect on this cluster.
+ - If version management is determined to be disabled, and the `.spec.rke2Config` or `.spec.k3sConfig` field exists in the new cluster object with a value different from the old one, the webhook will permit the update with a warning indicating that these changes will not take effect until version management is enabled for the cluster.
+ - If version management is determined to be disabled, and the `.spec.rke2Config` or `.spec.k3sConfig` field is missing, the webhook will permit the request to allow users to remove the unused fields via API or Terraform.
 
 ## ClusterProxyConfig
 

--- a/go.mod
+++ b/go.mod
@@ -18,9 +18,11 @@ replace (
 	k8s.io/component-helpers => k8s.io/component-helpers v0.32.1
 	k8s.io/controller-manager => k8s.io/controller-manager v0.32.1
 	k8s.io/cri-api => k8s.io/cri-api v0.32.1
+	k8s.io/cri-client => k8s.io/cri-client v0.32.1
 	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.32.1
 	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.32.1
 	k8s.io/endpointslice => k8s.io/endpointslice v0.32.1
+	k8s.io/externaljwt => k8s.io/externaljwt v0.32.1
 	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.32.1
 	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.32.1
 	k8s.io/kube-proxy => k8s.io/kube-proxy v0.32.1

--- a/pkg/resources/management.cattle.io/v3/cluster/Cluster.md
+++ b/pkg/resources/management.cattle.io/v3/cluster/Cluster.md
@@ -1,3 +1,11 @@
+
+## Mutation Checks
+
+#### Feature: version management on imported RKE2/K3s cluster 
+
+- When a cluster is created or updated, add the `rancher.io/imported-cluster-version-management: system-default` annotation if the annotation is missing or its value is an empty string.
+
+
 ## Validation Checks
 
 ### Annotations validation
@@ -7,3 +15,11 @@ When a cluster is created and `field.cattle.io/creator-principal-name` annotatio
 When a cluster is updated `field.cattle.io/creator-principal-name` and `field.cattle.io/creatorId` annotations must stay the same or removed.
 
 If `field.cattle.io/no-creator-rbac` annotation is set, `field.cattle.io/creatorId` cannot be set.
+
+
+#### Feature: version management on imported RKE2/K3s cluster
+
+ - When a cluster is created or updated, the `rancher.io/imported-cluster-version-management` annotation must be set with a valid value (true, false, or system-default). 
+ - If the cluster represents other types of clusters and the annotation is present, the webhook will permit the request with a warning that the annotation is intended for imported RKE2/k3s clusters and will not take effect on this cluster.
+ - If version management is determined to be disabled, and the `.spec.rke2Config` or `.spec.k3sConfig` field exists in the new cluster object with a value different from the old one, the webhook will permit the update with a warning indicating that these changes will not take effect until version management is enabled for the cluster.
+ - If version management is determined to be disabled, and the `.spec.rke2Config` or `.spec.k3sConfig` field is missing, the webhook will permit the request to allow users to remove the unused fields via API or Terraform.

--- a/pkg/resources/management.cattle.io/v3/cluster/mutator_test.go
+++ b/pkg/resources/management.cattle.io/v3/cluster/mutator_test.go
@@ -9,6 +9,7 @@ import (
 	data2 "github.com/rancher/wrangler/v3/pkg/data"
 	"github.com/stretchr/testify/assert"
 	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -43,4 +44,64 @@ func TestAdmitPreserveUnknownFields(t *testing.T) {
 	response, err = m.Admit(request)
 	assert.Nil(t, err)
 	assert.Nil(t, response.Patch)
+}
+
+func TestMutateVersionManagement(t *testing.T) {
+	tests := []struct {
+		name      string
+		cluster   *v3.Cluster
+		operation admissionv1.Operation
+		expect    bool
+	}{
+		{
+			name:      "invalid operation",
+			cluster:   &v3.Cluster{},
+			operation: admissionv1.Delete,
+			expect:    false,
+		},
+		{
+			name: "invalid cluster",
+			cluster: &v3.Cluster{
+				Status: v3.ClusterStatus{
+					Driver: "imported",
+				},
+			},
+			operation: admissionv1.Update,
+			expect:    false,
+		},
+		{
+			name: "missing annotation",
+			cluster: &v3.Cluster{
+				Status: v3.ClusterStatus{
+					Driver: "rke2",
+				},
+			},
+			operation: admissionv1.Create,
+			expect:    true,
+		},
+		{
+			name: "empty value",
+			cluster: &v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						VersionManagementAnno: "",
+					},
+				},
+				Status: v3.ClusterStatus{
+					Driver: "k3s",
+				},
+			},
+			operation: admissionv1.Update,
+			expect:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &ManagementClusterMutator{}
+			m.mutateVersionManagement(tt.cluster, tt.operation)
+			if tt.expect {
+				assert.Equal(t, tt.cluster.Annotations[VersionManagementAnno], "system-default")
+			}
+		})
+	}
 }

--- a/pkg/resources/management.cattle.io/v3/cluster/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/cluster/validator_test.go
@@ -52,13 +52,24 @@ func TestAdmit(t *testing.T) {
 		return nil, apierrors.NewNotFound(schema.GroupResource{}, name)
 	}).AnyTimes()
 
+	settingCache := fake.NewMockNonNamespacedCacheInterface[*v3.Setting](ctrl)
+	settingCache.EXPECT().Get(gomock.Any()).DoAndReturn(func(name string) (*v3.Setting, error) {
+		if name == VersionManagementSetting {
+			return &v3.Setting{
+				Value: "true",
+			}, nil
+		}
+		return nil, apierrors.NewNotFound(schema.GroupResource{}, name)
+	}).AnyTimes()
+
 	tests := []struct {
-		name           string
-		oldCluster     v3.Cluster
-		newCluster     v3.Cluster
-		operation      admissionv1.Operation
-		expectAllowed  bool
-		expectedReason metav1.StatusReason
+		name                 string
+		oldCluster           v3.Cluster
+		newCluster           v3.Cluster
+		operation            admissionv1.Operation
+		expectAllowed        bool
+		expectedReason       metav1.StatusReason
+		expectContainWarning bool
 	}{
 		{
 			name:          "Create",
@@ -309,14 +320,167 @@ func TestAdmit(t *testing.T) {
 			expectAllowed:  true,
 			expectedReason: metav1.StatusReasonBadRequest,
 		},
+		// Test cases for the version management feature
+		{
+			name:      "cluster version management - imported RKE2 cluster,valid annotation, create",
+			operation: admissionv1.Create,
+			newCluster: v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						VersionManagementAnno: "false",
+					},
+				},
+				Status: v3.ClusterStatus{
+					Driver: v3.ClusterDriverRke2,
+				},
+			},
+			expectAllowed: true,
+		},
+
+		{
+			name:      "cluster version management - imported RKE2 cluster,no annotation, create",
+			operation: admissionv1.Create,
+			newCluster: v3.Cluster{
+				Status: v3.ClusterStatus{
+					Driver: v3.ClusterDriverRke2,
+				},
+			},
+			expectAllowed:  false,
+			expectedReason: metav1.StatusReasonBadRequest,
+		},
+		{
+			name:      "cluster version management - imported K3s cluster,valid annotation, create",
+			operation: admissionv1.Create,
+			newCluster: v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						VersionManagementAnno: "true",
+					},
+				},
+				Status: v3.ClusterStatus{
+					Driver: v3.ClusterDriverK3s,
+				},
+			},
+			expectAllowed: true,
+		},
+		{
+			name:      "cluster version management - imported K3s cluster,valid annotation, update",
+			operation: admissionv1.Update,
+			oldCluster: v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						VersionManagementAnno: "false",
+					},
+				},
+				Status: v3.ClusterStatus{
+					Driver: v3.ClusterDriverK3s,
+				},
+			},
+			newCluster: v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						VersionManagementAnno: "system-default",
+					},
+				},
+				Status: v3.ClusterStatus{
+					Driver: v3.ClusterDriverK3s,
+				},
+			},
+			expectAllowed: true,
+		},
+		{
+			name:      "cluster version management - imported K3s cluster,drop annotation, update",
+			operation: admissionv1.Update,
+			oldCluster: v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						VersionManagementAnno: "system-default",
+					},
+				},
+				Status: v3.ClusterStatus{
+					Driver: v3.ClusterDriverK3s,
+				},
+			},
+			newCluster: v3.Cluster{
+				Status: v3.ClusterStatus{
+					Driver: v3.ClusterDriverK3s,
+				},
+			},
+			expectAllowed:  false,
+			expectedReason: metav1.StatusReasonBadRequest,
+		},
+		{
+			name:      "cluster version management - imported RKE2 cluster,invalid annotation, update",
+			operation: admissionv1.Update,
+			oldCluster: v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						VersionManagementAnno: "false",
+					},
+				},
+				Status: v3.ClusterStatus{
+					Driver: v3.ClusterDriverK3s,
+				},
+			},
+			newCluster: v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						VersionManagementAnno: "INVALID",
+					},
+				},
+				Status: v3.ClusterStatus{
+					Driver: v3.ClusterDriverRke2,
+				},
+			},
+			expectAllowed:  false,
+			expectedReason: metav1.StatusReasonBadRequest,
+		},
+		{
+			name:      "cluster version management - invalid cluster type, valid annotation, create",
+			operation: admissionv1.Create,
+			newCluster: v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						VersionManagementAnno: "false",
+					},
+				},
+				Status: v3.ClusterStatus{
+					Driver: v3.ClusterDriverAKS,
+				},
+			},
+			expectAllowed:        true,
+			expectContainWarning: true,
+		},
+		{
+			name:      "cluster version management - invalid cluster type, invalid annotation, update",
+			operation: admissionv1.Create,
+			oldCluster: v3.Cluster{
+				Status: v3.ClusterStatus{
+					Driver: v3.ClusterDriverAKS,
+				},
+			},
+			newCluster: v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						VersionManagementAnno: "INVALID",
+					},
+				},
+				Status: v3.ClusterStatus{
+					Driver: v3.ClusterDriverAKS,
+				},
+			},
+			expectAllowed:        true,
+			expectContainWarning: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			v := &Validator{
 				admitter: admitter{
-					sar:       &mockReviewer{},
-					userCache: userCache,
+					sar:          &mockReviewer{},
+					userCache:    userCache,
+					settingCache: settingCache,
 				},
 			}
 
@@ -347,6 +511,105 @@ func TestAdmit(t *testing.T) {
 					assert.Equal(t, tt.expectedReason, res.Result.Reason)
 				}
 			}
+			if tt.expectContainWarning {
+				assert.NotEmpty(t, res.Warnings)
+			}
+		})
+	}
+}
+
+func Test_versionManagementEnabled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	settingCache := fake.NewMockNonNamespacedCacheInterface[*v3.Setting](ctrl)
+	settingCache.EXPECT().Get(gomock.Any()).DoAndReturn(func(name string) (*v3.Setting, error) {
+		if name == VersionManagementSetting {
+			return &v3.Setting{
+				Value: "true",
+			}, nil
+		}
+		return nil, apierrors.NewNotFound(schema.GroupResource{}, name)
+	}).AnyTimes()
+
+	tests := []struct {
+		name         string
+		cluster      *v3.Cluster
+		expectError  bool
+		expectResult bool
+	}{
+		{
+			name:         "nil cluster",
+			cluster:      nil,
+			expectError:  true,
+			expectResult: false,
+		},
+		{
+			name: "no annotation",
+			cluster: &v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+			},
+			expectError:  true,
+			expectResult: false,
+		},
+		{
+			name: "annotation value false",
+			cluster: &v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						VersionManagementAnno: "false",
+					},
+				},
+			},
+			expectError:  false,
+			expectResult: false,
+		},
+		{
+			name: "annotation value true",
+			cluster: &v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						VersionManagementAnno: "true",
+					},
+				},
+			},
+			expectError:  false,
+			expectResult: true,
+		}, {
+			name: "annotation value system-default",
+			cluster: &v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						VersionManagementAnno: "system-default",
+					},
+				},
+			},
+			expectError:  false,
+			expectResult: true,
+		}, {
+			name: "annotation value invalid",
+			cluster: &v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						VersionManagementAnno: "INVALID",
+					},
+				},
+			},
+			expectError:  true,
+			expectResult: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &admitter{
+				settingCache: settingCache,
+			}
+			got, err := a.versionManagementEnabled(tt.cluster)
+			if tt.expectError {
+				assert.Error(t, err)
+			}
+			assert.Equal(t, tt.expectResult, got)
 		})
 	}
 }

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -35,14 +35,17 @@ import (
 // Validation returns a list of all ValidatingAdmissionHandlers used by the webhook.
 func Validation(clients *clients.Clients) ([]admission.ValidatingAdmissionHandler, error) {
 	var userCache v3.UserCache
+	var settingCache v3.SettingCache
 	if clients.MultiClusterManagement {
 		userCache = clients.Management.User().Cache()
+		settingCache = clients.Management.Setting().Cache()
 	}
 
 	clusters := managementCluster.NewValidator(
 		clients.K8s.AuthorizationV1().SubjectAccessReviews(),
 		clients.Management.PodSecurityAdmissionConfigurationTemplate().Cache(),
 		userCache,
+		settingCache,
 	)
 
 	handlers := []admission.ValidatingAdmissionHandler{


### PR DESCRIPTION

## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from other PRs, link them here and describe why they are needed for your solution section. -->
https://github.com/rancher/rancher/issues/41010

## Problem
<!-- Describe the root cause of the issue you are resolving. 
This may include what behavior is observed and why it is not desirable. If this is a new feature, describe why we need it and how it will be used. -->

As a new feature, Rancher will allow enabling or disabling version management for imported RKE2/K3s clusters. 
A new annotation on the management v3 cluster object will be used to control the cluster-level setting. 
Rancher Webhook will ensure that the annotation is correctly set on eligible clusters.

Please refer to the RFC for design details. 


## Solution
<!-- Describe what you changed to fix the issue. 
Relate your changes to the original bug/feature and explain why this addresses the issue. -->

Please refer to the RFC for design details.  
Alternatively, the changes are outlined in the `pkg/resources/management.cattle.io/v3/cluster/Cluster.md` file. 
 
## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [x] Test

This PR was also validated by running the binary and pointing it to a Rancher setup. 

  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [x] Docs