### PR TITLE
Fix crash when rancherd patches local cluster (#1100)

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -591,6 +591,8 @@ following:
 - Equal to another data directory
 - Attempts to nest another data directory
 
+If the action is an update, and the old cluster had a `nil` `.spec.rkeConfig`, accept the request, since this is how rancherd operates, and is required for harvester installations.
+
 ##### Etcd S3 CloudCredential Secret
 
 Prevent the creation of objects if the secret specified in `.spec.rkeConfig.etcd.s3.cloudCredentialName` does not exist.

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/Cluster.md
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/Cluster.md
@@ -24,6 +24,8 @@ following:
 - Equal to another data directory
 - Attempts to nest another data directory
 
+If the action is an update, and the old cluster had a `nil` `.spec.rkeConfig`, accept the request, since this is how rancherd operates, and is required for harvester installations.
+
 #### Etcd S3 CloudCredential Secret
 
 Prevent the creation of objects if the secret specified in `.spec.rkeConfig.etcd.s3.cloudCredentialName` does not exist.
@@ -107,4 +109,3 @@ Check for the presence of the `provisioning.cattle.io/allow-dynamic-schema-drop`
 perform no mutations. If the value is not present or not `"true"`, compare the value of the `dynamicSchemaSpec` field
 for each `machinePool`, to its' previous value. If the values are not identical, revert the value for the
 `dynamicSchemaSpec` for the specific `machinePool`, but do not reject the request.
-

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/validator.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/validator.go
@@ -253,6 +253,10 @@ func (p *provisioningAdmitter) validateDataDirectories(request *admission.Reques
 	if request.Operation != admissionv1.Update {
 		return admission.ResponseAllowed()
 	}
+	// possible in the harvester case, as rkeConfig is patched to be non-nil.
+	if oldCluster.Spec.RKEConfig == nil {
+		return admission.ResponseAllowed()
+	}
 
 	if response := p.validateSystemAgentDataDirectory(oldCluster, newCluster); !response.Allowed {
 		return response

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/validator_test.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/validator_test.go
@@ -949,6 +949,17 @@ func TestValidateDataDirectories(t *testing.T) {
 			shouldSucceed: true,
 		},
 		{
+			name:    "old no rkeconfig",
+			request: &admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{Operation: admissionv1.Update}},
+			cluster: &v1.Cluster{
+				Spec: v1.ClusterSpec{
+					RKEConfig: &v1.RKEConfig{},
+				},
+			},
+			oldCluster:    &v1.Cluster{},
+			shouldSucceed: true,
+		},
+		{
 			name:    "Create",
 			request: &admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{Operation: admissionv1.Create}},
 			cluster: &v1.Cluster{


### PR DESCRIPTION
Forwardport of https://github.com/rancher/webhook/pull/1100

## Issue: <!-- link the issue or issues this PR resolves here --> https://github.com/rancher/rancher/issues/51979
<!-- If your PR depends on changes from other PRs, link them here and describe why they are needed for your solution section. -->
## Problem
<!-- Describe the root cause of the issue you are resolving. 
This may include what behavior is observed and why it is not desirable. If this is a new feature, describe why we need it and how it will be used. -->

https://github.com/rancher/webhook/pull/410 introduced data directory validation to the webhook, designed to prevent users from changing data directories once the cluster has been created. Harvester leverages rancherd, which is effectively a self-bootstrapping mechanism for creating the Rancher local cluster. Part of this bootstrapping involves patching the local cluster to set the rkeConfig: {}, which result in Rancher reconciling it like any other normal CAPI cluster.

Previously, the webhook did not come up quick enough in the rancherd process, but now the webhook and it's related validatingwebhookconfiguration exists before the cluster can be patched. The data directory validation causes the webhook to panic (and reject the request), as it was not expected that a cluster would go from an rkeConfig with a nil value, to one without one.

## Solution
<!-- Describe what you changed to fix the issue. 
Relate your changes to the original bug/feature and explain why this addresses the issue. -->

if `oldCluster.Spec.RKEConfig == nil`, accept the request.

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [x] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [x] Docs