### PR TITLE
[v0.8] Revert user update validation changes

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -524,12 +524,6 @@ When a user is updated or deleted, a check occurs to ensure that the user making
 
 If the user making the request has the verb `manage-users` for the resource `users`, then it is allowed to bypass the check. Note that the wildcard `*` includes the `manage-users` verb.
 
-#### Invalid Fields - Update
-
-Users can update the following fields if they had not been set. But after getting initial values, the fields cannot be changed:
-
-- UserName
-
 ## UserAttribute
 
 ### Validation Checks

--- a/pkg/resources/management.cattle.io/v3/users/User.md
+++ b/pkg/resources/management.cattle.io/v3/users/User.md
@@ -5,9 +5,3 @@
 When a user is updated or deleted, a check occurs to ensure that the user making the request has permissions greater than or equal to the user being updated or deleted. To get the user's groups, the user's UserAttributes are checked. This is best effort, because UserAttributes are only updated when a User logs in, so it may not be perfectly up to date.
 
 If the user making the request has the verb `manage-users` for the resource `users`, then it is allowed to bypass the check. Note that the wildcard `*` includes the `manage-users` verb.
-
-### Invalid Fields - Update
-
-Users can update the following fields if they had not been set. But after getting initial values, the fields cannot be changed:
-
-- UserName

--- a/pkg/resources/management.cattle.io/v3/users/validator.go
+++ b/pkg/resources/management.cattle.io/v3/users/validator.go
@@ -14,7 +14,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/authentication/user"
 	authorizationv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	"k8s.io/kubernetes/pkg/registry/rbac/validation"
@@ -83,26 +82,26 @@ func (a *admitter) Admit(request *admission.Request) (*admissionv1.AdmissionResp
 		return &admissionv1.AdmissionResponse{Allowed: true}, nil
 	}
 
-	oldUser, newUser, err := objectsv3.UserOldAndNewFromRequest(&request.AdmissionRequest)
+	userObj, err := objectsv3.UserFromRequest(&request.AdmissionRequest)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get current User from request: %w", err)
 	}
 
 	// Need the UserAttribute to find the groups
-	userAttribute, err := a.userAttributeCache.Get(oldUser.Name)
+	userAttribute, err := a.userAttributeCache.Get(userObj.Name)
 	if err != nil && !apierrors.IsNotFound(err) {
-		return nil, fmt.Errorf("failed to get UserAttribute for %s: %w", oldUser.Name, err)
+		return nil, fmt.Errorf("failed to get UserAttribute for %s: %w", userObj.Name, err)
 	}
 
 	userInfo := &user.DefaultInfo{
-		Name:   oldUser.Name,
+		Name:   userObj.Name,
 		Groups: getGroupsFromUserAttribute(userAttribute),
 	}
 
 	// Get all rules for the user being modified
 	rules, err := a.resolver.RulesFor(context.Background(), userInfo, "")
 	if err != nil {
-		return nil, fmt.Errorf("failed to get rules for user %v: %w", oldUser, err)
+		return nil, fmt.Errorf("failed to get rules for user %v: %w", userObj, err)
 	}
 
 	// Ensure that rules of the user being modified aren't greater than the rules of the user making the request
@@ -116,13 +115,6 @@ func (a *admitter) Admit(request *admission.Request) (*admissionv1.AdmissionResp
 				Message: fmt.Sprintf("request is attempting to modify user with more permissions than requester %v", err),
 			},
 		}, nil
-	}
-
-	fieldPath := field.NewPath("user")
-	if request.Operation == admissionv1.Update {
-		if err := validateUpdateFields(oldUser, newUser, fieldPath); err != nil {
-			return admission.ResponseBadRequest(err.Error()), nil
-		}
 	}
 
 	return &admissionv1.AdmissionResponse{Allowed: true}, nil
@@ -142,13 +134,4 @@ func getGroupsFromUserAttribute(userAttribute *v3.UserAttribute) []string {
 		}
 	}
 	return result
-}
-
-// validateUpdateFields
-func validateUpdateFields(oldUser, newUser *v3.User, fieldPath *field.Path) error {
-	const reason = "field is immutable"
-	if oldUser.Username != "" && oldUser.Username != newUser.Username {
-		return field.Invalid(fieldPath.Child("username"), newUser.Username, reason)
-	}
-	return nil
 }

--- a/pkg/resources/management.cattle.io/v3/users/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/users/validator_test.go
@@ -35,7 +35,6 @@ var (
 		ObjectMeta: metav1.ObjectMeta{
 			Name: defaultUserName,
 		},
-		Username: defaultUserName,
 	}
 	getPods = []rbacv1.PolicyRule{
 		{
@@ -194,49 +193,6 @@ func Test_Admit(t *testing.T) {
 					return starPods, nil
 				}
 				return nil, fmt.Errorf("unexpected error")
-			},
-			allowed: false,
-		},
-		{
-			name:    "changing the username not allowed",
-			oldUser: defaultUser.DeepCopy(),
-			newUser: &v3.User{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: defaultUserName,
-				},
-				Username: "new-username",
-			},
-			requestUserName: requesterUserName,
-			resolverRulesFor: func(string) ([]rbacv1.PolicyRule, error) {
-				return getPods, nil
-			},
-			allowed: false,
-		},
-		{
-			name: "adding a new username allowed",
-			oldUser: &v3.User{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: defaultUserName,
-				},
-			},
-			newUser:         defaultUser.DeepCopy(),
-			requestUserName: requesterUserName,
-			resolverRulesFor: func(string) ([]rbacv1.PolicyRule, error) {
-				return getPods, nil
-			},
-			allowed: true,
-		},
-		{
-			name:    "removing username not allowed",
-			oldUser: defaultUser.DeepCopy(),
-			newUser: &v3.User{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: defaultUserName,
-				},
-			},
-			requestUserName: requesterUserName,
-			resolverRulesFor: func(string) ([]rbacv1.PolicyRule, error) {
-				return getPods, nil
 			},
 			allowed: false,
 		},


### PR DESCRIPTION
Reverts the changes from this PR https://github.com/rancher/webhook/pull/943 in the v0.8 branch. I meant for it to only go into `main`, but didn't realize we hadn't branched off the v2.12 versions yet.