### PR TITLE
docs: add alternative method to test webhook development

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ make
 
 ## Development
 
+You can choose your favourite method to test your webhook development:
+
+### Using an external webhook
+
 1. Get a new address that forwards to `https://localhost:9443` using ngrok.
 
     ```bash
@@ -177,6 +181,26 @@ make
     ./bin/webhook
     ```
 
+### Importing the built webhook
+
+1. Import the built image from your local registry into your `k3d` cluster:
+    
+    ```bash
+    k3d image import rancher/webhook:dev -c <cluster_name>
+    ```
+    
+2. Ensure the image was imported correctly:
+    
+    ```bash
+    docker exec -it <cluster_node_name> crictl images
+    ```
+    
+3. In the end, patch the webhook deployment on kubernetes:
+    
+    ```bash
+    kubectl patch deployment rancher-webhook -n cattle-system -p '{"spec": {"template": {"spec": {"containers": [{"image": "rancher/webhook:dev", "imagePullPolicy": "Never"}]}}}}'
+    ```
+    
 After 15 seconds the webhook will update the `ValidatingWebhookConfiguration` and `MutatingWebhookConfiguration` in the Kubernetes cluster to point at the locally running instance.
 
 > :warning: Kubernetes API server authentication will not work with ngrok.


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
There's no issue for this PR
<!-- If your PR depends on changes from other PRs, link them here and describe why they are needed for your solution section. -->

## Problem
Currently there's only one way to test the webhook development.
This PR introduces an alternative way to test it by importing the built image into the cluster and patching the webhook deployment.
Credits to @raulcabello and @JonCrowther for suggestion.
<!-- Describe the root cause of the issue you are resolving. 
This may include what behavior is observed and why it is not desirable. If this is a new feature, describe why we need it and how it will be used. -->

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [ ] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [x] Docs