### PR TITLE
[backport v2.11] webhook tls error and bump dynamiclistener v0.6.4-rc.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/evanphx/json-patch v5.9.11+incompatible
 	github.com/go-ldap/ldap/v3 v3.4.10
 	github.com/gorilla/mux v1.8.1
-	github.com/rancher/dynamiclistener v0.6.2
+	github.com/rancher/dynamiclistener v0.6.4-rc.2
 	github.com/rancher/lasso v0.2.4
 	github.com/rancher/rancher/pkg/apis v0.0.0-20250919133431-8e6245f06426
 	github.com/rancher/rke v1.8.5

--- a/go.sum
+++ b/go.sum
@@ -173,8 +173,8 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/rancher/aks-operator v1.11.6 h1:8MS9FupLEdRa2Edfe7nsk/yGyKr9ETPRrsioE8mmUGI=
 github.com/rancher/aks-operator v1.11.6/go.mod h1:IfhwFivRMaREoGJjO0J6/337iN7Ek4gITuFQeBFx1p0=
-github.com/rancher/dynamiclistener v0.6.2 h1:F0SEJhvO2aFe0eTvKGlQoy5x7HtwK8oJbyITVfBSb90=
-github.com/rancher/dynamiclistener v0.6.2/go.mod h1:ncmVR7qR8kR1o6xNkTcVS2mZ9WtlljimBilIlNjdyzc=
+github.com/rancher/dynamiclistener v0.6.4-rc.2 h1:2ko4gSmSTXnn8Yk8cJWcEGUoYYA0ESR5WmfbfBD/EmI=
+github.com/rancher/dynamiclistener v0.6.4-rc.2/go.mod h1:MqdVm4tlq7jPyd0+PrdVxSROPpvRnlaat65rqtXjCak=
 github.com/rancher/eks-operator v1.11.6 h1:ilGH/H6+YXktg0yHRlAba7rUFn9zN9cGxRNx00ZskDY=
 github.com/rancher/eks-operator v1.11.6/go.mod h1:n+NAS/0MzYHvhoQFLjM9znz4Qa6lU+qSJ71Erw8hb80=
 github.com/rancher/fleet/pkg/apis v0.12.3 h1:GMO3V0AK+V5BmuTMH7EPrL3QcrgFWUItEQCqPj1zNZQ=

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -151,6 +151,7 @@ func listenAndServe(ctx context.Context, clients *clients.Clients, validators []
 			return fmt.Errorf("failed to decode webhook port value '%s': %w", portStr, err)
 		}
 	}
+
 	return server.ListenAndServe(ctx, webhookHTTPSPort, webhookHTTPPort, router, &server.ListenOpts{
 		Secrets:       clients.Core.Secret(),
 		CertNamespace: namespace,
@@ -163,7 +164,8 @@ func listenAndServe(ctx context.Context, clients *clients.Clients, validators []
 			FilterCN:  dynamiclistener.OnlyAllow(tlsName),
 			TLSConfig: tlsConfig,
 		},
-		DisplayServerLogs: true,
+		DisplayServerLogs:       true,
+		IgnoreTLSHandshakeError: true,
 	})
 }
 


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/48484
### Problem
The Rancher webhook can generate a large volume of http: TLS handshake error logs when a client attempts to connect with a missing or invalid certificate. While these are often non-critical, they can overwhelm the logs, making it difficult to debug genuine issues. The current implementation doesn't provide a way to suppress these logs without impacting other important error messages. The community has requested a solution to reduce log noise caused by these specific errors, as detailed in issue #48484.

### Solution
`http: TLS handshake error` messages are downgraded from error to debug level. This means the messages will only appear in the logs if the CATTLE_DEBUG environment variable is set to true

### Test Scenarios
**Scenario 1**:` CATTLE_DEBUG = false`
Result: No TLS handshake error messages are logged. The messages are logged at the debug level but are not displayed because CATTLE_DEBUG is false.

**Scenario 2**: `CATTLE_DEBUG = true`

Result: TLS handshake error messages are logged at the debug level, as expected.

Log Example: level=debug msg="2025/08/21 18:03:25 http: TLS handshake error from 172.31.7.103:40900: EOF"

**How to reproduce and force the error:**
NOTE: The error happens when using rke2, not k3s.

Set the environment variables on rancher-webhook deployment (kubectl -n cattle-system edit deploy rancher-webhook)
CATTLE_DEBUG = "true"/"false"
Login on Rancher UI (or create/delete a new user)
Check the logs from rancher-webhook (kubectl logs -l app=rancher-webhook -n cattle-system)