### PR TITLE
Allow webhook pods to have leader election to govern which pod updates the config

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -26,7 +27,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
 )
 
 const (
@@ -46,6 +50,10 @@ const (
 )
 
 var caFile = filepath.Join(os.TempDir(), "k8s-webhook-server", "client-ca", "ca.crt")
+
+// leaderFlag indicates whether this process is the elected leader.
+// Gate config mutation work on this to avoid concurrent writers.
+var leaderFlag atomic.Bool
 
 // tlsOpt option function applied to all webhook servers.
 var tlsOpt = func(config *tls.Config) {
@@ -85,6 +93,51 @@ func ListenAndServe(ctx context.Context, cfg *rest.Config, mcmEnabled bool) erro
 		return err
 	}
 
+	k8sClient, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to create kubernetes clientset: %w", err)
+	}
+	id, err := os.Hostname()
+	if err != nil || id == "" {
+		id = fmt.Sprintf("rancher-webhook-%d", time.Now().UnixNano())
+	}
+
+	lock := &resourcelock.LeaseLock{
+		LeaseMeta: metav1.ObjectMeta{
+			Name:      "rancher-webhook-leader",
+			Namespace: namespace,
+		},
+		Client: k8sClient.CoordinationV1(),
+		LockConfig: resourcelock.ResourceLockConfig{
+			Identity: id,
+		},
+	}
+
+	go leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
+		Lock:            lock,
+		LeaseDuration:   15 * time.Second,
+		RenewDeadline:   10 * time.Second,
+		RetryPeriod:     2 * time.Second,
+		ReleaseOnCancel: true,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(c context.Context) {
+				leaderFlag.Store(true)
+				logrus.Infof("[%s] elected leader: will manage webhook configurations", id)
+			},
+			OnStoppedLeading: func() {
+				leaderFlag.Store(false)
+				logrus.Infof("[%s] lost leadership: will stop managing webhook configurations", id)
+			},
+			OnNewLeader: func(identity string) {
+				if identity == id {
+					logrus.Infof("[%s] I am the new leader", id)
+				} else {
+					logrus.Infof("[%s] observed new leader: %s", id, identity)
+				}
+			},
+		},
+	})
+
 	if err = listenAndServe(ctx, clients, validators, mutators); err != nil {
 		return err
 	}
@@ -111,6 +164,7 @@ func listenAndServe(ctx context.Context, clients *clients.Clients, validators []
 	router := mux.NewRouter()
 	errChecker := health.NewErrorChecker("Config Applied")
 	health.RegisterHealthCheckers(router, errChecker)
+	errChecker.Store(nil)
 	router.Use(certAuth())
 
 	logrus.Debug("Creating Webhook routes")
@@ -176,7 +230,14 @@ type secretHandler struct {
 }
 
 // sync updates the validating admission configuration whenever the TLS cert changes.
+// Only the elected leader performs the updates, followers are a no-op.
 func (s *secretHandler) sync(_ string, secret *corev1.Secret) (*corev1.Secret, error) {
+	// Only leader should manage webhook configuration
+	if !leaderFlag.Load() {
+		// Not the leader: do nothing, return nil
+		return nil, nil
+	}
+
 	if secret == nil || secret.Name != caName || secret.Namespace != namespace || len(secret.Data[corev1.TLSCertKey]) == 0 {
 		return nil, nil
 	}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/43525
<!-- If your PR depends on changes from other PRs, link them here and describe why they are needed for your solution section. -->
## Problem
<!-- Describe the root cause of the issue you are resolving. 
This may include what behavior is observed and why it is not desirable. If this is a new feature, describe why we need it and how it will be used. -->

## Solution
<!-- Describe what you changed to fix the issue. 
Relate your changes to the original bug/feature and explain why this addresses the issue. -->

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [ ] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [ ] Docs