### PR TITLE
Ensure operation is update when validating RKEConfig

### DIFF
--- a/pkg/resources/provisioning.cattle.io/v1/cluster/validator_test.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/validator_test.go
@@ -2733,3 +2733,155 @@ func Test_validateS3Secret(t *testing.T) {
 		})
 	}
 }
+
+func Test_ValidateRKEConfigChanged(t *testing.T) {
+	tests := []struct {
+		name       string
+		op         admissionv1.Operation
+		oldCluster *v1.Cluster
+		newCluster *v1.Cluster
+		expected   bool
+	}{
+		{
+			name:       "create",
+			op:         admissionv1.Create,
+			oldCluster: &v1.Cluster{},
+			newCluster: &v1.Cluster{},
+			expected:   true,
+		},
+		{
+			name:       "delete",
+			op:         admissionv1.Delete,
+			oldCluster: &v1.Cluster{},
+			newCluster: &v1.Cluster{},
+			expected:   true,
+		},
+		{
+			name:       "no change - nil",
+			op:         admissionv1.Update,
+			oldCluster: &v1.Cluster{},
+			newCluster: &v1.Cluster{},
+			expected:   true,
+		},
+		{
+			name:       "no change - nil - local",
+			op:         admissionv1.Update,
+			oldCluster: &v1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "local"}},
+			newCluster: &v1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "local"}},
+			expected:   true,
+		},
+		{
+			name: "no change - not nil",
+			op:   admissionv1.Update,
+			oldCluster: &v1.Cluster{
+				Spec: v1.ClusterSpec{
+					RKEConfig: &v1.RKEConfig{},
+				},
+			},
+			newCluster: &v1.Cluster{
+				Spec: v1.ClusterSpec{
+					RKEConfig: &v1.RKEConfig{},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "no change - not nil - local",
+			op:   admissionv1.Update,
+			oldCluster: &v1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "local",
+				},
+				Spec: v1.ClusterSpec{
+					RKEConfig: &v1.RKEConfig{},
+				},
+			},
+			newCluster: &v1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "local",
+				},
+				Spec: v1.ClusterSpec{
+					RKEConfig: &v1.RKEConfig{},
+				},
+			},
+			expected: true,
+		},
+		{
+			name:       "change - was nil",
+			op:         admissionv1.Update,
+			oldCluster: &v1.Cluster{},
+			newCluster: &v1.Cluster{
+				Spec: v1.ClusterSpec{
+					RKEConfig: &v1.RKEConfig{},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "change - was nil - local",
+			op:   admissionv1.Update,
+			oldCluster: &v1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "local",
+				},
+			},
+			newCluster: &v1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "local",
+				},
+				Spec: v1.ClusterSpec{
+					RKEConfig: &v1.RKEConfig{},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "change - was not nil",
+			op:   admissionv1.Update,
+			oldCluster: &v1.Cluster{
+				Spec: v1.ClusterSpec{
+					RKEConfig: &v1.RKEConfig{},
+				},
+			},
+			newCluster: &v1.Cluster{},
+			expected:   false,
+		},
+		{
+			name: "change - was not nil - local",
+			op:   admissionv1.Update,
+			oldCluster: &v1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "local",
+				},
+				Spec: v1.ClusterSpec{
+					RKEConfig: &v1.RKEConfig{},
+				},
+			},
+			newCluster: &v1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "local",
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			p := provisioningAdmitter{}
+			req := &admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: tt.op,
+				},
+			}
+			response := p.validateRKEConfigChanged(req, tt.oldCluster, tt.newCluster)
+			if tt.expected {
+				assert.True(t, response.Allowed, "Expected change to be admitted")
+			} else {
+				assert.False(t, response.Allowed, "Expected change not to be admitted")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> https://github.com/rancher/rancher/issues/52096
<!-- If your PR depends on changes from other PRs, link them here and describe why they are needed for your solution section. -->
## Problem
<!-- Describe the root cause of the issue you are resolving. 
This may include what behavior is observed and why it is not desirable. If this is a new feature, describe why we need it and how it will be used. -->
Forgot zero value for objects isn't `nil` so create operations were triggering rke config validation.

This is causing https://github.com/rancher/rancher/pull/52351 to fail.

## Solution
<!-- Describe what you changed to fix the issue. 
Relate your changes to the original bug/feature and explain why this addresses the issue. -->
Check `request.Operation` when performing RKEConfig validation.

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [x] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [x] Docs