### PR TITLE
Add imagePullSecrets support to rancher-webhook.

### DIFF
--- a/charts/rancher-webhook/templates/deployment.yaml
+++ b/charts/rancher-webhook/templates/deployment.yaml
@@ -18,6 +18,10 @@ spec:
         secret:
           secretName: client-ca
       {{- end }}
+{{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 6 }}
+      {{- end }}
       {{- if .Values.global.hostNetwork }}
       hostNetwork: true
       {{- end }}

--- a/charts/rancher-webhook/tests/deployment_test.yaml
+++ b/charts/rancher-webhook/tests/deployment_test.yaml
@@ -3,6 +3,15 @@ templates:
   - deployment.yaml
 
 tests:
+  - it: should render imagePullSecrets when set
+    set:
+      imagePullSecrets:
+        - name: my-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.imagePullSecrets
+          content:
+            name: my-secret
   - it: should set webhook default port values
     asserts:
       - equal:

--- a/charts/rancher-webhook/values.yaml
+++ b/charts/rancher-webhook/values.yaml
@@ -11,6 +11,8 @@ global:
 mcm:
   enabled: true
 
+imagePullSecrets: []
+
 # tolerations for the webhook deployment. See https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ for more info
 tolerations: []
 nodeSelector: {}


### PR DESCRIPTION
## Problem
rancher-webhook does not support imagepullsecrets. When using private registries this can be very annoying as the main rancher chart does support them, but subsequent pulls will fail.

## Solution
Added some yaml templating and tests to add imagepullsecrets. Also added default value.

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [ ] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [ ] Docs