### PR TITLE
Preserves the original sequence of machineConfigGlobal["kube-apiserver-arg"]

### DIFF
--- a/pkg/resources/provisioning.cattle.io/v1/cluster/mutator_test.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/mutator_test.go
@@ -53,6 +53,14 @@ func Test_GetKubeAPIServerArg(t *testing.T) {
 				{key: "foo3", value: "bar3=baz3"},
 			},
 		},
+		{
+			name:    "cluster with duplicate keys in kube-apiserver-arg",
+			cluster: clusterWithKubeAPIServerArg3(),
+			expected: &keyValueArgs{
+				{key: "foo", value: "bar"},
+				{key: "foo2", value: "bar2=baz2"},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -446,6 +454,16 @@ func clusterWithKubeAPIServerArg2() *v1.Cluster {
 	arg = append(arg, "foo=bar")
 	arg = append(arg, "foo2=bar2")
 	arg = append(arg, "foo3=bar3=baz3")
+	cluster.Spec.RKEConfig.MachineGlobalConfig.Data["kube-apiserver-arg"] = arg
+	return cluster
+}
+
+func clusterWithKubeAPIServerArg3() *v1.Cluster {
+	cluster := clusterWithoutKubeAPIServerArg()
+	var arg []interface{}
+	arg = append(arg, "foo=bar")
+	arg = append(arg, "foo2=bar2")
+	arg = append(arg, "foo2=bar2=baz2")
 	cluster.Spec.RKEConfig.MachineGlobalConfig.Data["kube-apiserver-arg"] = arg
 	return cluster
 }

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/validator.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/validator.go
@@ -471,7 +471,7 @@ func (p *provisioningAdmitter) validatePSACT(request *admission.Request, respons
 			}
 			// validate that the flags are not set
 			args := getKubeAPIServerArg(cluster)
-			if value, ok := args[kubeAPIAdmissionConfigOption]; ok && value == mountPath {
+			if args.keyHasValue(kubeAPIAdmissionConfigOption, mountPath) {
 				return fmt.Errorf("[provisioning cluster validator] admission-control-config-file under kube-apiserver-arg should not be set to %s", mountPath)
 			}
 		} else {
@@ -514,7 +514,7 @@ func (p *provisioningAdmitter) validatePSACT(request *admission.Request, respons
 			}
 			// validate that the flags are set
 			args := getKubeAPIServerArg(cluster)
-			if val, ok := args[kubeAPIAdmissionConfigOption]; !ok || val != mountPath {
+			if !args.keyHasValue(kubeAPIAdmissionConfigOption, mountPath) {
 				return fmt.Errorf("[provisioning cluster validator] admission-control-config-file under kube-apiserver-arg should be set to %s", mountPath)
 			}
 		}


### PR DESCRIPTION
## Issue: [rancher#43274](https://github.com/rancher/rancher/issues/43274)
## Problem
Currently, the `getKubeAPIServerArgs` logic parses the key-value args into a `map[string]string`. As a result any modification to the current map followed by a call to `setKubeAPIServerArgs` alters the original orde of arguments in cluster's `machineGlobalConfig["kube-apiserver-arg"]`.
This change in the sequence of elements is expected given the usage of maps, but leads to severe issues with Terraform.

## Solution
Instead of parsing the arguments into `map[string]string`, this commit parses the arguments into a slice of struct {key, value string}. 
This change preserves the original ordering of arguments as defined in the cluster's `machineGlobalConfig`, ensuring compatibility with tools like Terraform that are sensitive to input order.

## CheckList
- [x] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [ ] Docs