### PR TITLE
[release/v0.7] Prevent creating Rancher PR if RC not yet in rancher/charts

### DIFF
--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -3,15 +3,15 @@ on:
   workflow_dispatch:
     inputs:
       charts_ref:
-        description: "Submit PR against the following rancher/charts branch (eg: dev-v2.10)"
+        description: "Submit PR against the following rancher/charts branch (eg: dev-v2.11)"
         required: true
         default: "dev-v2.11"
       prev_webhook:
-        description: "Previous Webhook version (eg: v0.5.0-rc.13)"
+        description: "Previous Webhook version (eg: v0.7.0-rc.13)"
         required: true
         default: ""
       new_webhook:
-        description: "New Webhook version (eg: v0.5.0-rc.14)"
+        description: "New Webhook version (eg: v0.7.0-rc.14)"
         required: true
         default: ""
 

--- a/.github/workflows/release-rancher.yaml
+++ b/.github/workflows/release-rancher.yaml
@@ -29,6 +29,9 @@ jobs:
       # Required for vault
       id-token: write
     steps:
+      - name: Install dependencies
+        run: sudo snap install yq --channel=v4/stable
+
       - uses: actions/checkout@v4
         with:
           ref: "${{ env.WEBHOOK_REF }}"
@@ -59,6 +62,36 @@ jobs:
           # Allow making git push request later on
           persist-credentials: true
 
+      - name: Find charts branch
+        id: find_charts_branch
+        run: |
+          cd rancher
+          # Extract dev-v2.9 out of the following line:
+          #     ChartDefaultBranch                  = NewSetting("chart-default-branch", "dev-v2.9")
+          charts_branch=$(grep '"chart-default-branch"' pkg/settings/setting.go | cut -d'"' -f4)
+          echo "charts_branch=$charts_branch" >> $GITHUB_OUTPUT
+
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository_owner }}/charts
+          ref: "${{ steps.find_charts_branch.outputs.charts_branch }}"
+          path: charts
+
+      # Prevents the Rancher CI to continuously fail while the webhook RC is not
+      # yet added to charts' index.yaml file due to caching.
+      - name: Verify RC exists
+        env:
+          CHARTS_BRANCH: "${{ steps.find_charts_branch.outputs.charts_branch }}"
+        run: |
+          cd charts
+          new_webhook_short=$(echo "$NEW_WEBHOOK" | sed 's|^v||')  # e.g. 0.5.2-rc.3
+          # Empty output if the version is not found, otherwise the version will be outputed.
+          found=$(yq ".entries.rancher-webhook[].version | select(. == \"*$new_webhook_short\")" index.yaml)
+          if [ -z "$found" ]; then
+            echo "rancher-webhook RC version $NEW_WEBHOOK not found in charts (branch=$CHARTS_BRANCH). Aborting."
+            exit 1
+          fi
+
       - name: Configure the committer
         run: |
           cd rancher
@@ -68,9 +101,6 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           APP_USER: "${{ steps.app-token.outputs.app-slug }}[bot]"
-
-      - name: Install dependencies
-        run: sudo snap install yq --channel=v4/stable
 
       - name: Run release script
         run: |

--- a/.github/workflows/release-rancher.yaml
+++ b/.github/workflows/release-rancher.yaml
@@ -3,15 +3,15 @@ on:
   workflow_dispatch:
     inputs:
       rancher_ref:
-        description: "Submit PR against the following rancher/rancher branch (eg: main)"
+        description: "Submit PR against the following rancher/rancher branch (eg: release/v2.11)"
         required: true
-        default: "main"
+        default: "release/v2.11"
       prev_webhook:
-        description: "Previous Webhook version (eg: v0.5.0-rc.13)"
+        description: "Previous Webhook version (eg: v0.7.0-rc.13)"
         required: true
         default: ""
       new_webhook:
-        description: "New Webhook version (eg: v0.5.0-rc.14)"
+        description: "New Webhook version (eg: v0.7.0-rc.14)"
         required: true
         default: ""
 


### PR DESCRIPTION
**Backport**

Backport of https://github.com/rancher/webhook/pull/851

You can make changes to this PR with the following command:

```
git clone https://github.com/rancher/webhook
cd webhook
git switch backport-851-release-v0.7-21702
```



---

## Issue: 

If a PR is made to bump webhook in rancher/rancher but that version is not yet in rancher/charts, then the CI will be very broken (unless quite lucky). Here's why.

The CI in rancher/rancher runs the `build-server` job which builds the docker images and [publishes them as artifact](https://github.com/rancher/rancher/blob/969647581012ad8bd695b7f673534e1be5200c11/.github/workflows/pull-request.yml#L120-L127). 

Then, the `test` (for integration test) job [downloads those same artifacts](https://github.com/rancher/rancher/blob/969647581012ad8bd695b7f673534e1be5200c11/.github/workflows/integration-tests.yml#L42-L48) and loads them into docker. The docker image for rancher [contains a local copy of rancher/charts](https://github.com/rancher/rancher/blob/969647581012ad8bd695b7f673534e1be5200c11/package/Dockerfile#L110) at the time they were built. Afaik, this is used as a cache to speed things up before the charts controllers sync with GH. When integration-test fails, we re-run only that `test` job, so it keeps using the previously built images.

We can verify that the previously built images contain an older version of dev-v2.11 charts branch like this:

```
$ export JOB_ID=14066004902
$ gh run download -R rancher/rancher $JOB_ID -n rancher-linux-amd64
$ docker load < rancher-linux-amd64.tar

$ export IMAGE=rancher/rancher:v2.11-52479284fecbb21d6b8ed85f0dfcb2f2df1d62c2-head-amd64 #  This image tag will change
$ docker run -it --entrypoint cat $IMAGE /var/lib/rancher-data/local-catalogs/v2/rancher-charts/4b40cac650031b74776e87c1a726b0484d0877c3ec137da0872547ff9b73a721/index.yaml
```

We can see that this index.yaml file indeed doesn't contain `-rc.11` but `-rc.10`. In majority of cases, the charts sync wouldn't happen fast enough (could be GH issue or something else?) and the CI kept trying to install `-rc.11` with an older version of `index.yaml` until the CI times out (5 minutes) due to webhook not being deployed.


## Solution

Until we find something better (if any), we'll fail the automation for bumping webhook in rancher/rancher if the RC is not found in rancher/charts. This should prevent most cases from happening.