### PR TITLE
Fix admin can deactivate itself

### DIFF
--- a/pkg/resources/management.cattle.io/v3/users/validator.go
+++ b/pkg/resources/management.cattle.io/v3/users/validator.go
@@ -100,10 +100,10 @@ func (a *admitter) Admit(request *admission.Request) (*admissionv1.AdmissionResp
 			}
 		}
 
-		oldUserEnabled := ptr.Deref(oldUser.Enabled, false)
-		newUserEnabled := ptr.Deref(newUser.Enabled, false)
+		oldUserEnabled := ptr.Deref(oldUser.Enabled, true)
+		newUserEnabled := ptr.Deref(newUser.Enabled, true)
 
-		if newUser.Username == request.UserInfo.Username && oldUserEnabled && !newUserEnabled {
+		if newUser.Name == request.UserInfo.Username && oldUserEnabled && !newUserEnabled {
 			return admission.ResponseBadRequest("can't deactivate yourself"), nil
 		}
 	}

--- a/pkg/resources/management.cattle.io/v3/users/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/users/validator_test.go
@@ -259,7 +259,13 @@ func Test_Admit(t *testing.T) {
 				Username: defaultUserName,
 				Enabled:  ptr.To(true),
 			},
-			newUser:         defaultUser.DeepCopy(),
+			newUser: &v3.User{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: defaultUserName,
+				},
+				Username: defaultUserName,
+				Enabled:  ptr.To(false),
+			},
 			requestUserName: defaultUserName,
 			allowed:         false,
 		},


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/52199
## Problem
Admin can deactivate itself.

## Solution
- `request.UserInfo.Username` contains the `user.Name` not the `user.Username`, which is not always the same
- `Enabled` defaults to true if not initialized
