### PR TITLE
Ensure operation is update when validating RKEConfig

### DIFF
--- a/pkg/resources/provisioning.cattle.io/v1/cluster/validator.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/validator.go
@@ -114,7 +114,7 @@ func (p *provisioningAdmitter) Admit(request *admission.Request) (*admissionv1.A
 			return response, err
 		}
 
-		if response := p.validateRKEConfigChanged(oldCluster, cluster); !response.Allowed {
+		if response := p.validateRKEConfigChanged(request, oldCluster, cluster); !response.Allowed {
 			return response, nil
 		}
 
@@ -186,11 +186,10 @@ func getEnvVar(name string, envVars []rkev1.EnvVar) *rkev1.EnvVar {
 // validateRKEConfigChanged validates that after creation, the `spec.rkeConfig` cannot be set to a non-nil value if it
 // was nil, and likewise cannot be set to a nil value if it was not. The local cluster is explicitly exempted from
 // setting rkeConfig from nil to not nil, as it is a valid usecase to do so for rancherd in harvester environments.
-func (p *provisioningAdmitter) validateRKEConfigChanged(oldCluster, newCluster *v1.Cluster) *admissionv1.AdmissionResponse {
-	if oldCluster == nil {
+func (p *provisioningAdmitter) validateRKEConfigChanged(request *admission.Request, oldCluster, newCluster *v1.Cluster) *admissionv1.AdmissionResponse {
+	if request.Operation != admissionv1.Update {
 		return admission.ResponseAllowed()
 	}
-
 	if oldCluster.Spec.RKEConfig == nil && newCluster.Spec.RKEConfig != nil && oldCluster.Name != localCluster {
 		return admission.ResponseBadRequest("RKEConfig cannot be changed from null after cluster creation")
 	} else if oldCluster.Spec.RKEConfig != nil && newCluster.Spec.RKEConfig == nil {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> https://github.com/rancher/rancher/issues/52223
<!-- If your PR depends on changes from other PRs, link them here and describe why they are needed for your solution section. -->
## Problem
<!-- Describe the root cause of the issue you are resolving. 
This may include what behavior is observed and why it is not desirable. If this is a new feature, describe why we need it and how it will be used. -->

Forgot zero value for objects isn't `nil` so create operations were triggering rke config validation. 

This is causing https://github.com/rancher/rancher/pull/52351 to fail.

## Solution
<!-- Describe what you changed to fix the issue. 
Relate your changes to the original bug/feature and explain why this addresses the issue. -->

Check `request.Operation` when performing RKEConfig validation.

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [x] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [x] Docs