### PR TITLE
validate password for local users

### DIFF
--- a/pkg/resources/core/v1/secret/Secret.md
+++ b/pkg/resources/core/v1/secret/Secret.md
@@ -12,6 +12,11 @@ places a `field.cattle.io/creatorId` annotation with the name of the user as the
 
 If `field.cattle.io/no-creator-rbac` annotation is set, `field.cattle.io/creatorId` does not get set.
 
+For secrets that holds local users passwords, which are stored in the `cattle-local-user-passwords` namespace:
+- Verifies the password has the minimum required length.
+- The password is not the same as the username.
+- It encrypts the password using pbkdf2 
+
 ### On delete
 
 Checks if there are any RoleBindings owned by this secret which provide access to a role granting access to this secret.

--- a/pkg/resources/management.cattle.io/v3/users/User.md
+++ b/pkg/resources/management.cattle.io/v3/users/User.md
@@ -1,5 +1,9 @@
 ## Validation Checks
 
+### Create
+
+Verifies there aren't any other users with the same username.
+
 ### Update and Delete
 
 When a user is updated or deleted, a check occurs to ensure that the user making the request has permissions greater than or equal to the user being updated or deleted. To get the user's groups, the user's UserAttributes are checked. This is best effort, because UserAttributes are only updated when a User logs in, so it may not be perfectly up to date.
