### PR TITLE
[Backport v0.8] Fix removing imported warning

### DIFF
--- a/pkg/resources/management.cattle.io/v3/cluster/validator.go
+++ b/pkg/resources/management.cattle.io/v3/cluster/validator.go
@@ -495,9 +495,9 @@ func getSchedulingCustomization(cluster *apisv3.Cluster) *apisv3.AgentScheduling
 }
 
 // validateVersionManagementFeature validates the annotation for the version management feature is set with valid value on the imported RKE2/K3s cluster,
-// additionally, it permits but include a warning to the response if either of the following is true:
-//   - the annotation is found on a cluster rather than imported RKE2/K3s cluster;
-//   - the spec.rke2Config or spec.k3sConfig is changed when the version management feature is disabled for the cluster.
+// additionally, it permits to the response if either of the following is true:
+//   - the annotation is found on a cluster rather than imported RKE2/K3s cluster (does not takes effect);
+//   - the spec.rke2Config or spec.k3sConfig is changed when the version management feature is disabled for the cluster (emits a warning).
 func (a *admitter) validateVersionManagementFeature(oldCluster, newCluster *apisv3.Cluster, op admissionv1.Operation) (*admissionv1.AdmissionResponse, error) {
 	if op != admissionv1.Create && op != admissionv1.Update {
 		return admission.ResponseAllowed(), nil

--- a/pkg/resources/management.cattle.io/v3/cluster/validator.go
+++ b/pkg/resources/management.cattle.io/v3/cluster/validator.go
@@ -508,10 +508,6 @@ func (a *admitter) validateVersionManagementFeature(oldCluster, newCluster *apis
 
 	if driver != apisv3.ClusterDriverRke2 && driver != apisv3.ClusterDriverK3s {
 		response := admission.ResponseAllowed()
-		if exist {
-			msg := fmt.Sprintf("The annotation [%s] takes effect only on imported RKE2/K3s cluster, please consider removing it from cluster [%s]", VersionManagementAnno, newCluster.Name)
-			response.Warnings = append(response.Warnings, msg)
-		}
 		return response, nil
 	}
 

--- a/pkg/resources/management.cattle.io/v3/cluster/validator.go
+++ b/pkg/resources/management.cattle.io/v3/cluster/validator.go
@@ -494,12 +494,10 @@ func getSchedulingCustomization(cluster *apisv3.Cluster) *apisv3.AgentScheduling
 	return cluster.Spec.ClusterAgentDeploymentCustomization.SchedulingCustomization
 }
 
-// validateVersionManagementFeature validates the annotation for the version management feature is set with valid value on the imported RKE2/K3s cluster,
-// additionally, it permits to the response if either of the following is true:
-//   - the annotation is found on a cluster rather than imported RKE2/K3s cluster;
-//   - the spec.rke2Config or spec.k3sConfig is changed when the version management feature is disabled for the cluster (emits a warning);
-//
-// however, this annotation does not take any effect on clusters that are not imported RKE2/K3s clusters.
+// validateVersionManagementFeature validates the annotation for the version management feature is set with valid value on the imported RKE2/K3s cluster;
+// Note the following:
+//   - no validation is done if the cluster is not an imported RKE2/K3s cluster;
+//   - a warning is emitted if `spec.rke2Config` or `spec.k3sConfig` is changed when the version management feature is disabled for the cluster.
 func (a *admitter) validateVersionManagementFeature(oldCluster, newCluster *apisv3.Cluster, op admissionv1.Operation) (*admissionv1.AdmissionResponse, error) {
 	if op != admissionv1.Create && op != admissionv1.Update {
 		return admission.ResponseAllowed(), nil

--- a/pkg/resources/management.cattle.io/v3/cluster/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/cluster/validator_test.go
@@ -522,9 +522,6 @@ func TestAdmit(t *testing.T) {
 					assert.Equal(t, tt.expectedReason, res.Result.Reason)
 				}
 			}
-			if tt.expectContainWarning {
-				assert.NotEmpty(t, res.Warnings)
-			}
 		})
 	}
 }

--- a/pkg/resources/management.cattle.io/v3/cluster/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/cluster/validator_test.go
@@ -64,13 +64,12 @@ func TestAdmit(t *testing.T) {
 	}).AnyTimes()
 
 	tests := []struct {
-		name                 string
-		oldCluster           v3.Cluster
-		newCluster           v3.Cluster
-		operation            admissionv1.Operation
-		expectAllowed        bool
-		expectedReason       metav1.StatusReason
-		expectContainWarning bool
+		name           string
+		oldCluster     v3.Cluster
+		newCluster     v3.Cluster
+		operation      admissionv1.Operation
+		expectAllowed  bool
+		expectedReason metav1.StatusReason
 	}{
 		{
 			name:          "Create",
@@ -449,8 +448,7 @@ func TestAdmit(t *testing.T) {
 					Driver: v3.ClusterDriverAKS,
 				},
 			},
-			expectAllowed:        true,
-			expectContainWarning: true,
+			expectAllowed: true,
 		},
 		{
 			name:      "cluster version management - invalid cluster type, invalid annotation, update",
@@ -470,8 +468,7 @@ func TestAdmit(t *testing.T) {
 					Driver: v3.ClusterDriverAKS,
 				},
 			},
-			expectAllowed:        true,
-			expectContainWarning: true,
+			expectAllowed: true,
 		},
 		{
 			name:      "Delete local cluster where Rancher is deployed",


### PR DESCRIPTION
Backport from https://github.com/rancher/webhook/pull/990

## Issue: 
https://github.com/rancher/rancher/issues/51024

## Problem: 
Described on issue. TLDR: the warning is not useful anymore.