### PR TITLE
48484 bug webhook error msg

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -43,6 +43,8 @@ const (
 	webhookPortEnvKey       = "CATTLE_PORT"
 	webhookURLEnvKey        = "CATTLE_WEBHOOK_URL"
 	allowedCNsEnv           = "ALLOWED_CNS"
+	ignoreTLSHandshakeError = "IGNORE_TLS_HANDSHAKE_ERROR"
+	ignoreTLSHandErrorVal   = false
 )
 
 var caFile = filepath.Join(os.TempDir(), "k8s-webhook-server", "client-ca", "ca.crt")
@@ -151,6 +153,7 @@ func listenAndServe(ctx context.Context, clients *clients.Clients, validators []
 			return fmt.Errorf("failed to decode webhook port value '%s': %w", portStr, err)
 		}
 	}
+	ignoreTLSHandErrorVal, _ := strconv.ParseBool(os.Getenv(ignoreTLSHandshakeError))
 	return server.ListenAndServe(ctx, webhookHTTPSPort, webhookHTTPPort, router, &server.ListenOpts{
 		Secrets:       clients.Core.Secret(),
 		CertNamespace: namespace,
@@ -163,7 +166,8 @@ func listenAndServe(ctx context.Context, clients *clients.Clients, validators []
 			FilterCN:  dynamiclistener.OnlyAllow(tlsName),
 			TLSConfig: tlsConfig,
 		},
-		DisplayServerLogs: true,
+		DisplayServerLogs:       true,
+		IgnoreTLSHandshakeError: ignoreTLSHandErrorVal,
 	})
 }
 


### PR DESCRIPTION
## Issue: [#48484]
<!-- If your PR depends on changes from other PRs, link them here and describe why they are needed for your solution section. -->
## Problem
The Rancher webhook can generate a large volume of `http: TLS handshake error` logs when a client attempts to connect with a missing or invalid certificate. While these are often non-critical, they can overwhelm the logs, making it difficult to debug genuine issues. The current implementation doesn't provide a way to suppress these logs without impacting other important error messages. The community has requested a solution to reduce log noise caused by these specific errors, as detailed in issue #48484.
## Solution
This PR introduces a new environment variable, **IGNORE_TLS_HANDSHAKE_ERROR**, to the Rancher webhook. This variable, which defaults to `false`, gives operators control over the logging behavior of TLS handshake errors.

When **IGNORE_TLS_HANDSHAKE_ERROR** is set to `true`, `http: TLS handshake error `messages are downgraded from `error` to `debug` level. This means the messages will only appear in the logs if the **CATTLE_DEBUG** environment variable is also set to `true`. This approach provides a clear mechanism to either ignore these specific errors for a quieter log output or enable them for in-depth debugging.

## **Test Scenarios**
Scenario 1: `CATTLE_DEBUG = false, IGNORE_TLS_HANDSHAKE_ERROR = true`

Result: No TLS handshake error messages are logged. The messages are logged at the debug level but are not displayed because **CATTLE_DEBUG** is false.

Scenario 2: `CATTLE_DEBUG = false, IGNORE_TLS_HANDSHAKE_ERROR = false`

Result: No TLS handshake `error` messages are logged. The messages are logged at the `error` level, but the scenario does not produce the error.

Scenario 3:` CATTLE_DEBUG = true, IGNORE_TLS_HANDSHAKE_ERROR = true`

Result: TLS handshake `error` messages are logged at the `debug` level, as expected.

_`Log Example: level=debug msg="2025/08/21 18:03:25 http: TLS handshake error from 172.31.7.103:40900: EOF"`_

Scenario 4: `CATTLE_DEBUG = true, IGNORE_TLS_HANDSHAKE_ERROR = false`

Result: TLS handshake error messages are logged at the error level, preserving the default behavior.

_`Log Example: level=error msg="2025/08/21 18:17:38 http: TLS handshake error from 172.31.7.103:49312: EOF"`_

### How to reproduce and force the error:
- Set the environment variables on rancher-webhook deployment `(kubectl -n cattle-system edit deploy rancher-webhook)`
- CATTLE_DEBUG and IGNORE_TLS_HANDSHAKE_ERROR
- Login on Rancher UI 
- Check the logs from rancher-webhook `(kubectl logs -l app=rancher-webhook -n cattle-system)`
