### PR TITLE
Update default chart branch to dev-v2.12

### DIFF
--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -5,7 +5,7 @@ on:
       charts_ref:
         description: "Submit PR against the following rancher/charts branch (eg: dev-v2.10)"
         required: true
-        default: "dev-v2.11"
+        default: "dev-v2.12"
       prev_webhook:
         description: "Previous Webhook version (eg: v0.5.0-rc.13)"
         required: true


### PR DESCRIPTION
Update release-charts action to use the new dev-v2.12 branch of charts by default