### PR TITLE
[release/v0.7] Upgrade charts rancher-version to 2.11

### DIFF
--- a/charts/rancher-webhook/Chart.yaml
+++ b/charts/rancher-webhook/Chart.yaml
@@ -10,6 +10,6 @@ annotations:
   catalog.cattle.io/release-name: rancher-webhook
   catalog.cattle.io/os: linux
   catalog.cattle.io/permits-os: linux,windows
-  catalog.cattle.io/rancher-version: ">= 2.10.0-0 < 2.11.0-0"
+  catalog.cattle.io/rancher-version: ">= 2.11.0-0 < 2.12.0-0"
   catalog.cattle.io/kube-version: "< 1.33.0-0"
   catalog.cattle.io/managed: "true"


### PR DESCRIPTION
## Problem
<!-- Describe the root cause of the issue you are resolving. 
This may include what behavior is observed and why it is not desirable. If this is a new feature, describe why we need it and how it will be used. -->
Upgrading rancher-version to 2.11 was missed in the 1.32 upgrade PR #672 
