### PR TITLE
Move username validation to happen before manage-users check

### DIFF
--- a/pkg/resources/management.cattle.io/v3/users/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/users/validator_test.go
@@ -115,12 +115,12 @@ func Test_Admit(t *testing.T) {
 			oldUser:         defaultUser.DeepCopy(),
 			requestUserName: requesterUserName,
 			resolverRulesFor: func(s string) ([]rbacv1.PolicyRule, error) {
-				if s == requesterUserName {
+				switch s {
+				case requesterUserName, defaultUserName:
 					return getPods, nil
-				} else if s == defaultUserName {
-					return getPods, nil
+				default:
+					return nil, fmt.Errorf("unexpected error")
 				}
-				return nil, fmt.Errorf("unexpected error")
 			},
 			allowed: true,
 		},
@@ -130,12 +130,12 @@ func Test_Admit(t *testing.T) {
 			newUser:         defaultUser.DeepCopy(),
 			requestUserName: requesterUserName,
 			resolverRulesFor: func(s string) ([]rbacv1.PolicyRule, error) {
-				if s == requesterUserName {
+				switch s {
+				case requesterUserName, defaultUserName:
 					return getPods, nil
-				} else if s == defaultUserName {
-					return getPods, nil
+				default:
+					return nil, fmt.Errorf("unexpected error")
 				}
-				return nil, fmt.Errorf("unexpected error")
 			},
 			allowed: true,
 		},
@@ -144,12 +144,14 @@ func Test_Admit(t *testing.T) {
 			oldUser:         defaultUser.DeepCopy(),
 			requestUserName: requesterUserName,
 			resolverRulesFor: func(s string) ([]rbacv1.PolicyRule, error) {
-				if s == requesterUserName {
+				switch s {
+				case requesterUserName:
 					return starPods, nil
-				} else if s == defaultUserName {
+				case defaultUserName:
 					return getPods, nil
+				default:
+					return nil, fmt.Errorf("unexpected error")
 				}
-				return nil, fmt.Errorf("unexpected error")
 			},
 			allowed: true,
 		},
@@ -159,12 +161,14 @@ func Test_Admit(t *testing.T) {
 			newUser:         defaultUser.DeepCopy(),
 			requestUserName: requesterUserName,
 			resolverRulesFor: func(s string) ([]rbacv1.PolicyRule, error) {
-				if s == requesterUserName {
+				switch s {
+				case requesterUserName:
 					return starPods, nil
-				} else if s == defaultUserName {
+				case defaultUserName:
 					return getPods, nil
+				default:
+					return nil, fmt.Errorf("unexpected error")
 				}
-				return nil, fmt.Errorf("unexpected error")
 			},
 			allowed: true,
 		},
@@ -173,12 +177,14 @@ func Test_Admit(t *testing.T) {
 			oldUser:         defaultUser.DeepCopy(),
 			requestUserName: requesterUserName,
 			resolverRulesFor: func(s string) ([]rbacv1.PolicyRule, error) {
-				if s == requesterUserName {
+				switch s {
+				case requesterUserName:
 					return getPods, nil
-				} else if s == defaultUserName {
+				case defaultUserName:
 					return starPods, nil
+				default:
+					return nil, fmt.Errorf("unexpected error")
 				}
-				return nil, fmt.Errorf("unexpected error")
 			},
 			allowed: false,
 		},
@@ -188,12 +194,14 @@ func Test_Admit(t *testing.T) {
 			newUser:         defaultUser.DeepCopy(),
 			requestUserName: requesterUserName,
 			resolverRulesFor: func(s string) ([]rbacv1.PolicyRule, error) {
-				if s == requesterUserName {
+				switch s {
+				case requesterUserName:
 					return getPods, nil
-				} else if s == defaultUserName {
+				case defaultUserName:
 					return starPods, nil
+				default:
+					return nil, fmt.Errorf("unexpected error")
 				}
-				return nil, fmt.Errorf("unexpected error")
 			},
 			allowed: false,
 		},
@@ -207,10 +215,7 @@ func Test_Admit(t *testing.T) {
 				Username: "new-username",
 			},
 			requestUserName: requesterUserName,
-			resolverRulesFor: func(string) ([]rbacv1.PolicyRule, error) {
-				return getPods, nil
-			},
-			allowed: false,
+			allowed:         false,
 		},
 		{
 			name: "adding a new username allowed",
@@ -235,10 +240,7 @@ func Test_Admit(t *testing.T) {
 				},
 			},
 			requestUserName: requesterUserName,
-			resolverRulesFor: func(string) ([]rbacv1.PolicyRule, error) {
-				return getPods, nil
-			},
-			allowed: false,
+			allowed:         false,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Problem
The username validation currently gets bypassed with the `manage-users` verb.

## Solution
Move the validation check for usernames above the `manage-users` check

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [x] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [x] Docs