### PR TITLE
Make sure to update the project with the generated name

### DIFF
--- a/pkg/resources/management.cattle.io/v3/project/mutator.go
+++ b/pkg/resources/management.cattle.io/v3/project/mutator.go
@@ -155,8 +155,9 @@ func (m *Mutator) createProjectNamespace(project *v3.Project) (*v3.Project, erro
 	// for the backing namespace, we need to generate it ourselves
 	if project.Name == "" {
 		// If err is nil, (meaning "project exists", see below) we need to repeat the generation process to find a project name and backing namespace that isn't taken
+		newName := ""
 		for err == nil {
-			newName := names.SimpleNameGenerator.GenerateName(project.GenerateName)
+			newName = names.SimpleNameGenerator.GenerateName(project.GenerateName)
 			_, err = m.projectCache.Get(newProject.Spec.ClusterName, newName)
 			if err == nil {
 				// A project with this name already exists. Generate a new name.
@@ -173,6 +174,7 @@ func (m *Mutator) createProjectNamespace(project *v3.Project) (*v3.Project, erro
 				return nil, err
 			}
 		}
+		newProject.Name = newName
 	} else {
 		backingNamespace = name.SafeConcatName(newProject.Spec.ClusterName, strings.ToLower(newProject.Name))
 		_, err = m.namespaceCache.Get(backingNamespace)


### PR DESCRIPTION
Follow up of https://github.com/rancher/webhook/pull/869

That change generates the name and creates a namespace for it, but it didn't update the name of the project, so the name would then be generated by the kubernetes controller resulting in a different named namespace and project.

This fixes it.