### PR TITLE
[backport v2.10] Refactors keyValueArgs handling for improved efficiency (#928)

### DIFF
--- a/pkg/resources/provisioning.cattle.io/v1/cluster/validator.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/validator.go
@@ -458,7 +458,10 @@ func (p *provisioningAdmitter) validatePSACT(request *admission.Request, respons
 				return fmt.Errorf("[provisioning cluster validator] machineSelectorFile for PSA should not be in the cluster Spec")
 			}
 			// validate that the flags are not set
-			args := getKubeAPIServerArg(cluster)
+			args, err := getKubeAPIServerArgs(cluster)
+			if err != nil {
+				return fmt.Errorf("[provisioning cluster validator] failed to get the kube-apiserver arguments: %w", err)
+			}
 			if args.keyHasValue(kubeAPIAdmissionConfigOption, mountPath) {
 				return fmt.Errorf("[provisioning cluster validator] admission-control-config-file under kube-apiserver-arg should not be set to %s", mountPath)
 			}
@@ -501,7 +504,10 @@ func (p *provisioningAdmitter) validatePSACT(request *admission.Request, respons
 				return fmt.Errorf("[provisioning cluster validator] machineSelectorFile for PSA should be in the cluster Spec")
 			}
 			// validate that the flags are set
-			args := getKubeAPIServerArg(cluster)
+			args, err := getKubeAPIServerArgs(cluster)
+			if err != nil {
+				return fmt.Errorf("[provisioning cluster validator] failed to get the kube-apiserver arguments: %w", err)
+			}
 			if !args.keyHasValue(kubeAPIAdmissionConfigOption, mountPath) {
 				return fmt.Errorf("[provisioning cluster validator] admission-control-config-file under kube-apiserver-arg should be set to %s", mountPath)
 			}


### PR DESCRIPTION
Follow up to https://github.com/rancher/webhook/pull/926
Backport of #928 

## Issue: Related to https://github.com/rancher/rancher/issues/50339
## Problem
<!-- Describe the root cause of the issue you are resolving. 
This may include what behavior is observed and why it is not desirable. If this is a new feature, describe why we need it and how it will be used. -->

## Solution
This PR:
- Decouples `parseFromRawArgs` from the keyValueArgs receiver.
- Simplifies the logic and results in improved performance.
- Updates `getKubeAPIServerArgs` to return errors to the UI.

Per benchmark, this approach improves the performance by ~10-12%.

## CheckList
- [x] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [ ] Docs