### PR TITLE
feat(chart): add resources for webhook container

### DIFF
--- a/charts/rancher-webhook/templates/deployment.yaml
+++ b/charts/rancher-webhook/templates/deployment.yaml
@@ -76,6 +76,9 @@ spec:
             add:
             - NET_BIND_SERVICE
         {{- end }}
+        {{- if .Values.resources }}
+        resources: {{- toYaml .Values.resources | nindent 10 }}
+        {{- end }}
       serviceAccountName: rancher-webhook
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{.Values.priorityClassName}}"

--- a/charts/rancher-webhook/tests/deployment_test.yaml
+++ b/charts/rancher-webhook/tests/deployment_test.yaml
@@ -71,3 +71,8 @@ tests:
           content:
             name: ALLOWED_CNS
             value: kube-apiserver,joe
+
+  - it: should not set resources by default.
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].resources

--- a/charts/rancher-webhook/values.yaml
+++ b/charts/rancher-webhook/values.yaml
@@ -14,6 +14,8 @@ mcm:
 # tolerations for the webhook deployment. See https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ for more info
 tolerations: []
 nodeSelector: {}
+# resources of the webhook container
+resources: {}
 
 ## PriorityClassName assigned to deployment.
 priorityClassName: ""


### PR DESCRIPTION
Makes the resources of the webhook container configurable with the helm values.

## Issue: #963
<!-- If your PR depends on changes from other PRs, link them here and describe why they are needed for your solution section. -->
## Problem
<!-- Describe the root cause of the issue you are resolving. 
This may include what behavior is observed and why it is not desirable. If this is a new feature, describe why we need it and how it will be used. -->
The webhook container has no resources set and the chart does not allow to configure anything. This always puts the container into `BestEffort` QoS class, which can lead to restarts on a node with pressure.

## Solution
<!-- Describe what you changed to fix the issue. 
Relate your changes to the original bug/feature and explain why this addresses the issue. -->

This adds a value `resources` that allows to configure requests/limits of the container. The default is unaffected as the value defaults to an empty object.

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [x] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [ ] Docs

Did not find any docs for the chart values.