### PR TITLE
[v0.6] Username uniqueness check for Create and Update

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -418,6 +418,10 @@ When a Token is updated, the following checks take place:
 
 ### Validation Checks
 
+#### Create and Delete
+
+Verifies there aren't any other users with the same username.
+
 #### Update and Delete
 
 When a user is updated or deleted, a check occurs to ensure that the user making the request has permissions greater than or equal to the user being updated or deleted. To get the user's groups, the user's UserAttributes are checked. This is best effort, because UserAttributes are only updated when a User logs in, so it may not be perfectly up to date.

--- a/pkg/resources/management.cattle.io/v3/users/User.md
+++ b/pkg/resources/management.cattle.io/v3/users/User.md
@@ -1,5 +1,9 @@
 ## Validation Checks
 
+### Create and Delete
+
+Verifies there aren't any other users with the same username.
+
 ### Update and Delete
 
 When a user is updated or deleted, a check occurs to ensure that the user making the request has permissions greater than or equal to the user being updated or deleted. To get the user's groups, the user's UserAttributes are checked. This is best effort, because UserAttributes are only updated when a User logs in, so it may not be perfectly up to date.

--- a/pkg/resources/management.cattle.io/v3/users/validator.go
+++ b/pkg/resources/management.cattle.io/v3/users/validator.go
@@ -12,6 +12,7 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/authentication/user"
@@ -32,6 +33,7 @@ type admitter struct {
 	resolver           validation.AuthorizationRuleResolver
 	sar                authorizationv1.SubjectAccessReviewInterface
 	userAttributeCache controllerv3.UserAttributeCache
+	userCache          controllerv3.UserCache
 }
 
 // Validator validates tokens.
@@ -40,12 +42,13 @@ type Validator struct {
 }
 
 // NewValidator returns a new Validator instance.
-func NewValidator(userAttributeCache controllerv3.UserAttributeCache, sar authorizationv1.SubjectAccessReviewInterface, defaultResolver validation.AuthorizationRuleResolver) *Validator {
+func NewValidator(userAttributeCache controllerv3.UserAttributeCache, sar authorizationv1.SubjectAccessReviewInterface, defaultResolver validation.AuthorizationRuleResolver, userCache controllerv3.UserCache) *Validator {
 	return &Validator{
 		admitter: admitter{
 			resolver:           defaultResolver,
 			userAttributeCache: userAttributeCache,
 			sar:                sar,
+			userCache:          userCache,
 		},
 	}
 }
@@ -77,11 +80,22 @@ func (a *admitter) Admit(request *admission.Request) (*admissionv1.AdmissionResp
 		return nil, fmt.Errorf("failed to get current User from request: %w", err)
 	}
 
-	// Validate update fields
+	if request.Operation == admissionv1.Create && newUser.Username != "" {
+		if resp, err := a.checkUsernameUniqueness(newUser.Username); err != nil || resp != nil {
+			return resp, err
+		}
+		return &admissionv1.AdmissionResponse{Allowed: true}, nil
+	}
+
 	fieldPath := field.NewPath("user")
 	if request.Operation == admissionv1.Update {
 		if err := validateUpdateFields(oldUser, newUser, fieldPath); err != nil {
 			return admission.ResponseBadRequest(err.Error()), nil
+		}
+		if oldUser.Username == "" && newUser.Username != "" {
+			if resp, err := a.checkUsernameUniqueness(newUser.Username); err != nil || resp != nil {
+				return resp, err
+			}
 		}
 	}
 
@@ -125,6 +139,23 @@ func (a *admitter) Admit(request *admission.Request) (*admissionv1.AdmissionResp
 		}, nil
 	}
 	return &admissionv1.AdmissionResponse{Allowed: true}, nil
+}
+
+// checkUsernameUniqueness checks if a given username is already in use by another user.
+func (a *admitter) checkUsernameUniqueness(username string) (*admissionv1.AdmissionResponse, error) {
+	if username == "" {
+		return nil, nil
+	}
+	users, err := a.userCache.List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get users: %w", err)
+	}
+	for _, user := range users {
+		if user.Username == username {
+			return admission.ResponseBadRequest("username already exists"), nil
+		}
+	}
+	return nil, nil
 }
 
 // getGroupsFromUserAttributes gets the list of group principals from a UserAttribute.

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -79,7 +79,7 @@ func Validation(clients *clients.Clients) ([]admission.ValidatingAdmissionHandle
 			userattribute.NewValidator(),
 			clusterrole.NewValidator(),
 			clusterrolebinding.NewValidator(),
-			users.NewValidator(clients.Management.UserAttribute().Cache(), clients.K8s.AuthorizationV1().SubjectAccessReviews(), clients.DefaultResolver),
+			users.NewValidator(clients.Management.UserAttribute().Cache(), clients.K8s.AuthorizationV1().SubjectAccessReviews(), clients.DefaultResolver, clients.Management.User().Cache()),
 		)
 	} else {
 		handlers = append(handlers, clusterauthtoken.NewValidator())


### PR DESCRIPTION
Backport of https://github.com/rancher/webhook/pull/1053 with some additional code pulled from https://github.com/rancher/webhook/pull/1015

The original backport https://github.com/rancher/webhook/pull/1053 has the username uniqueness check on update, and https://github.com/rancher/webhook/pull/1015 has the check on create.