### PR TITLE
[backport v2.10] Preserves the original sequence of machineConfigGlobal["kube-apiserver-arg"]

### DIFF
--- a/pkg/resources/provisioning.cattle.io/v1/cluster/mutator.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/mutator.go
@@ -60,6 +60,58 @@ var gvr = schema.GroupVersionResource{
 	Resource: "clusters",
 }
 
+// keyValueArg represents a key-value pair configuration argument.
+type keyValueArg struct {
+	key   string
+	value string
+}
+
+type keyValueArgs []keyValueArg
+
+// newKeyValueArgs initializes and returns an empty keyValueArgs slice.
+func newKeyValueArgs() *keyValueArgs {
+	return &keyValueArgs{}
+}
+
+// parseFromRawArgs converts an interface representing a slice of "key=value" strings into a slice of keyValueArg.
+func (kv *keyValueArgs) parseFromRawArgs(input interface{}) {
+	parsed := convert.ToInterfaceSlice(input)
+	if parsed == nil {
+		logrus.Errorf("failed to convert input into slice: invalid type: %v", input)
+		return
+	}
+	for _, arg := range parsed {
+		key, val, found := strings.Cut(convert.ToString(arg), "=")
+		if !found {
+			logrus.Warnf("skipping argument [%s] which does not have right format", arg)
+			continue
+		}
+		kv.update(key, val)
+	}
+}
+
+// update updates the value for the given key if it exists in the slice; otherwise it appends a new key-value pair.
+func (kv *keyValueArgs) update(key, val string) {
+	idx := slices.IndexFunc(*kv, func(arg keyValueArg) bool {
+		return arg.key == key
+	})
+	if idx != -1 {
+		(*kv)[idx].value = val
+	} else {
+		*kv = append(*kv, keyValueArg{key: key, value: val})
+	}
+}
+
+// keyHasValue returns true if the given key-value pair exists in the slice of keyValueArg.
+func (kv *keyValueArgs) keyHasValue(key, val string) bool {
+	for _, arg := range *kv {
+		if arg.key == key && arg.value == val {
+			return true
+		}
+	}
+	return false
+}
+
 // ProvisioningClusterMutator implements admission.MutatingAdmissionWebhook.
 type ProvisioningClusterMutator struct {
 	secret corecontroller.SecretController
@@ -210,10 +262,10 @@ func (m *ProvisioningClusterMutator) handlePSACT(request *admission.Request, clu
 			// drop relevant fields if they exist in the cluster
 			dropMachineSelectorFile(machineSelectorFileForPSA(secretName, mountPath, ""), cluster, true)
 			args := getKubeAPIServerArg(cluster)
-			if args[kubeAPIAdmissionConfigOption] == mountPath {
-				delete(args, kubeAPIAdmissionConfigOption)
-				setKubeAPIServerArg(args, cluster)
-			}
+			newArgs := slices.DeleteFunc(*args, func(arg keyValueArg) bool {
+				return arg.key == kubeAPIAdmissionConfigOption && arg.value == mountPath
+			})
+			setKubeAPIServerArg(newArgs, cluster)
 		} else {
 			// Now, handle the case of PSACT being set when creating or updating the cluster
 			template, err := m.psact.Get(templateName)
@@ -242,8 +294,8 @@ func (m *ProvisioningClusterMutator) handlePSACT(request *admission.Request, clu
 			hash := sha256.Sum256(fileContent)
 			addMachineSelectorFile(machineSelectorFileForPSA(secretName, mountPath, base64.StdEncoding.EncodeToString(hash[:])), cluster)
 			args := getKubeAPIServerArg(cluster)
-			args[kubeAPIAdmissionConfigOption] = mountPath
-			setKubeAPIServerArg(args, cluster)
+			args.update(kubeAPIAdmissionConfigOption, mountPath)
+			setKubeAPIServerArg(*args, cluster)
 		}
 	}
 	return admission.ResponseAllowed(), nil
@@ -281,39 +333,27 @@ func (m *ProvisioningClusterMutator) ensureSecret(namespace, name string, data m
 	return nil
 }
 
-// getKubeAPIServerArg returns a map representation of the value of kube-apiserver-arg from the cluster's MachineGlobalConfig.
-// An empty map is returned if kube-apiserver-arg is not set in the cluster.
-func getKubeAPIServerArg(cluster *v1.Cluster) map[string]string {
-	if cluster.Spec.RKEConfig.MachineGlobalConfig.Data != nil {
-		return toMap(cluster.Spec.RKEConfig.MachineGlobalConfig.Data["kube-apiserver-arg"])
-	}
-	return map[string]string{}
-}
-
-func toMap(input interface{}) map[string]string {
-	args := map[string]string{}
-	parsed := convert.ToInterfaceSlice(input)
-	for _, arg := range parsed {
-		key, val, found := strings.Cut(convert.ToString(arg), "=")
-		if !found {
-			logrus.Debugf("skipping argument [%s] which does not have right format", arg)
-			continue
-		}
-		args[key] = val
+// getKubeAPIServerArg returns a slice of keyValueArg representing the parsed value of
+// "kube-apiserver-arg" from the cluster's MachineGlobalConfig.
+// An empty slice is returned if "kube-apiserver-arg" is not set in the cluster.
+func getKubeAPIServerArg(cluster *v1.Cluster) *keyValueArgs {
+	args := newKeyValueArgs()
+	if rawArgs, exists := cluster.Spec.RKEConfig.MachineGlobalConfig.Data["kube-apiserver-arg"]; exists {
+		args.parseFromRawArgs(rawArgs)
 	}
 	return args
 }
 
 // setKubeAPIServerArg uses the provided arg to overwrite the value of kube-apiserver-arg under the cluster's MachineGlobalConfig.
 // If the provided arg is an empty map, setKubeAPIServerArg removes the existing kube-apiserver-arg from the cluster's MachineGlobalConfig.
-func setKubeAPIServerArg(arg map[string]string, cluster *v1.Cluster) {
-	if len(arg) == 0 {
+func setKubeAPIServerArg(args []keyValueArg, cluster *v1.Cluster) {
+	if len(args) == 0 {
 		delete(cluster.Spec.RKEConfig.MachineGlobalConfig.Data, "kube-apiserver-arg")
 		return
 	}
-	parsed := make([]any, 0, len(arg))
-	for key, val := range arg {
-		parsed = append(parsed, fmt.Sprintf("%s=%s", key, val))
+	parsed := make([]any, len(args))
+	for i, arg := range args {
+		parsed[i] = arg.key + "=" + arg.value
 	}
 	if cluster.Spec.RKEConfig.MachineGlobalConfig.Data == nil {
 		cluster.Spec.RKEConfig.MachineGlobalConfig.Data = make(map[string]interface{})

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/mutator_test.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/mutator_test.go
@@ -20,12 +20,12 @@ func Test_GetKubeAPIServerArg(t *testing.T) {
 	tests := []struct {
 		name     string
 		cluster  *v1.Cluster
-		expected map[string]string
+		expected *keyValueArgs
 	}{
 		{
 			name:     "cluster without kube-apiserver-arg",
 			cluster:  clusterWithoutKubeAPIServerArg(),
-			expected: map[string]string{},
+			expected: &keyValueArgs{},
 		},
 		{
 			name: "cluster without MachineGlobalConfig",
@@ -34,30 +34,39 @@ func Test_GetKubeAPIServerArg(t *testing.T) {
 					RKEConfig: &v1.RKEConfig{},
 				},
 			},
-			expected: map[string]string{},
+			expected: &keyValueArgs{},
 		},
 		{
 			name:    "cluster with kube-apiserver-arg",
 			cluster: clusterWithKubeAPIServerArg(),
-			expected: map[string]string{
-				"foo":  "bar",
-				"foo2": "bar2",
+			expected: &keyValueArgs{
+				{key: "foo", value: "bar"},
+				{key: "foo2", value: "bar2"},
 			},
 		},
 		{
 			name:    "cluster with kube-apiserver-arg-2",
 			cluster: clusterWithKubeAPIServerArg2(),
-			expected: map[string]string{
-				"foo":  "bar",
-				"foo2": "bar2",
-				"foo3": "bar3=baz3",
+			expected: &keyValueArgs{
+				{key: "foo", value: "bar"},
+				{key: "foo2", value: "bar2"},
+				{key: "foo3", value: "bar3=baz3"},
+			},
+		},
+		{
+			name:    "cluster with duplicate keys in kube-apiserver-arg",
+			cluster: clusterWithKubeAPIServerArg3(),
+			expected: &keyValueArgs{
+				{key: "foo", value: "bar"},
+				{key: "foo2", value: "bar2=baz2"},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getKubeAPIServerArg(tt.cluster); !equality.Semantic.DeepEqual(got, tt.expected) {
-				t.Errorf("got: [%v], expected: [%v]", got, tt.expected)
+			got := getKubeAPIServerArg(tt.cluster)
+			if !reflect.DeepEqual(*tt.expected, *got) {
+				t.Errorf("got: [%v], expected: [%v]", *got, *tt.expected)
 			}
 		})
 	}
@@ -66,15 +75,15 @@ func Test_GetKubeAPIServerArg(t *testing.T) {
 func Test_SetKubeAPIServerArg(t *testing.T) {
 	tests := []struct {
 		name     string
-		arg      map[string]string
+		arg      keyValueArgs
 		cluster  *v1.Cluster
 		expected *v1.Cluster
 	}{
 		{
 			name: "cluster that already has kube-apiserver-arg",
-			arg: map[string]string{
-				"foo":  "bar",
-				"foo2": "bar2",
+			arg: keyValueArgs{
+				{key: "foo", value: "bar"},
+				{key: "foo2", value: "bar2"},
 			},
 			cluster: &v1.Cluster{
 				Spec: v1.ClusterSpec{
@@ -95,9 +104,9 @@ func Test_SetKubeAPIServerArg(t *testing.T) {
 		},
 		{
 			name: "cluster that does not have MachineGlobalConfig",
-			arg: map[string]string{
-				"foo":  "bar",
-				"foo2": "bar2",
+			arg: keyValueArgs{
+				{key: "foo", value: "bar"},
+				{key: "foo2", value: "bar2"},
 			},
 			cluster: &v1.Cluster{
 				Spec: v1.ClusterSpec{
@@ -108,9 +117,9 @@ func Test_SetKubeAPIServerArg(t *testing.T) {
 		},
 		{
 			name: "cluster does not have kube-apiserver-arg but other args",
-			arg: map[string]string{
-				"foo":  "bar",
-				"foo2": "bar2",
+			arg: keyValueArgs{
+				{key: "foo", value: "bar"},
+				{key: "foo2", value: "bar2"},
 			},
 			cluster: &v1.Cluster{
 				Spec: v1.ClusterSpec{
@@ -134,11 +143,13 @@ func Test_SetKubeAPIServerArg(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			got := newKeyValueArgs()
+			expected := newKeyValueArgs()
 			setKubeAPIServerArg(tt.arg, tt.cluster)
-			got := toMap(tt.cluster.Spec.RKEConfig.MachineGlobalConfig.Data["kube-apiserver-arg"])
-			expected := toMap(tt.expected.Spec.RKEConfig.MachineGlobalConfig.Data["kube-apiserver-arg"])
-			if !equality.Semantic.DeepEqual(got, expected) {
-				t.Errorf("got: %v, expected: %v", got, expected)
+			got.parseFromRawArgs(tt.cluster.Spec.RKEConfig.MachineGlobalConfig.Data["kube-apiserver-arg"])
+			expected.parseFromRawArgs(tt.expected.Spec.RKEConfig.MachineGlobalConfig.Data["kube-apiserver-arg"])
+			if !reflect.DeepEqual(*got, *expected) {
+				t.Errorf("got: %v, expected: %v", *got, *expected)
 			}
 		})
 	}
@@ -443,6 +454,16 @@ func clusterWithKubeAPIServerArg2() *v1.Cluster {
 	arg = append(arg, "foo=bar")
 	arg = append(arg, "foo2=bar2")
 	arg = append(arg, "foo3=bar3=baz3")
+	cluster.Spec.RKEConfig.MachineGlobalConfig.Data["kube-apiserver-arg"] = arg
+	return cluster
+}
+
+func clusterWithKubeAPIServerArg3() *v1.Cluster {
+	cluster := clusterWithoutKubeAPIServerArg()
+	var arg []interface{}
+	arg = append(arg, "foo=bar")
+	arg = append(arg, "foo2=bar2")
+	arg = append(arg, "foo2=bar2=baz2")
 	cluster.Spec.RKEConfig.MachineGlobalConfig.Data["kube-apiserver-arg"] = arg
 	return cluster
 }

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/validator.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/validator.go
@@ -459,7 +459,7 @@ func (p *provisioningAdmitter) validatePSACT(request *admission.Request, respons
 			}
 			// validate that the flags are not set
 			args := getKubeAPIServerArg(cluster)
-			if value, ok := args[kubeAPIAdmissionConfigOption]; ok && value == mountPath {
+			if args.keyHasValue(kubeAPIAdmissionConfigOption, mountPath) {
 				return fmt.Errorf("[provisioning cluster validator] admission-control-config-file under kube-apiserver-arg should not be set to %s", mountPath)
 			}
 		} else {
@@ -502,7 +502,7 @@ func (p *provisioningAdmitter) validatePSACT(request *admission.Request, respons
 			}
 			// validate that the flags are set
 			args := getKubeAPIServerArg(cluster)
-			if val, ok := args[kubeAPIAdmissionConfigOption]; !ok || val != mountPath {
+			if !args.keyHasValue(kubeAPIAdmissionConfigOption, mountPath) {
 				return fmt.Errorf("[provisioning cluster validator] admission-control-config-file under kube-apiserver-arg should be set to %s", mountPath)
 			}
 		}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/50339
Backport of https://github.com/rancher/webhook/pull/913

## Problem
Currently, the `getKubeAPIServerArgs` logic parses the key-value args into a `map[string]string`. As a result any modification to the current map followed by a call to `setKubeAPIServerArgs` alters the original order of arguments in cluster’s `machineGlobalConfig[“kube-apiserver-arg”]`.
This change in the sequence of elements is expected given the usage of maps, but leads to severe issues with Terraform.

## Solution
Instead of parsing the arguments into `map[string]string`, this commit parses the arguments into a slice of struct {key, value string}.
This change preserves the original ordering of arguments as defined in the cluster’s `machineGlobalConfig`, ensuring compatibility with tools like Terraform that are sensitive to input order.

## CheckList
- [x] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator’s or mutator’s behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [ ] Docs