### PR TITLE
Validate authconfig only if the auth provider is enabled

### DIFF
--- a/pkg/resources/management.cattle.io/v3/authconfig/validator.go
+++ b/pkg/resources/management.cattle.io/v3/authconfig/validator.go
@@ -92,6 +92,11 @@ func (a *admitter) admitUpdate(request *admission.Request, oldAuthConfig, newAut
 func (a *admitter) admitCommonCreateUpdate(request *admission.Request, _, newAuthConfig *v3.AuthConfig) (*admissionv1.AdmissionResponse, error) {
 	var err error
 
+	if !newAuthConfig.Enabled {
+		// Validate the config only if the auth provider is enabled.
+		return admission.ResponseAllowed(), nil
+	}
+
 	switch newAuthConfig.Type {
 	case "openLdapConfig", "freeIpaConfig":
 		err = validateLDAPConfig(request)

--- a/pkg/resources/management.cattle.io/v3/authconfig/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/authconfig/validator_test.go
@@ -22,6 +22,7 @@ var (
 
 func TestValidateLdapConfig(t *testing.T) {
 	t.Parallel()
+
 	fields := v3.LdapFields{
 		Servers:                     []string{"ldap.example.com"},
 		TLS:                         true,
@@ -46,9 +47,10 @@ func TestValidateLdapConfig(t *testing.T) {
 	invalidFilter := "cn=foo" // No parentheses.
 
 	tests := []struct {
-		desc    string
-		fields  func() v3.LdapFields
-		allowed bool
+		desc     string
+		fields   func() v3.LdapFields
+		disabled bool // Whether the auth provider is disabled.
+		allowed  bool
 	}{
 		{
 			desc:    "valid config",
@@ -61,6 +63,16 @@ func TestValidateLdapConfig(t *testing.T) {
 				fields.Servers = nil
 				return fields
 			},
+		},
+		{
+			desc: "servers not specified for the disabled provider",
+			fields: func() v3.LdapFields {
+				fields := fields
+				fields.Servers = nil
+				return fields
+			},
+			disabled: true,
+			allowed:  true,
 		},
 		{
 			desc: "tls is on without certificate",
@@ -203,7 +215,7 @@ func TestValidateLdapConfig(t *testing.T) {
 					if test.fields != nil {
 						fields = test.fields()
 					}
-					testLdapAdmit(t, validator, provider, op, fields, test.allowed)
+					testLdapAdmit(t, validator, provider, op, fields, !test.disabled, test.allowed)
 				})
 			}
 		}
@@ -233,6 +245,7 @@ func TestValidateActiveDirectoryConfig(t *testing.T) {
 	}
 	config.ObjectMeta.Name = "activedirectory"
 	config.Type = "activeDirectoryConfig"
+	config.Enabled = true
 
 	invalidAttr := "1foo"     // Leading digit.
 	invalidFilter := "cn=foo" // No parentheses.
@@ -253,6 +266,16 @@ func TestValidateActiveDirectoryConfig(t *testing.T) {
 				config.Servers = nil
 				return config
 			},
+		},
+		{
+			desc: "servers not specified for the disabled provider",
+			config: func() v3.ActiveDirectoryConfig {
+				config := config
+				config.Servers = nil
+				config.Enabled = false
+				return config
+			},
+			allowed: true,
 		},
 		{
 			desc: "tls is on without certificate",
@@ -435,7 +458,7 @@ func TestIsValidLdapAttr(t *testing.T) {
 	}
 }
 
-func testLdapAdmit(t *testing.T, validator *authconfig.Validator, provider string, op v1.Operation, fields v3.LdapFields, allowed bool) {
+func testLdapAdmit(t *testing.T, validator *authconfig.Validator, provider string, op v1.Operation, fields v3.LdapFields, enabled, allowed bool) {
 	var oldConfig, newConfig any
 	switch provider {
 	case "openldap":
@@ -444,6 +467,7 @@ func testLdapAdmit(t *testing.T, validator *authconfig.Validator, provider strin
 		o.Type = "openLdapConfig"
 		n := o
 		n.LdapFields = fields
+		n.Enabled = enabled
 		oldConfig, newConfig = o, n
 	case "freeipa":
 		o := v3.OpenLdapConfig{}
@@ -451,6 +475,7 @@ func testLdapAdmit(t *testing.T, validator *authconfig.Validator, provider strin
 		o.Type = "freeIpaConfig"
 		n := o
 		n.LdapFields = fields
+		n.Enabled = enabled
 		oldConfig, newConfig = o, n
 	}
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from other PRs, link them here and describe why they are needed for your solution section. -->
## Problem
<!-- Describe the root cause of the issue you are resolving. 
This may include what behavior is observed and why it is not desirable. If this is a new feature, describe why we need it and how it will be used. -->

With #682 we introduced some required validations for LDAP/AD auth providers but we keep authconfigs objects for all auth providers even for disabled ones, which leads to errors like this

```
2025/02/27 18:02:34 [ERROR] failed to call leader func: failed to add authconfig data: admission webhook "rancher.cattle.io.authconfigs.management.cattle.io" denied the request: servers: Forbidden: at least one server is required
```

## Solution
<!-- Describe what you changed to fix the issue. 
Relate your changes to the original bug/feature and explain why this addresses the issue. -->

Validate the authconfig only if the auth provider is enabled.

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [x] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [ ] Docs