@@ -11,3 +15,5 @@ If the user making the request has the verb `manage-users` for the resource `use
 Users can update the following fields if they had not been set. But after getting initial values, the fields cannot be changed:
 
 - UserName
+
+A user can't deactivate or delete himself.

--- a/pkg/resources/management.cattle.io/v3/users/validator.go
+++ b/pkg/resources/management.cattle.io/v3/users/validator.go
@@ -3,6 +3,7 @@ package users
 import (
 	"context"
 	"fmt"
+	"k8s.io/utils/ptr"
 
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/webhook/pkg/admission"
@@ -13,6 +14,7 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/authentication/user"
@@ -33,6 +35,7 @@ type admitter struct {
 	resolver           validation.AuthorizationRuleResolver
 	sar                authorizationv1.SubjectAccessReviewInterface
 	userAttributeCache controllerv3.UserAttributeCache
+	userCache          controllerv3.UserCache
 }
 
 // Validator validates tokens.
@@ -41,12 +44,13 @@ type Validator struct {
 }
 
 // NewValidator returns a new Validator instance.
-func NewValidator(userAttributeCache controllerv3.UserAttributeCache, sar authorizationv1.SubjectAccessReviewInterface, defaultResolver validation.AuthorizationRuleResolver) *Validator {
+func NewValidator(userAttributeCache controllerv3.UserAttributeCache, sar authorizationv1.SubjectAccessReviewInterface, defaultResolver validation.AuthorizationRuleResolver, userCache controllerv3.UserCache) *Validator {
 	return &Validator{
 		admitter: admitter{
 			resolver:           defaultResolver,
 			userAttributeCache: userAttributeCache,
 			sar:                sar,
+			userCache:          userCache,
 		},
 	}
 }
@@ -58,7 +62,7 @@ func (v *Validator) GVR() schema.GroupVersionResource {
 
 // Operations returns list of operations handled by the validator.
 func (v *Validator) Operations() []admissionregistrationv1.OperationType {
-	return []admissionregistrationv1.OperationType{admissionregistrationv1.Update, admissionregistrationv1.Delete}
+	return []admissionregistrationv1.OperationType{admissionregistrationv1.Create, admissionregistrationv1.Update, admissionregistrationv1.Delete}
 }
 
 func (v *Validator) ValidatingWebhook(clientConfig admissionregistrationv1.WebhookClientConfig) []admissionregistrationv1.ValidatingWebhook {
@@ -73,6 +77,24 @@ func (v *Validator) Admitters() []admission.Admitter {
 }
 
 func (a *admitter) Admit(request *admission.Request) (*admissionv1.AdmissionResponse, error) {
+	oldUser, newUser, err := objectsv3.UserOldAndNewFromRequest(&request.AdmissionRequest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current User from request: %w", err)
+	}
+
+	if request.Operation == admissionv1.Create && newUser.Username != "" {
+		users, err := a.userCache.List(labels.Everything())
+		if err != nil {
+			return nil, fmt.Errorf("failed to get users %w", err)
+		}
+		for _, user := range users {
+			if user.Username == newUser.Username {
+				return admission.ResponseBadRequest("username already exists"), nil
+			}
+		}
+		return &admissionv1.AdmissionResponse{Allowed: true}, nil
+	}
+
 	// Check if requester has manage-user verb
 	hasManageUsers, err := auth.RequestUserHasVerb(request, gvr, a.sar, manageUsersVerb, "", "")
 	if err != nil {
@@ -81,11 +103,6 @@ func (a *admitter) Admit(request *admission.Request) (*admissionv1.AdmissionResp
 
 	if hasManageUsers {
 		return &admissionv1.AdmissionResponse{Allowed: true}, nil
-	}
-
-	oldUser, newUser, err := objectsv3.UserOldAndNewFromRequest(&request.AdmissionRequest)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get current User from request: %w", err)
 	}
 
 	// Need the UserAttribute to find the groups
@@ -122,6 +139,17 @@ func (a *admitter) Admit(request *admission.Request) (*admissionv1.AdmissionResp
 	if request.Operation == admissionv1.Update {
 		if err := validateUpdateFields(oldUser, newUser, fieldPath); err != nil {
 			return admission.ResponseBadRequest(err.Error()), nil
+		}
+		oldUserEnabled := ptr.Deref(oldUser.Enabled, false)
+		newUserEnabled := ptr.Deref(newUser.Enabled, false)
+
+		if newUser.Username == request.UserInfo.Username && oldUserEnabled && !newUserEnabled {
+			return admission.ResponseBadRequest("can't deactivate yourself"), nil
+		}
+	}
+	if request.Operation == admissionv1.Delete {
+		if oldUser.Name == request.UserInfo.Username {
+			return admission.ResponseBadRequest("can't delete yourself"), nil
 		}
 	}
 

--- a/pkg/resources/management.cattle.io/v3/users/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/users/validator_test.go
@@ -3,11 +3,13 @@ package users
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/webhook/pkg/admission"
+	controllerv3 "github.com/rancher/webhook/pkg/generated/controllers/management.cattle.io/v3"
 	"github.com/rancher/wrangler/v3/pkg/generic/fake"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
@@ -16,10 +18,12 @@ import (
 	authorizationv1 "k8s.io/api/authorization/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/authentication/user"
 	authorizationFake "k8s.io/client-go/kubernetes/typed/authorization/v1/fake"
 	k8testing "k8s.io/client-go/testing"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -78,6 +82,7 @@ func Test_Admit(t *testing.T) {
 		resolverRulesFor func(string) ([]rbacv1.PolicyRule, error)
 		requestUserName  string
 		allowed          bool
+		mockUserCache    func() controllerv3.UserCache
 		wantErr          bool
 	}{
 		{
@@ -240,6 +245,76 @@ func Test_Admit(t *testing.T) {
 			},
 			allowed: false,
 		},
+		{
+			name:    "changing an user password is not allowed",
+			oldUser: defaultUser.DeepCopy(),
+			newUser: &v3.User{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: defaultUserName,
+				},
+				Password: "new-password",
+			},
+			requestUserName: requesterUserName,
+			resolverRulesFor: func(string) ([]rbacv1.PolicyRule, error) {
+				return getPods, nil
+			},
+			allowed: false,
+		},
+		{
+			name:            "user can't delete himself",
+			oldUser:         defaultUser.DeepCopy(),
+			requestUserName: defaultUserName,
+			resolverRulesFor: func(string) ([]rbacv1.PolicyRule, error) {
+				return getPods, nil
+			},
+			allowed: false,
+		},
+		{
+			name: "user can't deactivate himself",
+			oldUser: &v3.User{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: defaultUserName,
+				},
+				Username: defaultUserName,
+				Enabled:  ptr.To(true),
+			},
+			newUser:         defaultUser.DeepCopy(),
+			requestUserName: defaultUserName,
+			resolverRulesFor: func(string) ([]rbacv1.PolicyRule, error) {
+				return getPods, nil
+			},
+			allowed: false,
+		},
+		{
+			name:            "username already exists",
+			newUser:         defaultUser.DeepCopy(),
+			requestUserName: defaultUserName,
+			mockUserCache: func() controllerv3.UserCache {
+				mock := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+				mock.EXPECT().List(labels.Everything()).Return([]*v3.User{
+					{
+						Username: defaultUserName,
+					},
+				}, nil)
+
+				return mock
+			},
+
+			allowed: false,
+		},
+		{
+			name:            "failed to get users",
+			newUser:         defaultUser.DeepCopy(),
+			requestUserName: defaultUserName,
+			mockUserCache: func() controllerv3.UserCache {
+				mock := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+				mock.EXPECT().List(labels.Everything()).Return(nil, errors.New("some error"))
+
+				return mock
+			},
+			allowed: false,
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -256,6 +331,9 @@ func Test_Admit(t *testing.T) {
 				a.resolver = &fakeResolver{
 					rulesFor: tt.resolverRulesFor,
 				}
+			}
+			if tt.mockUserCache != nil {
+				a.userCache = tt.mockUserCache()
 			}
 
 			req := createUserRequest(t, tt.oldUser, tt.newUser, tt.requestUserName)

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -87,7 +87,7 @@ func Validation(clients *clients.Clients) ([]admission.ValidatingAdmissionHandle
 			clusterrole.NewValidator(),
 			clusterrolebinding.NewValidator(),
 			authconfig.NewValidator(),
-			users.NewValidator(clients.Management.UserAttribute().Cache(), clients.K8s.AuthorizationV1().SubjectAccessReviews(), clients.DefaultResolver),
+			users.NewValidator(clients.Management.UserAttribute().Cache(), clients.K8s.AuthorizationV1().SubjectAccessReviews(), clients.DefaultResolver, clients.Management.User().Cache()),
 		)
 	} else {
 		handlers = append(handlers, clusterauthtoken.NewValidator())
@@ -106,7 +106,7 @@ func Mutation(clients *clients.Clients) ([]admission.MutatingAdmissionHandler, e
 	}
 
 	if clients.MultiClusterManagement {
-		secrets := secret.NewMutator(clients.RBAC.Role(), clients.RBAC.RoleBinding())
+		secrets := secret.NewMutator(clients.RBAC.Role(), clients.RBAC.RoleBinding(), clients.Management.Setting().Cache(), clients.Management.User().Cache())
 		projects := project.NewMutator(clients.Core.Namespace().Cache(), clients.Management.RoleTemplate().Cache(), clients.Management.Project().Cache())
 		grbs := globalrolebinding.NewMutator(clients.Management.GlobalRole().Cache())
 		mutators = append(mutators, secrets, projects, grbs)


### PR DESCRIPTION
## Issue:  https://github.com/rancher/rancher-security/issues/1261

## Problem
Users have been migrated to the public API which means that users can be created with kubectl bypassing norman validations.
User passwords are encrypted with pbkfd2. This encryption will be done by the webhook unless the user or Rancher already encrypted it. In this case the `cattle.io/password-hash` annotation must be provided.

## Solution
Move Norman validations to the webhook:
- User can't delete or deactivate himself.
- 2 users can't be created with the same username
- Password must have min length
- Password can't match the user name

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [x] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [x] Docs