### PR TITLE
Remove golang.org/x/exp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,6 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/mock v0.5.0
-	golang.org/x/exp v0.0.0-20250210185358-939b2ce775ac
 	golang.org/x/text v0.22.0
 	golang.org/x/tools v0.30.0
 	k8s.io/api v0.32.1
@@ -137,6 +136,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/crypto v0.33.0 // indirect
+	golang.org/x/exp v0.0.0-20250210185358-939b2ce775ac // indirect
 	golang.org/x/mod v0.23.0 // indirect
 	golang.org/x/net v0.35.0 // indirect
 	golang.org/x/oauth2 v0.23.0 // indirect

--- a/pkg/codegen/docs.go
+++ b/pkg/codegen/docs.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
-	"golang.org/x/exp/slices"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/mutator.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/mutator.go
@@ -6,9 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/blang/semver"
 	v1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"


### PR DESCRIPTION
Issue https://github.com/rancher/webhook/issues/677

golang.org/x/exp/slices uses `slices` indirectly 😄 