### PR TITLE
[release/v0.8] Label admission-configuration-psact secret to be backed up

### DIFF
--- a/pkg/resources/provisioning.cattle.io/v1/cluster/mutator.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/mutator.go
@@ -42,6 +42,7 @@ const (
 	mountPath = "/etc/rancher/%s/config/rancher-psact.yaml"
 
 	controlPlaneRoleLabel            = "rke.cattle.io/control-plane-role"
+	backupLabel                      = "resources.cattle.io/backup"
 	secretAnnotation                 = "rke.cattle.io/object-authorized-for-clusters"
 	allowDynamicSchemaDropAnnotation = "provisioning.cattle.io/allow-dynamic-schema-drop"
 	runtimeK3S                       = "k3s"
@@ -316,6 +317,9 @@ func (m *ProvisioningClusterMutator) ensureSecret(namespace, name string, data m
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			Labels: map[string]string{
+				backupLabel: "true",
+			},
 		},
 		Data: data,
 		Type: corev1.SecretTypeOpaque,

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/mutator_test.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/mutator_test.go
@@ -505,6 +505,7 @@ func machineSelectorFile2() rkev1.RKEProvisioningFiles {
 		MachineLabelSelector: &metav1.LabelSelector{
 			MatchLabels: map[string]string{
 				controlPlaneRoleLabel: "true",
+				backupLabel:           "true",
 			},
 		},
 		FileSources: []rkev1.ProvisioningFileSource{
@@ -530,6 +531,7 @@ func machineSelectorFile1() rkev1.RKEProvisioningFiles {
 		MachineLabelSelector: &metav1.LabelSelector{
 			MatchLabels: map[string]string{
 				controlPlaneRoleLabel: "true",
+				backupLabel:           "true",
 			},
 		},
 		FileSources: []rkev1.ProvisioningFileSource{


### PR DESCRIPTION
Issue: https://github.com/rancher/backup-restore-operator/issues/663