### PR TITLE
Do not validate PC and PDB settings if they have not been customized

### DIFF
--- a/pkg/resources/management.cattle.io/v3/setting/validator.go
+++ b/pkg/resources/management.cattle.io/v3/setting/validator.go
@@ -400,6 +400,10 @@ func (a *admitter) validateAgentTLSMode(oldSetting, newSetting *v3.Setting) erro
 }
 
 func (a *admitter) validateClusterAgentPriorityClass(newSetting *v3.Setting) error {
+	if newSetting.Value == "" {
+		return nil
+	}
+
 	pc := provv1.PriorityClassSpec{}
 
 	err := json.Unmarshal([]byte(newSetting.Value), &pc)
@@ -423,6 +427,10 @@ func (a *admitter) validateClusterAgentPriorityClass(newSetting *v3.Setting) err
 }
 
 func (a *admitter) validateClusterAgentPodDisruptionBudget(newSetting *v3.Setting) error {
+	if newSetting.Value == "" {
+		return nil
+	}
+
 	pdb := provv1.PodDisruptionBudgetSpec{}
 
 	err := json.Unmarshal([]byte(newSetting.Value), &pdb)

--- a/pkg/resources/management.cattle.io/v3/setting/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/setting/validator_test.go
@@ -424,6 +424,11 @@ func (s *SettingSuite) TestValidateClusterAgentSchedulingPriorityClass() {
 }
 `,
 		},
+		{
+			name:     "base case - no customization",
+			allowed:  true,
+			newValue: "",
+		},
 	}
 
 	for _, test := range tests {
@@ -537,7 +542,13 @@ func (s *SettingSuite) TestValidateClusterAgentSchedulingPodDisruptionBudget() {
 	"fake": "0",
 }`,
 		},
+		{
+			name:     "base case - no customization",
+			allowed:  true,
+			newValue: "",
+		},
 	}
+
 	for _, test := range tests {
 		test := test
 		s.T().Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
## Issue: https://github.com/rancher/backup-restore-operator/issues/642, https://github.com/rancher/rancher/issues/48995

## Problem
When the backup restore operator attempts to restore a snapshot taken from a rancher version including the PC and PDB feature, the webhook will attempt to validate the `cluster-agent-default-priority-class` and `cluster-agent-default-pod-disruption-budget` settings even if they have not been customized. This results in a json marshaling error, blocking the request. This issue will only reproduce when attempting to reapply the default settings json through BRO or manually. Manual reproduction steps can be found in the linked BRO issue. 

## Solution
Add a conditional to ensure that the setting is only validated if it has been customized. 

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [x] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [ ] Docs
   - No documentation updates required 