### PR TITLE
[2.13] add validation for etcd s3 cloud credential 

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -580,6 +580,10 @@ following:
 - Equal to another data directory
 - Attempts to nest another data directory
 
+##### Etcd S3 CloudCredential Secret
+
+Prevent the creation of objects if the secret specified in `.spec.rkeConfig.etcd.s3.cloudCredentialName` does not exist.
+
 #### On Update
 
 ##### Creator ID Annotation
@@ -596,7 +600,7 @@ section. A secondary validator will ensure that the effective data directory for
 from the one chosen during cluster creation. Additionally, the changing of a data directory for the `system-agent`, 
 kubernetes distro (RKE2/K3s), and CAPR components is also prohibited.
 
-#### cluster.spec.clusterAgentDeploymentCustomization and cluster.spec.fleetAgentDeploymentCustomization
+##### cluster.spec.clusterAgentDeploymentCustomization and cluster.spec.fleetAgentDeploymentCustomization
 
 The `DeploymentCustomization` fields are of 3 types:
 - `appendTolerations`: adds tolerations to the appropriate deployment (cluster-agent/fleet-agent)
@@ -611,7 +615,7 @@ A `Toleration` is matched to a regex which is provided by upstream [apimachinery
 
 For the `Affinity` based rules, the `podAffinity`/`podAntiAffinity` are validated via label selectors via [this apimachinery function](https://github.com/kubernetes/apimachinery/blob/02a41040d88da08de6765573ae2b1a51f424e1ca/pkg/apis/meta/v1/validation/validation.go#L56) whereas the `nodeAffinity` `nodeSelectorTerms` are validated via the same `Toleration` function.
 
-#### cluster.spec.clusterAgentDeploymentCustomization.schedulingCustomization
+##### cluster.spec.clusterAgentDeploymentCustomization.schedulingCustomization
 
 The `SchedulingCustomization` subfield of the `DeploymentCustomization` field defines the properties of a Pod Disruption Budget and Priority Class which will be automatically deployed by Rancher for the cattle-cluster-agent.
 
@@ -637,9 +641,15 @@ the format expected by Go, and helps to prevent subtle issues elsewhere when wri
 
 The only exception to this check is if the existing cluster already has a `NO_PROXY` variable which includes spaces in its value. In this case, update operations are permitted. If `NO_PROXY` is later updated to value which does not contain spaces, this exception will no longer occur.
 
+##### Etcd S3 CloudCredential Secret
+
+Prevent the update of objects if the secret specified in `.spec.rkeConfig.etcd.s3.cloudCredentialName` does not exist.
+
 ### Mutation Checks
 
 #### On Create
+
+##### Creator ID Annotation
 
 When a cluster is created `field.cattle.io/creatorId` is set to the Username from the request.
 

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/Cluster.md
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/Cluster.md
@@ -24,6 +24,10 @@ following:
 - Equal to another data directory
 - Attempts to nest another data directory
 
+#### Etcd S3 CloudCredential Secret
+
+Prevent the creation of objects if the secret specified in `.spec.rkeConfig.etcd.s3.cloudCredentialName` does not exist.
+
 ### On Update
 
 #### Creator ID Annotation
@@ -40,7 +44,7 @@ section. A secondary validator will ensure that the effective data directory for
 from the one chosen during cluster creation. Additionally, the changing of a data directory for the `system-agent`, 
 kubernetes distro (RKE2/K3s), and CAPR components is also prohibited.
 
-### cluster.spec.clusterAgentDeploymentCustomization and cluster.spec.fleetAgentDeploymentCustomization
+#### cluster.spec.clusterAgentDeploymentCustomization and cluster.spec.fleetAgentDeploymentCustomization
 
 The `DeploymentCustomization` fields are of 3 types:
 - `appendTolerations`: adds tolerations to the appropriate deployment (cluster-agent/fleet-agent)
@@ -55,7 +59,7 @@ A `Toleration` is matched to a regex which is provided by upstream [apimachinery
 
 For the `Affinity` based rules, the `podAffinity`/`podAntiAffinity` are validated via label selectors via [this apimachinery function](https://github.com/kubernetes/apimachinery/blob/02a41040d88da08de6765573ae2b1a51f424e1ca/pkg/apis/meta/v1/validation/validation.go#L56) whereas the `nodeAffinity` `nodeSelectorTerms` are validated via the same `Toleration` function.
 
-### cluster.spec.clusterAgentDeploymentCustomization.schedulingCustomization
+#### cluster.spec.clusterAgentDeploymentCustomization.schedulingCustomization
 
 The `SchedulingCustomization` subfield of the `DeploymentCustomization` field defines the properties of a Pod Disruption Budget and Priority Class which will be automatically deployed by Rancher for the cattle-cluster-agent.
 
@@ -81,9 +85,15 @@ the format expected by Go, and helps to prevent subtle issues elsewhere when wri
 
 The only exception to this check is if the existing cluster already has a `NO_PROXY` variable which includes spaces in its value. In this case, update operations are permitted. If `NO_PROXY` is later updated to value which does not contain spaces, this exception will no longer occur.
 
+#### Etcd S3 CloudCredential Secret
+
+Prevent the update of objects if the secret specified in `.spec.rkeConfig.etcd.s3.cloudCredentialName` does not exist.
+
 ## Mutation Checks
 
 ### On Create
+
+#### Creator ID Annotation
 
 When a cluster is created `field.cattle.io/creatorId` is set to the Username from the request.
 

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/validator_test.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/validator_test.go
@@ -2503,8 +2503,123 @@ func Test_validateS3Secret(t *testing.T) {
 		shouldSucceed bool
 	}{
 		{
+			name:          "valid - s3 credential is changed and exists",
+			shouldSucceed: true,
+			oldCluster: &v1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "fleet-default",
+					Name:      "testing-cluster",
+				},
+				Spec: v1.ClusterSpec{
+					RKEConfig: &v1.RKEConfig{
+						ClusterConfiguration: rkev1.ClusterConfiguration{
+							ETCD: &rkev1.ETCD{
+								S3: &rkev1.ETCDSnapshotS3{
+									CloudCredentialName: "old-secret",
+								},
+							},
+						},
+					},
+				},
+			},
+			cluster: &v1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "fleet-default",
+					Name:      "testing-cluster",
+				},
+				Spec: v1.ClusterSpec{
+					RKEConfig: &v1.RKEConfig{
+						ClusterConfiguration: rkev1.ClusterConfiguration{
+							ETCD: &rkev1.ETCD{
+								S3: &rkev1.ETCDSnapshotS3{
+									CloudCredentialName: "credential-from-client",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:          "invalid - s3 credential is changed and does not exist",
+			shouldSucceed: false,
+			oldCluster: &v1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "fleet-default",
+					Name:      "testing-cluster",
+				},
+				Spec: v1.ClusterSpec{
+					RKEConfig: &v1.RKEConfig{
+						ClusterConfiguration: rkev1.ClusterConfiguration{
+							ETCD: &rkev1.ETCD{
+								S3: &rkev1.ETCDSnapshotS3{
+									CloudCredentialName: "old-secret",
+								},
+							},
+						},
+					},
+				},
+			},
+			cluster: &v1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "fleet-default",
+					Name:      "testing-cluster",
+				},
+				Spec: v1.ClusterSpec{
+					RKEConfig: &v1.RKEConfig{
+						ClusterConfiguration: rkev1.ClusterConfiguration{
+							ETCD: &rkev1.ETCD{
+								S3: &rkev1.ETCDSnapshotS3{
+									CloudCredentialName: "non-exist",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:          "valid - s3 credential remains the same and exists",
+			shouldSucceed: true,
+			oldCluster: &v1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "fleet-default",
+					Name:      "testing-cluster",
+				},
+				Spec: v1.ClusterSpec{
+					RKEConfig: &v1.RKEConfig{
+						ClusterConfiguration: rkev1.ClusterConfiguration{
+							ETCD: &rkev1.ETCD{
+								S3: &rkev1.ETCDSnapshotS3{
+									CloudCredentialName: "credential-from-cache",
+								},
+							},
+						},
+					},
+				},
+			},
+			cluster: &v1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "fleet-default",
+					Name:      "testing-cluster",
+				},
+				Spec: v1.ClusterSpec{
+					RKEConfig: &v1.RKEConfig{
+						ClusterConfiguration: rkev1.ClusterConfiguration{
+							ETCD: &rkev1.ETCD{
+								S3: &rkev1.ETCDSnapshotS3{
+									CloudCredentialName: "credential-from-cache",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name:          "invalid - s3 credential does not exist",
 			shouldSucceed: false,
+			oldCluster:    &v1.Cluster{},
 			cluster: &v1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "fleet-default",
@@ -2526,6 +2641,7 @@ func Test_validateS3Secret(t *testing.T) {
 		{
 			name:          "valid - s3 credential can be found in cache",
 			shouldSucceed: true,
+			oldCluster:    &v1.Cluster{},
 			cluster: &v1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "fleet-default",
@@ -2547,6 +2663,7 @@ func Test_validateS3Secret(t *testing.T) {
 		{
 			name:          "valid - s3 credential can be found in client",
 			shouldSucceed: true,
+			oldCluster:    &v1.Cluster{},
 			cluster: &v1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "fleet-default",
@@ -2568,6 +2685,7 @@ func Test_validateS3Secret(t *testing.T) {
 		{
 			name:          "valid - s3 credential is empty string",
 			shouldSucceed: true,
+			oldCluster:    &v1.Cluster{},
 			cluster: &v1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "fleet-default",
@@ -2598,7 +2716,7 @@ func Test_validateS3Secret(t *testing.T) {
 				secretCache:  createMockSecretCache(ctrl),
 			}
 
-			response, err := a.validateS3Secret(tt.cluster)
+			response, err := a.validateS3Secret(tt.oldCluster, tt.cluster)
 			assert.Equal(t, tt.shouldSucceed, response.Allowed)
 			assert.NoError(t, err)
 		})

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/validator_test.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/validator_test.go
@@ -15,7 +15,8 @@ import (
 	"go.uber.org/mock/gomock"
 	admissionv1 "k8s.io/api/admission/v1"
 	k8sv1 "k8s.io/api/core/v1"
-	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
@@ -1555,11 +1556,11 @@ func Test_validateAgentDeploymentCustomization(t *testing.T) {
 						PodAffinity: &k8sv1.PodAffinity{
 							RequiredDuringSchedulingIgnoredDuringExecution: []k8sv1.PodAffinityTerm{
 								{
-									LabelSelector: &v12.LabelSelector{
+									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
 											"key": "validValue",
 										},
-										MatchExpressions: []v12.LabelSelectorRequirement{
+										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
 												Key:      "validKey",
 												Operator: "In",
@@ -1573,9 +1574,9 @@ func Test_validateAgentDeploymentCustomization(t *testing.T) {
 								{
 									Weight: 1,
 									PodAffinityTerm: k8sv1.PodAffinityTerm{
-										NamespaceSelector: &v12.LabelSelector{
+										NamespaceSelector: &metav1.LabelSelector{
 											MatchLabels: nil,
-											MatchExpressions: []v12.LabelSelectorRequirement{
+											MatchExpressions: []metav1.LabelSelectorRequirement{
 												{
 													Key:      "validKey",
 													Operator: "In",
@@ -1595,11 +1596,11 @@ func Test_validateAgentDeploymentCustomization(t *testing.T) {
 						PodAntiAffinity: &k8sv1.PodAntiAffinity{
 							RequiredDuringSchedulingIgnoredDuringExecution: []k8sv1.PodAffinityTerm{
 								{
-									LabelSelector: &v12.LabelSelector{
+									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
 											"key": "validValue",
 										},
-										MatchExpressions: []v12.LabelSelectorRequirement{
+										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
 												Key:      "validKey",
 												Operator: "In",
@@ -1613,9 +1614,9 @@ func Test_validateAgentDeploymentCustomization(t *testing.T) {
 								{
 									Weight: 1,
 									PodAffinityTerm: k8sv1.PodAffinityTerm{
-										NamespaceSelector: &v12.LabelSelector{
+										NamespaceSelector: &metav1.LabelSelector{
 											MatchLabels: nil,
-											MatchExpressions: []v12.LabelSelectorRequirement{
+											MatchExpressions: []metav1.LabelSelectorRequirement{
 												{
 													Key:      "validKey",
 													Operator: "In",
@@ -1707,11 +1708,11 @@ func Test_validateAgentDeploymentCustomization(t *testing.T) {
 						PodAffinity: &k8sv1.PodAffinity{
 							RequiredDuringSchedulingIgnoredDuringExecution: []k8sv1.PodAffinityTerm{
 								{
-									LabelSelector: &v12.LabelSelector{
+									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
 											"key": "`{}invalidKey",
 										},
-										MatchExpressions: []v12.LabelSelectorRequirement{
+										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
 												Key:      "`{}invalidKey",
 												Operator: "In",
@@ -1725,9 +1726,9 @@ func Test_validateAgentDeploymentCustomization(t *testing.T) {
 								{
 									Weight: 1,
 									PodAffinityTerm: k8sv1.PodAffinityTerm{
-										NamespaceSelector: &v12.LabelSelector{
+										NamespaceSelector: &metav1.LabelSelector{
 											MatchLabels: nil,
-											MatchExpressions: []v12.LabelSelectorRequirement{
+											MatchExpressions: []metav1.LabelSelectorRequirement{
 												{
 													Key:      "`{}invalidKey",
 													Operator: "In",
@@ -1747,11 +1748,11 @@ func Test_validateAgentDeploymentCustomization(t *testing.T) {
 						PodAntiAffinity: &k8sv1.PodAntiAffinity{
 							RequiredDuringSchedulingIgnoredDuringExecution: []k8sv1.PodAffinityTerm{
 								{
-									LabelSelector: &v12.LabelSelector{
+									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
 											"key": "validValue",
 										},
-										MatchExpressions: []v12.LabelSelectorRequirement{
+										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
 												Key:      "`{}invalidKey",
 												Operator: "In",
@@ -1765,9 +1766,9 @@ func Test_validateAgentDeploymentCustomization(t *testing.T) {
 								{
 									Weight: 1,
 									PodAffinityTerm: k8sv1.PodAffinityTerm{
-										NamespaceSelector: &v12.LabelSelector{
+										NamespaceSelector: &metav1.LabelSelector{
 											MatchLabels: nil,
-											MatchExpressions: []v12.LabelSelectorRequirement{
+											MatchExpressions: []metav1.LabelSelectorRequirement{
 												{
 													Key:      "`{}invalidKey",
 													Operator: "In",
@@ -2452,4 +2453,154 @@ func createMockFeatureCache(ctrl *gomock.Controller, featureName string, enabled
 		}, nil
 	}).AnyTimes()
 	return featureCache
+}
+
+func createMockSecretClient(ctrl *gomock.Controller) *fake.MockControllerInterface[*k8sv1.Secret, *k8sv1.SecretList] {
+	secretClient := fake.NewMockControllerInterface[*k8sv1.Secret, *k8sv1.SecretList](ctrl)
+	secretClient.EXPECT().Get("fleet-default", "credential-from-client", gomock.Any()).Return(
+		&k8sv1.Secret{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Secret",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "fleet-default",
+				Name:      "credential-from-client",
+			},
+		}, nil).AnyTimes()
+	secretClient.EXPECT().Get("fleet-default", "non-exist", gomock.Any()).Return(
+		nil, apierrors.NewNotFound(k8sv1.Resource("secret"), "secret")).AnyTimes()
+
+	return secretClient
+}
+
+func createMockSecretCache(ctrl *gomock.Controller) *fake.MockCacheInterface[*k8sv1.Secret] {
+	secretCache := fake.NewMockCacheInterface[*k8sv1.Secret](ctrl)
+	secretCache.EXPECT().Get("fleet-default", "credential-from-cache").Return(
+		&k8sv1.Secret{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Secret",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "fleet-default",
+				Name:      "credential-from-cache",
+			},
+		}, nil).AnyTimes()
+	secretCache.EXPECT().Get("fleet-default", "credential-from-client").Return(
+		nil, apierrors.NewNotFound(k8sv1.Resource("secret"), "secret")).AnyTimes()
+	secretCache.EXPECT().Get("fleet-default", "non-exist").Return(
+		nil, apierrors.NewNotFound(k8sv1.Resource("secret"), "secret")).AnyTimes()
+
+	return secretCache
+}
+
+func Test_validateS3Secret(t *testing.T) {
+	tests := []struct {
+		name          string
+		cluster       *v1.Cluster
+		oldCluster    *v1.Cluster
+		shouldSucceed bool
+	}{
+		{
+			name:          "invalid - s3 credential does not exist",
+			shouldSucceed: false,
+			cluster: &v1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "fleet-default",
+					Name:      "testing-cluster",
+				},
+				Spec: v1.ClusterSpec{
+					RKEConfig: &v1.RKEConfig{
+						ClusterConfiguration: rkev1.ClusterConfiguration{
+							ETCD: &rkev1.ETCD{
+								S3: &rkev1.ETCDSnapshotS3{
+									CloudCredentialName: "non-exist",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:          "valid - s3 credential can be found in cache",
+			shouldSucceed: true,
+			cluster: &v1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "fleet-default",
+					Name:      "testing-cluster",
+				},
+				Spec: v1.ClusterSpec{
+					RKEConfig: &v1.RKEConfig{
+						ClusterConfiguration: rkev1.ClusterConfiguration{
+							ETCD: &rkev1.ETCD{
+								S3: &rkev1.ETCDSnapshotS3{
+									CloudCredentialName: "credential-from-cache",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:          "valid - s3 credential can be found in client",
+			shouldSucceed: true,
+			cluster: &v1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "fleet-default",
+					Name:      "testing-cluster",
+				},
+				Spec: v1.ClusterSpec{
+					RKEConfig: &v1.RKEConfig{
+						ClusterConfiguration: rkev1.ClusterConfiguration{
+							ETCD: &rkev1.ETCD{
+								S3: &rkev1.ETCDSnapshotS3{
+									CloudCredentialName: "credential-from-client",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:          "valid - s3 credential is empty string",
+			shouldSucceed: true,
+			cluster: &v1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "fleet-default",
+					Name:      "testing-cluster",
+				},
+				Spec: v1.ClusterSpec{
+					RKEConfig: &v1.RKEConfig{
+						ClusterConfiguration: rkev1.ClusterConfiguration{
+							ETCD: &rkev1.ETCD{
+								S3: &rkev1.ETCDSnapshotS3{
+									CloudCredentialName: "",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	t.Parallel()
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			a := provisioningAdmitter{
+				secretClient: createMockSecretClient(ctrl),
+				secretCache:  createMockSecretCache(ctrl),
+			}
+
+			response, err := a.validateS3Secret(tt.cluster)
+			assert.Equal(t, tt.shouldSucceed, response.Allowed)
+			assert.NoError(t, err)
+		})
+	}
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from other PRs, link them here and describe why they are needed for your solution section. -->

https://github.com/rancher/rancher/issues/50987

## Problem
<!-- Describe the root cause of the issue you are resolving. 
This may include what behavior is observed and why it is not desirable. If this is a new feature, describe why we need it and how it will be used. -->

While creating a node driver or custom RKE2/k3s cluster, if the secret used for saving etcd backups to S3 does not exist, then the cluster will be stuck waiting for node ref, and Rnacher will generate empty plans for nodes.

Note that this bug can only be triggered when creating or updating the cluster programmatically or via editing YAML.

## Solution
<!-- Describe what you changed to fix the issue. 
Relate your changes to the original bug/feature and explain why this addresses the issue. -->

Add validation for the etcd S3 cloud credential to reject the request for creating or updating the provisioning cluster if the provided secret does not exist. 


## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [x] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [x] Docs