### PR TITLE
Restore pinning of github.com/rancher/rke to un-rc version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.4
 toolchain go1.23.6
 
 replace (
+	github.com/rancher/rke => github.com/rancher/rke v1.8.4
 	k8s.io/api => k8s.io/api v0.32.1
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.32.1
 	k8s.io/apimachinery => k8s.io/apimachinery v0.32.1


### PR DESCRIPTION
Our pinning was accidentally undone.  Restoring that here.
Pinned to version nearest to r/r that is in an un-rc state.