### PR TITLE
[v0.7] Don't require certificate if tls is on for ldap/ad authconfigs

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -97,7 +97,6 @@ If yes, the webhook redacts the role, so that it only grants a deletion permissi
 When an LDAP (`openldap`, `freeipa`) or ActiveDirectory (`activedirectory`) authconfig is created or updated, the following checks take place:
 
 - The field `servers` is required.
-- If the field `tls` is set to true, the field `certificate` is required.
 - If set, the following fields should have valid LDAP attribute names according to RFC4512
   - `userSearchAttribute`
   - `userLoginAttribute`

--- a/pkg/resources/management.cattle.io/v3/authconfig/Authconfig.md
+++ b/pkg/resources/management.cattle.io/v3/authconfig/Authconfig.md
@@ -6,7 +6,6 @@
 When an LDAP (`openldap`, `freeipa`) or ActiveDirectory (`activedirectory`) authconfig is created or updated, the following checks take place:
 
 - The field `servers` is required.
-- If the field `tls` is set to true, the field `certificate` is required.
 - If set, the following fields should have valid LDAP attribute names according to RFC4512
   - `userSearchAttribute`
   - `userLoginAttribute`

--- a/pkg/resources/management.cattle.io/v3/authconfig/validator.go
+++ b/pkg/resources/management.cattle.io/v3/authconfig/validator.go
@@ -125,9 +125,6 @@ func validateLDAPConfig(request *admission.Request) error {
 	if len(config.Servers) < 1 {
 		err = errors.Join(err, field.Forbidden(field.NewPath("servers"), "at least one server is required"))
 	}
-	if config.TLS && config.Certificate == "" {
-		err = errors.Join(err, field.Forbidden(field.NewPath("certificate"), "certificate is required"))
-	}
 
 	if config.UserSearchAttribute != "" {
 		for _, attr := range strings.Split(config.UserSearchAttribute, "|") {
@@ -201,9 +198,6 @@ func validateActiveDirectoryConfig(request *admission.Request) error {
 
 	if len(config.Servers) < 1 {
 		err = errors.Join(err, field.Forbidden(field.NewPath("servers"), "at least one server is required"))
-	}
-	if config.TLS && config.Certificate == "" {
-		err = errors.Join(err, field.Forbidden(field.NewPath("certificate"), "certificate is required"))
 	}
 
 	if config.UserSearchAttribute != "" {

--- a/pkg/resources/management.cattle.io/v3/authconfig/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/authconfig/validator_test.go
@@ -81,6 +81,7 @@ func TestValidateLdapConfig(t *testing.T) {
 				fields.Certificate = ""
 				return fields
 			},
+			allowed: true,
 		},
 		{
 			desc: "invalid UserSearchAttribute",
@@ -284,6 +285,7 @@ func TestValidateActiveDirectoryConfig(t *testing.T) {
 				config.Certificate = ""
 				return config
 			},
+			allowed: true,
 		},
 		{
 			desc: "invalid UserSearchAttribute",


### PR DESCRIPTION
Backport of #927