### PR TITLE
validate the new project state for consistency, ignore old state

### DIFF
--- a/pkg/resources/management.cattle.io/v3/project/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/project/validator_test.go
@@ -990,7 +990,7 @@ func TestProjectValidation(t *testing.T) {
 			wantAllowed: false,
 		},
 		{
-			name:      "update with project quota less than used quota",
+			name:      "update with project quota less than used quota, quota changed",
 			operation: admissionv1.Update,
 			oldProject: &v3.Project{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1036,6 +1036,154 @@ func TestProjectValidation(t *testing.T) {
 					},
 				},
 			},
+			wantAllowed: false,
+		},
+		{
+			name:      "update with project quota less than used quota, used quota changed",
+			operation: admissionv1.Update,
+			oldProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+				Spec: v3.ProjectSpec{
+					ClusterName: "testcluster",
+					ResourceQuota: &v3.ProjectResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "100",
+						},
+						UsedLimit: v3.ResourceQuotaLimit{
+							ConfigMaps: "100",
+						},
+					},
+					NamespaceDefaultResourceQuota: &v3.NamespaceResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "50",
+						},
+					},
+				},
+			},
+			newProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+				Spec: v3.ProjectSpec{
+					ClusterName: "testcluster",
+					ResourceQuota: &v3.ProjectResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "100",
+						},
+						UsedLimit: v3.ResourceQuotaLimit{
+							ConfigMaps: "1000",
+						},
+					},
+					NamespaceDefaultResourceQuota: &v3.NamespaceResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "50",
+						},
+					},
+				},
+			},
+			wantAllowed: false,
+		},
+		{
+			name:      "update project with bogus used quota, to good used quota",
+			operation: admissionv1.Update,
+			oldProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+				Spec: v3.ProjectSpec{
+					ClusterName: "testcluster",
+					ResourceQuota: &v3.ProjectResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "100",
+						},
+						UsedLimit: v3.ResourceQuotaLimit{
+							ConfigMaps: "xxxxxxxxxx",
+						},
+					},
+					NamespaceDefaultResourceQuota: &v3.NamespaceResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "50",
+						},
+					},
+				},
+			},
+			newProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+				Spec: v3.ProjectSpec{
+					ClusterName: "testcluster",
+					ResourceQuota: &v3.ProjectResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "100",
+						},
+						UsedLimit: v3.ResourceQuotaLimit{
+							ConfigMaps: "100",
+						},
+					},
+					NamespaceDefaultResourceQuota: &v3.NamespaceResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "50",
+						},
+					},
+				},
+			},
+			wantAllowed: true,
+		},
+		{
+			name:      "update project with good used quota, to bogus used quota",
+			operation: admissionv1.Update,
+			oldProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+				Spec: v3.ProjectSpec{
+					ClusterName: "testcluster",
+					ResourceQuota: &v3.ProjectResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "100",
+						},
+						UsedLimit: v3.ResourceQuotaLimit{
+							ConfigMaps: "100",
+						},
+					},
+					NamespaceDefaultResourceQuota: &v3.NamespaceResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "50",
+						},
+					},
+				},
+			},
+			newProject: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testcluster",
+				},
+				Spec: v3.ProjectSpec{
+					ClusterName: "testcluster",
+					ResourceQuota: &v3.ProjectResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "100",
+						},
+						UsedLimit: v3.ResourceQuotaLimit{
+							ConfigMaps: "xxxxxxxxxx",
+						},
+					},
+					NamespaceDefaultResourceQuota: &v3.NamespaceResourceQuota{
+						Limit: v3.ResourceQuotaLimit{
+							ConfigMaps: "50",
+						},
+					},
+				},
+			},
+			wantErr:     true,
 			wantAllowed: false,
 		},
 		{


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

https://github.com/rancher/rancher/issues/49041

## Problem

The webhook checked new quotas against old used limit information.
This ignored the possibility that the users may supply bogus used-limit data, for example on project creation.
And further ignored that parts of the system make changes to used-limits.
With bogus used-limit in the project setting this back to good information fails because of the validation failure triggered by the use of the old bad data.

## Solution

The webhook now checks the entire new project state, quotas and used-limit for consistency.

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [x] Test - additional unit tests
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [x] Docs - no change, behaviour was wrong, not matching the docs