### PR TITLE
feat: updatepsa for project level

### DIFF
--- a/pkg/resources/core/v1/namespace/psalabels.go
+++ b/pkg/resources/core/v1/namespace/psalabels.go
@@ -73,7 +73,10 @@ func (p *psaLabelAdmitter) Admit(request *admission.Request) (*admissionv1.Admis
 	// so that if we are not able to get them,
 	// the SAR request will be done in any case.
 	if ns.Annotations[projectID] != "" {
-		projectInfo := strings.Split(ns.Annotations[projectID], ":")
+		projectNamespace, projectName, found := strings.Cut(ns.Annotations[projectID], ":")
+		if found {
+		...
+		}
 		if len(projectInfo) == 2 {
 			projectNamespace = projectInfo[0]
 			projectName = projectInfo[1]

--- a/pkg/resources/core/v1/namespace/psalabels.go
+++ b/pkg/resources/core/v1/namespace/psalabels.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	updatePSAVerb = "updatepsa"
-	projectId     = "field.cattle.io/projectId"
+	projectID     = "field.cattle.io/projectId"
 )
 
 type psaLabelAdmitter struct {
@@ -72,8 +72,8 @@ func (p *psaLabelAdmitter) Admit(request *admission.Request) (*admissionv1.Admis
 	// here we are filling the variables above with the projectId,
 	// so that if we are not able to get them,
 	// the SAR request will be done in any case.
-	if ns.Annotations[projectId] != "" {
-		projectInfo := strings.Split(ns.Annotations[projectId], ":")
+	if ns.Annotations[projectID] != "" {
+		projectInfo := strings.Split(ns.Annotations[projectID], ":")
 		if len(projectInfo) == 2 {
 			projectNamespace = projectInfo[0]
 			projectName = projectInfo[1]

--- a/pkg/resources/core/v1/namespace/psalabels.go
+++ b/pkg/resources/core/v1/namespace/psalabels.go
@@ -3,18 +3,23 @@ package namespace
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/rancher/webhook/pkg/admission"
 	objectsv1 "github.com/rancher/webhook/pkg/generated/objects/core/v1"
 	"github.com/rancher/webhook/pkg/resources/common"
 	admissionv1 "k8s.io/api/admission/v1"
 	v1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	authorizationv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	"k8s.io/utils/trace"
 )
 
-const updatePSAVerb = "updatepsa"
+const (
+	updatePSAVerb = "updatepsa"
+	projectId     = "field.cattle.io/projectId"
+)
 
 type psaLabelAdmitter struct {
 	sar authorizationv1.SubjectAccessReviewInterface
@@ -22,6 +27,7 @@ type psaLabelAdmitter struct {
 
 // Admit ensures that users have sufficient permissions to add/remove PSAs to a namespace.
 func (p *psaLabelAdmitter) Admit(request *admission.Request) (*admissionv1.AdmissionResponse, error) {
+
 	if request.Operation == admissionv1.Delete {
 		return admission.ResponseAllowed(), nil
 	}
@@ -31,12 +37,14 @@ func (p *psaLabelAdmitter) Admit(request *admission.Request) (*admissionv1.Admis
 
 	response := &admissionv1.AdmissionResponse{}
 
+	var ns, oldns *corev1.Namespace
+	var err error
 	// Is the request attempting to modify the special PSA labels (enforce, warn, audit)?
 	// If it isn't, we're done.
 	// If it is, we then need to check to see if they should be allowed.
 	switch request.Operation {
 	case admissionv1.Create:
-		ns, err := objectsv1.NamespaceFromRequest(&request.AdmissionRequest)
+		ns, err = objectsv1.NamespaceFromRequest(&request.AdmissionRequest)
 		if err != nil {
 			return nil, fmt.Errorf("failed to decode namespace from request: %w", err)
 		}
@@ -45,7 +53,7 @@ func (p *psaLabelAdmitter) Admit(request *admission.Request) (*admissionv1.Admis
 			return response, nil
 		}
 	case admissionv1.Update:
-		oldns, ns, err := objectsv1.NamespaceOldAndNewFromRequest(&request.AdmissionRequest)
+		oldns, ns, err = objectsv1.NamespaceOldAndNewFromRequest(&request.AdmissionRequest)
 		if err != nil {
 			return nil, fmt.Errorf("failed to decode namespace from request: %w", err)
 		}
@@ -60,26 +68,59 @@ func (p *psaLabelAdmitter) Admit(request *admission.Request) (*admissionv1.Admis
 		extras[k] = v1.ExtraValue(v)
 	}
 
-	resp, err := p.sar.Create(request.Context, &v1.SubjectAccessReview{
+	var projectNamespace, projectName string
+	// here we are filling the variables above with the projectId,
+	// so that if we are not able to get them,
+	// the SAR request will be done in any case.
+	if ns.Annotations[projectId] != "" {
+		projectInfo := strings.Split(ns.Annotations[projectId], ":")
+		if len(projectInfo) == 2 {
+			projectNamespace = projectInfo[0]
+			projectName = projectInfo[1]
+		}
+	}
+
+	fmt.Println("SAR:")
+	fmt.Println("verb:", updatePSAVerb)
+	fmt.Println("group:", projectsGVR.Group)
+	fmt.Println("version:", projectsGVR.Version)
+	fmt.Println("resource:", projectsGVR.Resource)
+	fmt.Println("user:", request.UserInfo.Username)
+	fmt.Println("groups:", request.UserInfo.Groups)
+	fmt.Println("uid:", request.UserInfo.UID)
+	fmt.Println("extra:", request.UserInfo.Extra)
+	fmt.Println("ns:", projectNamespace)
+	fmt.Println("name:", projectName)
+	fmt.Println("===========>")
+	sarReq := &v1.SubjectAccessReview{
 		Spec: v1.SubjectAccessReviewSpec{
 			ResourceAttributes: &v1.ResourceAttributes{
-				Verb:     updatePSAVerb,
-				Group:    projectsGVR.Group,
-				Version:  projectsGVR.Version,
-				Resource: projectsGVR.Resource,
+				Verb:      updatePSAVerb,
+				Group:     projectsGVR.Group,
+				Version:   projectsGVR.Version,
+				Resource:  projectsGVR.Resource,
+				Namespace: projectNamespace,
+				Name:      projectName,
 			},
 			User:   request.UserInfo.Username,
 			Groups: request.UserInfo.Groups,
 			UID:    request.UserInfo.UID,
 			Extra:  extras,
 		},
-	}, metav1.CreateOptions{})
+	}
+
+	resp, err := p.sar.Create(request.Context, sarReq, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("SAR request creation failed: %w", err)
 	}
+	fmt.Println("allowed:", resp.Status.Allowed)
+	fmt.Println("denied:", resp.Status.Denied)
+	fmt.Println("err:", resp.Status.EvaluationError)
+	fmt.Println("reason:", resp.Status.Reason)
 
 	if resp.Status.Allowed {
 		response.Allowed = true
+		fmt.Println("allowed")
 	} else {
 		response.Result = &metav1.Status{
 			Status:  "Failure",
@@ -87,6 +128,8 @@ func (p *psaLabelAdmitter) Admit(request *admission.Request) (*admissionv1.Admis
 			Reason:  metav1.StatusReasonUnauthorized,
 			Code:    http.StatusForbidden,
 		}
+		fmt.Println("denied")
 	}
+	fmt.Println()
 	return response, nil
 }

--- a/pkg/resources/core/v1/namespace/psalabels.go
+++ b/pkg/resources/core/v1/namespace/psalabels.go
@@ -69,18 +69,17 @@ func (p *psaLabelAdmitter) Admit(request *admission.Request) (*admissionv1.Admis
 	}
 
 	var projectNamespace, projectName string
+	var found bool
 	// here we are filling the variables above with the projectId,
 	// so that if we are not able to get them,
 	// the SAR request will be done in any case.
-	if ns.Annotations[projectID] != "" {
-		projectNamespace, projectName, found := strings.Cut(ns.Annotations[projectID], ":")
-		if found {
-		...
-		}
-		if len(projectInfo) == 2 {
-			projectNamespace = projectInfo[0]
-			projectName = projectInfo[1]
-		}
+	projectNamespace, projectName, found = strings.Cut(ns.Annotations[projectID], ":")
+	if !found {
+		// here we overwrite the projectNamespace variable
+		// with an empty string.
+		// This is because if the separator does not appear
+		// in the first argument (s), string.Cut returns: s, "", false
+		projectNamespace = ""
 	}
 
 	resp, err := p.sar.Create(request.Context, &v1.SubjectAccessReview{

--- a/pkg/resources/core/v1/namespace/psalabels_test.go
+++ b/pkg/resources/core/v1/namespace/psalabels_test.go
@@ -272,6 +272,25 @@ func TestValidatePSALabels(t *testing.T) {
 			allowed: false,
 		},
 		{
+			name:        "Create namespace with PSA for permitted user should be allowed",
+			userName:    allowSarUser,
+			clusterName: "validcluster",
+			operation:   admissionv1.Create,
+			namespace: v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "anynamespace",
+					Labels: map[string]string{
+						common.EnforceLabel: "baseline",
+					},
+					Annotations: map[string]string{
+						projectId: "local:p-22n91",
+					},
+				},
+			},
+			wantErr: false,
+			allowed: true,
+		},
+		{
 			name:        "Delete update PSA for NON admin user-should not be allowed",
 			userName:    failSarUser,
 			clusterName: "validcluster",

--- a/pkg/resources/core/v1/namespace/psalabels_test.go
+++ b/pkg/resources/core/v1/namespace/psalabels_test.go
@@ -283,7 +283,7 @@ func TestValidatePSALabels(t *testing.T) {
 						common.EnforceLabel: "baseline",
 					},
 					Annotations: map[string]string{
-						projectId: "local:p-22n91",
+						projectID: "local:p-22n91",
 					},
 				},
 			},


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/48721
<!-- If your PR depends on changes from other PRs, link them here and describe why they are needed for your solution section. -->
## Problem
Currently, updatepsa is only available to Cluster Roles and not Project Roles due to security concern. Customer wants the ability to assign this to a Project Role.

## Solution
Allow user to update PSA when admin grant access to do it.
In this PR, we are adding information to craft a better SAR (SubjectAccessReview) request.

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [x] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [x] Docs