### PR TITLE
Fix crash in mutator when rancherd patches local cluster

### DIFF
--- a/pkg/resources/provisioning.cattle.io/v1/cluster/mutator.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/mutator.go
@@ -194,7 +194,7 @@ func (m *ProvisioningClusterMutator) Admit(request *admission.Request) (*admissi
 // dynamicSchemaSpec field for a machine pool if the "provisioning.cattle.io/allow-dynamic-schema-drop" annotation is
 // not present and true on the cluster. If the value of the annotation is true, no mutation is performed.
 func (m *ProvisioningClusterMutator) handleDynamicSchemaDrop(request *admission.Request, oldCluster, cluster *v1.Cluster) *admissionv1.AdmissionResponse {
-	if cluster.Name == "local" || cluster.Spec.RKEConfig == nil {
+	if cluster.Name == "local" || oldCluster == nil || oldCluster.Spec.RKEConfig == nil || cluster.Spec.RKEConfig == nil {
 		return admission.ResponseAllowed()
 	}
 

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/mutator_test.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/mutator_test.go
@@ -687,6 +687,22 @@ func TestDynamicSchemaDrop(t *testing.T) {
 			cluster: &v1.Cluster{},
 		},
 		{
+			name:    "old not v2prov cluster",
+			request: &admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{Operation: admissionv1.Update}},
+			cluster: &v1.Cluster{
+				Spec: v1.ClusterSpec{
+					RKEConfig: &v1.RKEConfig{
+						MachinePools: []v1.RKEMachinePool{
+							{
+								Name: "a",
+							},
+						},
+					},
+				},
+			},
+			oldCluster: &v1.Cluster{},
+		},
+		{
 			name:    "no schema present on old or new cluster",
 			request: &admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{Operation: admissionv1.Update}},
 			cluster: &v1.Cluster{


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> https://github.com/rancher/rancher/issues/52096
<!-- If your PR depends on changes from other PRs, link them here and describe why they are needed for your solution section. -->
## Problem
<!-- Describe the root cause of the issue you are resolving. 
This may include what behavior is observed and why it is not desirable. If this is a new feature, describe why we need it and how it will be used. -->

https://github.com/rancher/webhook/pull/410 introduced data directory validation to the webhook, designed to prevent users from changing data directories once the cluster has been created. Harvester leverages rancherd, which is effectively a self-bootstrapping mechanism for creating the Rancher local cluster. Part of this bootstrapping involves patching the local cluster to set the rkeConfig: {}, which result in Rancher reconciling it like any other normal CAPI cluster.

Previously, the webhook did not come up quick enough in the rancherd process, but now the webhook and it's related mutatingwebhookconfiguration exists before the cluster can be patched. The data directory validation causes the webhook to panic (and reject the request), as it was not expected that a cluster would go from an rkeConfig with a nil value, to one without one.

## Solution
<!-- Describe what you changed to fix the issue. 
Relate your changes to the original bug/feature and explain why this addresses the issue. -->

if `oldCluster.Spec.RKEConfig == nil`, accept the request.

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [x] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [x] Docs - No need to update docs on this one I believe.