### PR TITLE
Validate PodDisruptionBudget and PriorityClass for fleetAgentDeploymentCustomization

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -544,10 +544,10 @@ When settings are updated, the following additional checks take place:
   annotation `cattle.io/force=true`.
 
 
-- `cluster-agent-default-priority-class` must contain a valid JSON object which matches the format of a `v1.PriorityClassSpec` object. The Value field must be greater than or equal to negative 1 billion and less than or equal to 1 billion. The Preemption field must be a string value set to either `PreemptLowerPriority` or `Never`.
+- `cluster-agent-default-priority-class` and `fleet-agent-default-priority-class` must contain a valid JSON object which matches the format of a `v1.PriorityClassSpec` object. The Value field must be greater than or equal to negative 1 billion and less than or equal to 1 billion. The Preemption field must be a string value set to either `PreemptLowerPriority` or `Never`.
 
 
-- `cluster-agent-default-pod-disruption-budget` must contain a valid JSON object which matches the format of a `v1.PodDisruptionBudgetSpec` object. The `minAvailable` and `maxUnavailable` fields must have a string value that is either a non-negative whole number, or a non-negative whole number percentage value less than or equal to `100%`.
+- `cluster-agent-default-pod-disruption-budget` and `fleet-agent-default-pod-disruption-budget` must contain a valid JSON object which matches the format of a `v1.PodDisruptionBudgetSpec` object. The `minAvailable` and `maxUnavailable` fields must have a string value that is either a non-negative whole number, or a non-negative whole number percentage value less than or equal to `100%`.
 
 ## Token
 
@@ -680,7 +680,7 @@ A `Toleration` is matched to a regex which is provided by upstream [apimachinery
 
 For the `Affinity` based rules, the `podAffinity`/`podAntiAffinity` are validated via label selectors via [this apimachinery function](https://github.com/kubernetes/apimachinery/blob/02a41040d88da08de6765573ae2b1a51f424e1ca/pkg/apis/meta/v1/validation/validation.go#L56) whereas the `nodeAffinity` `nodeSelectorTerms` are validated via the same `Toleration` function.
 
-##### cluster.spec.clusterAgentDeploymentCustomization.schedulingCustomization
+##### cluster.spec.clusterAgentDeploymentCustomization.schedulingCustomization and cluster.spec.fleetAgentDeploymentCustomization.schedulingCustomization
 
 The `SchedulingCustomization` subfield of the `DeploymentCustomization` field defines the properties of a Pod Disruption Budget and Priority Class which will be automatically deployed by Rancher for the cattle-cluster-agent.
 

--- a/pkg/resources/common/common.go
+++ b/pkg/resources/common/common.go
@@ -33,6 +33,20 @@ const (
 // between 0% and 100% so that it can be used in a Pod Disruption Budget
 var PdbPercentageRegex = regexp.MustCompile("^([0-9]|[1-9][0-9]|100)%$")
 
+type AgentType string
+
+const (
+	AgentTypeCluster AgentType = "cluster"
+	AgentTypeFleet   AgentType = "fleet"
+)
+
+var (
+	AllAgentTypes = []AgentType{
+		AgentTypeCluster,
+		AgentTypeFleet,
+	}
+)
+
 // ConvertAuthnExtras converts authnv1 type extras to authzv1 extras. Technically these are both
 // type alias to string, so the conversion is straightforward
 func ConvertAuthnExtras(extra map[string]authnv1.ExtraValue) map[string]authzv1.ExtraValue {

--- a/pkg/resources/management.cattle.io/v3/setting/Setting.md
+++ b/pkg/resources/management.cattle.io/v3/setting/Setting.md
@@ -20,7 +20,7 @@ When settings are updated, the following additional checks take place:
   annotation `cattle.io/force=true`.
 
 
-- `cluster-agent-default-priority-class` must contain a valid JSON object which matches the format of a `v1.PriorityClassSpec` object. The Value field must be greater than or equal to negative 1 billion and less than or equal to 1 billion. The Preemption field must be a string value set to either `PreemptLowerPriority` or `Never`.
+- `cluster-agent-default-priority-class` and `fleet-agent-default-priority-class` must contain a valid JSON object which matches the format of a `v1.PriorityClassSpec` object. The Value field must be greater than or equal to negative 1 billion and less than or equal to 1 billion. The Preemption field must be a string value set to either `PreemptLowerPriority` or `Never`.
 
 
-- `cluster-agent-default-pod-disruption-budget` must contain a valid JSON object which matches the format of a `v1.PodDisruptionBudgetSpec` object. The `minAvailable` and `maxUnavailable` fields must have a string value that is either a non-negative whole number, or a non-negative whole number percentage value less than or equal to `100%`.
+- `cluster-agent-default-pod-disruption-budget` and `fleet-agent-default-pod-disruption-budget` must contain a valid JSON object which matches the format of a `v1.PodDisruptionBudgetSpec` object. The `minAvailable` and `maxUnavailable` fields must have a string value that is either a non-negative whole number, or a non-negative whole number percentage value less than or equal to `100%`.

--- a/pkg/resources/management.cattle.io/v3/setting/validator.go
+++ b/pkg/resources/management.cattle.io/v3/setting/validator.go
@@ -34,6 +34,8 @@ const (
 	AgentTLSMode                          = "agent-tls-mode"
 	CattleClusterAgentPriorityClass       = "cluster-agent-default-priority-class"
 	CattleClusterAgentPodDisruptionBudget = "cluster-agent-default-pod-disruption-budget"
+	FleetAgentPriorityClass               = "fleet-agent-default-priority-class"
+	FleetAgentPodDisruptionBudget         = "fleet-agent-default-pod-disruption-budget"
 )
 
 // MinDeleteInactiveUserAfter is the minimum duration for delete-inactive-user-after setting.
@@ -121,10 +123,10 @@ func (a *admitter) admitUpdate(oldSetting, newSetting *v3.Setting) (*admissionv1
 	switch newSetting.Name {
 	case AgentTLSMode:
 		err = a.validateAgentTLSMode(oldSetting, newSetting)
-	case CattleClusterAgentPriorityClass:
-		err = a.validateClusterAgentPriorityClass(newSetting)
-	case CattleClusterAgentPodDisruptionBudget:
-		err = a.validateClusterAgentPodDisruptionBudget(newSetting)
+	case CattleClusterAgentPriorityClass, FleetAgentPriorityClass:
+		err = a.validateAgentPriorityClass(newSetting)
+	case CattleClusterAgentPodDisruptionBudget, FleetAgentPodDisruptionBudget:
+		err = a.validateAgentPodDisruptionBudget(newSetting)
 	default:
 	}
 
@@ -399,7 +401,7 @@ func (a *admitter) validateAgentTLSMode(oldSetting, newSetting *v3.Setting) erro
 	return nil
 }
 
-func (a *admitter) validateClusterAgentPriorityClass(newSetting *v3.Setting) error {
+func (a *admitter) validateAgentPriorityClass(newSetting *v3.Setting) error {
 	if newSetting.Value == "" {
 		return nil
 	}
@@ -426,7 +428,7 @@ func (a *admitter) validateClusterAgentPriorityClass(newSetting *v3.Setting) err
 	return nil
 }
 
-func (a *admitter) validateClusterAgentPodDisruptionBudget(newSetting *v3.Setting) error {
+func (a *admitter) validateAgentPodDisruptionBudget(newSetting *v3.Setting) error {
 	if newSetting.Value == "" {
 		return nil
 	}

--- a/pkg/resources/management.cattle.io/v3/setting/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/setting/validator_test.go
@@ -431,23 +431,24 @@ func (s *SettingSuite) TestValidateClusterAgentSchedulingPriorityClass() {
 		},
 	}
 
-	for _, test := range tests {
-		test := test
-		s.T().Run(test.name, func(t *testing.T) {
-			t.Parallel()
+	for _, settingName := range []string{setting.CattleClusterAgentPriorityClass, setting.FleetAgentPriorityClass} {
+		for _, test := range tests {
+			s.T().Run(test.name, func(t *testing.T) {
+				t.Parallel()
 
-			validator := setting.NewValidator(nil, nil)
-			s.testAdmit(t, validator, nil, &v3.Setting{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: setting.CattleClusterAgentPriorityClass,
-				},
-				Value: test.newValue,
-			}, v1.Update, test.allowed)
-		})
+				validator := setting.NewValidator(nil, nil)
+				s.testAdmit(t, validator, nil, &v3.Setting{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: settingName,
+					},
+					Value: test.newValue,
+				}, v1.Update, test.allowed)
+			})
+		}
 	}
 }
 
-func (s *SettingSuite) TestValidateClusterAgentSchedulingPodDisruptionBudget() {
+func (s *SettingSuite) TestValidateAgentSchedulingPodDisruptionBudget() {
 	tests := []struct {
 		name     string
 		newValue string
@@ -549,19 +550,20 @@ func (s *SettingSuite) TestValidateClusterAgentSchedulingPodDisruptionBudget() {
 		},
 	}
 
-	for _, test := range tests {
-		test := test
-		s.T().Run(test.name, func(t *testing.T) {
-			t.Parallel()
+	for _, settingName := range []string{setting.CattleClusterAgentPodDisruptionBudget, setting.FleetAgentPodDisruptionBudget} {
+		for _, test := range tests {
+			s.T().Run(test.name, func(t *testing.T) {
+				t.Parallel()
 
-			validator := setting.NewValidator(nil, nil)
-			s.testAdmit(t, validator, nil, &v3.Setting{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: setting.CattleClusterAgentPodDisruptionBudget,
-				},
-				Value: test.newValue,
-			}, v1.Update, test.allowed)
-		})
+				validator := setting.NewValidator(nil, nil)
+				s.testAdmit(t, validator, nil, &v3.Setting{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: settingName,
+					},
+					Value: test.newValue,
+				}, v1.Update, test.allowed)
+			})
+		}
 	}
 }
 

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/Cluster.md
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/Cluster.md
@@ -67,7 +67,7 @@ A `Toleration` is matched to a regex which is provided by upstream [apimachinery
 
 For the `Affinity` based rules, the `podAffinity`/`podAntiAffinity` are validated via label selectors via [this apimachinery function](https://github.com/kubernetes/apimachinery/blob/02a41040d88da08de6765573ae2b1a51f424e1ca/pkg/apis/meta/v1/validation/validation.go#L56) whereas the `nodeAffinity` `nodeSelectorTerms` are validated via the same `Toleration` function.
 
-#### cluster.spec.clusterAgentDeploymentCustomization.schedulingCustomization
+#### cluster.spec.clusterAgentDeploymentCustomization.schedulingCustomization and cluster.spec.fleetAgentDeploymentCustomization.schedulingCustomization
 
 The `SchedulingCustomization` subfield of the `DeploymentCustomization` field defines the properties of a Pod Disruption Budget and Priority Class which will be automatically deployed by Rancher for the cattle-cluster-agent.
 

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/validator_test.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/validator_test.go
@@ -1841,20 +1841,20 @@ func Test_validateAgentSchedulingCustomizationPriorityClass(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		cluster        *v1.Cluster
-		oldCluster     *v1.Cluster
+		oldPC          *v1.PriorityClassSpec
+		pc             *v1.PriorityClassSpec
 		featureEnabled bool
 		shouldSucceed  bool
 	}{
 		{
 			name:           "empty priority class - feature enabled",
-			cluster:        &v1.Cluster{},
+			pc:             nil,
 			shouldSucceed:  true,
 			featureEnabled: true,
 		},
 		{
 			name:           "empty priority class - feature disabled",
-			cluster:        &v1.Cluster{},
+			pc:             nil,
 			shouldSucceed:  true,
 			featureEnabled: true,
 		},
@@ -1862,236 +1862,173 @@ func Test_validateAgentSchedulingCustomizationPriorityClass(t *testing.T) {
 			name:           "valid priority class with default preemption",
 			shouldSucceed:  true,
 			featureEnabled: true,
-			cluster: &v1.Cluster{
-				Spec: v1.ClusterSpec{
-					ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
-						SchedulingCustomization: &v1.AgentSchedulingCustomization{
-							PriorityClass: &v1.PriorityClassSpec{
-								Value: 123456,
-							},
-						},
-					},
-				},
+			pc: &v1.PriorityClassSpec{
+				Value: 123456,
 			},
 		},
 		{
 			name:           "valid priority class with custom preemption",
 			shouldSucceed:  true,
 			featureEnabled: true,
-			cluster: &v1.Cluster{
-				Spec: v1.ClusterSpec{
-					ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
-						SchedulingCustomization: &v1.AgentSchedulingCustomization{
-							PriorityClass: &v1.PriorityClassSpec{
-								Value:            123456,
-								PreemptionPolicy: &preemptionNever,
-							},
-						},
-					},
-				},
+			pc: &v1.PriorityClassSpec{
+				Value:            123456,
+				PreemptionPolicy: &preemptionNever,
 			},
 		},
 		{
 			name:           "invalid priority class - value too large",
 			shouldSucceed:  false,
 			featureEnabled: true,
-			cluster: &v1.Cluster{
-				Spec: v1.ClusterSpec{
-					ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
-						SchedulingCustomization: &v1.AgentSchedulingCustomization{
-							PriorityClass: &v1.PriorityClassSpec{
-								Value: 1234567891234567890,
-							},
-						},
-					},
-				},
+			pc: &v1.PriorityClassSpec{
+				Value: 1234567891234567890,
 			},
 		},
 		{
 			name:           "invalid priority class - value too small",
 			shouldSucceed:  false,
 			featureEnabled: true,
-			cluster: &v1.Cluster{
-				Spec: v1.ClusterSpec{
-					ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
-						SchedulingCustomization: &v1.AgentSchedulingCustomization{
-							PriorityClass: &v1.PriorityClassSpec{
-								Value: -1234567891234567890,
-							},
-						},
-					},
-				},
+			pc: &v1.PriorityClassSpec{
+				Value: -1234567891234567890,
 			},
 		},
 		{
 			name:           "invalid priority class - preemption value invalid",
 			shouldSucceed:  false,
 			featureEnabled: true,
-			cluster: &v1.Cluster{
-				Spec: v1.ClusterSpec{
-					ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
-						SchedulingCustomization: &v1.AgentSchedulingCustomization{
-							PriorityClass: &v1.PriorityClassSpec{
-								Value:            24321,
-								PreemptionPolicy: &preemptionInvalid,
-							},
-						},
-					},
-				},
+			pc: &v1.PriorityClassSpec{
+				Value:            24321,
+				PreemptionPolicy: &preemptionInvalid,
 			},
 		},
 		{
 			name:           "invalid priority class - feature is disabled",
 			shouldSucceed:  false,
 			featureEnabled: false,
-			cluster: &v1.Cluster{
-				Spec: v1.ClusterSpec{
-					ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
-						SchedulingCustomization: &v1.AgentSchedulingCustomization{
-							PriorityClass: &v1.PriorityClassSpec{
-								Value:            24321,
-								PreemptionPolicy: &preemptionInvalid,
-							},
-						},
-					},
-				},
+			pc: &v1.PriorityClassSpec{
+				Value:            24321,
+				PreemptionPolicy: &preemptionInvalid,
 			},
 		},
 		{
 			name:           "invalid update attempt - feature is disabled",
 			shouldSucceed:  false,
 			featureEnabled: false,
-			oldCluster: &v1.Cluster{
-				Spec: v1.ClusterSpec{
-					ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
-						SchedulingCustomization: &v1.AgentSchedulingCustomization{
-							PriorityClass: &v1.PriorityClassSpec{
-								Value: 1234,
-							},
-						},
-					},
-				},
+			oldPC: &v1.PriorityClassSpec{
+				Value: 1234,
 			},
-			cluster: &v1.Cluster{
-				Spec: v1.ClusterSpec{
-					ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
-						SchedulingCustomization: &v1.AgentSchedulingCustomization{
-							PriorityClass: &v1.PriorityClassSpec{
-								Value: 4321,
-							},
-						},
-					},
-				},
+			pc: &v1.PriorityClassSpec{
+				Value: 4321,
 			},
 		},
 		{
 			name:           "valid update attempt - feature is enabled",
 			shouldSucceed:  false,
 			featureEnabled: false,
-			oldCluster: &v1.Cluster{
-				Spec: v1.ClusterSpec{
-					ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
-						SchedulingCustomization: &v1.AgentSchedulingCustomization{
-							PriorityClass: &v1.PriorityClassSpec{
-								Value: 1234,
-							},
-						},
-					},
-				},
+			oldPC: &v1.PriorityClassSpec{
+				Value: 1234,
 			},
-			cluster: &v1.Cluster{
-				Spec: v1.ClusterSpec{
-					ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
-						SchedulingCustomization: &v1.AgentSchedulingCustomization{
-							PriorityClass: &v1.PriorityClassSpec{
-								Value: 4321,
-							},
-						},
-					},
-				},
+			pc: &v1.PriorityClassSpec{
+				Value: 4321,
 			},
 		},
 		{
 			name:           "valid update attempt - feature is disabled, but fields are unchanged",
 			shouldSucceed:  true,
 			featureEnabled: false,
-			oldCluster: &v1.Cluster{
-				Spec: v1.ClusterSpec{
-					ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
-						SchedulingCustomization: &v1.AgentSchedulingCustomization{
-							PriorityClass: &v1.PriorityClassSpec{
-								Value: 1234,
-							},
-						},
-					},
-				},
+			oldPC: &v1.PriorityClassSpec{
+				Value: 1234,
 			},
-			cluster: &v1.Cluster{
-				Spec: v1.ClusterSpec{
-					ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
-						SchedulingCustomization: &v1.AgentSchedulingCustomization{
-							PriorityClass: &v1.PriorityClassSpec{
-								Value: 1234,
-							},
-						},
-					},
-				},
+			pc: &v1.PriorityClassSpec{
+				Value: 1234,
 			},
 		},
 		{
 			name:           "valid update attempt - field is removed while feature is disabled",
 			shouldSucceed:  true,
 			featureEnabled: false,
-			oldCluster: &v1.Cluster{
-				Spec: v1.ClusterSpec{
-					ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
-						SchedulingCustomization: &v1.AgentSchedulingCustomization{
-							PriorityClass: &v1.PriorityClassSpec{
-								Value: 1234,
-							},
-						},
-					},
-				},
+			oldPC: &v1.PriorityClassSpec{
+				Value: 1234,
 			},
-			cluster: &v1.Cluster{
-				Spec: v1.ClusterSpec{},
-			},
+			pc: nil,
 		},
 	}
 
 	t.Parallel()
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			a := provisioningAdmitter{
-				featureCache: createMockFeatureCache(ctrl, common.SchedulingCustomizationFeatureName, tt.featureEnabled),
-			}
+	for _, agentType := range common.AllAgentTypes {
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				a := provisioningAdmitter{
+					featureCache: createMockFeatureCache(ctrl, common.SchedulingCustomizationFeatureName, tt.featureEnabled),
+				}
 
-			response, err := a.validatePriorityClass(tt.oldCluster, tt.cluster)
-			assert.Equal(t, tt.shouldSucceed, response.Allowed)
-			assert.NoError(t, err)
-		})
+				var oldCluster, cluster *v1.Cluster
+				switch agentType {
+				case common.AgentTypeCluster:
+					oldCluster = &v1.Cluster{
+						Spec: v1.ClusterSpec{
+							ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
+								SchedulingCustomization: &v1.AgentSchedulingCustomization{
+									PriorityClass: tt.oldPC,
+								},
+							},
+						},
+					}
+					cluster = &v1.Cluster{
+						Spec: v1.ClusterSpec{
+							ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
+								SchedulingCustomization: &v1.AgentSchedulingCustomization{
+									PriorityClass: tt.pc,
+								},
+							},
+						},
+					}
+				case common.AgentTypeFleet:
+					oldCluster = &v1.Cluster{
+						Spec: v1.ClusterSpec{
+							FleetAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
+								SchedulingCustomization: &v1.AgentSchedulingCustomization{
+									PriorityClass: tt.oldPC,
+								},
+							},
+						},
+					}
+					cluster = &v1.Cluster{
+						Spec: v1.ClusterSpec{
+							FleetAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
+								SchedulingCustomization: &v1.AgentSchedulingCustomization{
+									PriorityClass: tt.pc,
+								},
+							},
+						},
+					}
+				}
+
+				response, err := a.validatePriorityClass(oldCluster, cluster)
+				assert.Equal(t, tt.shouldSucceed, response.Allowed)
+				assert.NoError(t, err)
+			})
+		}
 	}
 }
 
 func Test_validateAgentSchedulingCustomizationPodDisruptionBudget(t *testing.T) {
 	tests := []struct {
 		name           string
-		cluster        *v1.Cluster
-		oldCluster     *v1.Cluster
+		pdb            *v1.PodDisruptionBudgetSpec
+		oldPdb         *v1.PodDisruptionBudgetSpec
 		featureEnabled bool
 		shouldSucceed  bool
 	}{
 		{
 			name:           "no scheduling customization - feature enabled",
-			cluster:        &v1.Cluster{},
+			pdb:            nil,
 			shouldSucceed:  true,
 			featureEnabled: true,
 		},
 		{
 			name:           "no scheduling customization - feature disabled",
-			cluster:        &v1.Cluster{},
+			pdb:            nil,
 			shouldSucceed:  true,
 			featureEnabled: false,
 		},
@@ -2099,364 +2036,230 @@ func Test_validateAgentSchedulingCustomizationPodDisruptionBudget(t *testing.T) 
 			name:           "invalid PDB configuration - negative min available integer",
 			shouldSucceed:  false,
 			featureEnabled: true,
-			cluster: &v1.Cluster{
-				Spec: v1.ClusterSpec{
-					ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
-						SchedulingCustomization: &v1.AgentSchedulingCustomization{
-							PodDisruptionBudget: &v1.PodDisruptionBudgetSpec{
-								MinAvailable: "-1",
-							},
-						},
-					},
-				},
+			pdb: &v1.PodDisruptionBudgetSpec{
+				MinAvailable: "-1",
 			},
 		},
 		{
 			name:           "invalid PDB configuration - negative max unavailable integer",
 			shouldSucceed:  false,
 			featureEnabled: true,
-			cluster: &v1.Cluster{
-				Spec: v1.ClusterSpec{
-					ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
-						SchedulingCustomization: &v1.AgentSchedulingCustomization{
-							PodDisruptionBudget: &v1.PodDisruptionBudgetSpec{
-								MaxUnavailable: "-1",
-							},
-						},
-					},
-				},
+			pdb: &v1.PodDisruptionBudgetSpec{
+				MaxUnavailable: "-1",
 			},
 		},
 		{
 			name:           "invalid PDB configuration - both fields set",
 			shouldSucceed:  false,
 			featureEnabled: true,
-			cluster: &v1.Cluster{
-				Spec: v1.ClusterSpec{
-					ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
-						SchedulingCustomization: &v1.AgentSchedulingCustomization{
-							PodDisruptionBudget: &v1.PodDisruptionBudgetSpec{
-								MaxUnavailable: "1",
-								MinAvailable:   "1",
-							},
-						},
-					},
-				},
+			pdb: &v1.PodDisruptionBudgetSpec{
+				MaxUnavailable: "1",
+				MinAvailable:   "1",
 			},
 		},
 		{
 			name:           "invalid PDB configuration - string passed to max unavailable",
 			shouldSucceed:  false,
 			featureEnabled: true,
-			cluster: &v1.Cluster{
-				Spec: v1.ClusterSpec{
-					ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
-						SchedulingCustomization: &v1.AgentSchedulingCustomization{
-							PodDisruptionBudget: &v1.PodDisruptionBudgetSpec{
-								MaxUnavailable: "five",
-							},
-						},
-					},
-				},
+			pdb: &v1.PodDisruptionBudgetSpec{
+				MaxUnavailable: "five",
 			},
 		},
 		{
 			name:           "invalid PDB configuration - string passed to min available",
 			shouldSucceed:  false,
 			featureEnabled: true,
-			cluster: &v1.Cluster{
-				Spec: v1.ClusterSpec{
-					ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
-						SchedulingCustomization: &v1.AgentSchedulingCustomization{
-							PodDisruptionBudget: &v1.PodDisruptionBudgetSpec{
-								MinAvailable: "five",
-							},
-						},
-					},
-				},
+			pdb: &v1.PodDisruptionBudgetSpec{
+				MinAvailable: "five",
 			},
 		},
 		{
 			name:           "invalid PDB configuration - string with invalid percentage number set for min available",
 			shouldSucceed:  false,
 			featureEnabled: true,
-			cluster: &v1.Cluster{
-				Spec: v1.ClusterSpec{
-					ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
-						SchedulingCustomization: &v1.AgentSchedulingCustomization{
-							PodDisruptionBudget: &v1.PodDisruptionBudgetSpec{
-								MinAvailable: "5.5%",
-							},
-						},
-					},
-				},
+			pdb: &v1.PodDisruptionBudgetSpec{
+				MinAvailable: "5.5%",
 			},
 		},
 		{
 			name:           "invalid PDB configuration - string with invalid percentage number set for max unavailable",
 			shouldSucceed:  false,
 			featureEnabled: true,
-			cluster: &v1.Cluster{
-				Spec: v1.ClusterSpec{
-					ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
-						SchedulingCustomization: &v1.AgentSchedulingCustomization{
-							PodDisruptionBudget: &v1.PodDisruptionBudgetSpec{
-								MaxUnavailable: "5.5%",
-							},
-						},
-					},
-				},
+			pdb: &v1.PodDisruptionBudgetSpec{
+				MaxUnavailable: "5.5%",
 			},
 		},
 		{
 			name:           "invalid PDB configuration - both set to zero",
 			shouldSucceed:  false,
 			featureEnabled: true,
-			cluster: &v1.Cluster{
-				Spec: v1.ClusterSpec{
-					ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
-						SchedulingCustomization: &v1.AgentSchedulingCustomization{
-							PodDisruptionBudget: &v1.PodDisruptionBudgetSpec{
-								MinAvailable:   "0",
-								MaxUnavailable: "0",
-							},
-						},
-					},
-				},
+			pdb: &v1.PodDisruptionBudgetSpec{
+				MinAvailable:   "0",
+				MaxUnavailable: "0",
 			},
 		},
 		{
 			name:           "valid PDB configuration - max unavailable set to integer",
 			shouldSucceed:  true,
 			featureEnabled: true,
-			cluster: &v1.Cluster{
-				Spec: v1.ClusterSpec{
-					ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
-						SchedulingCustomization: &v1.AgentSchedulingCustomization{
-							PodDisruptionBudget: &v1.PodDisruptionBudgetSpec{
-								MaxUnavailable: "1",
-							},
-						},
-					},
-				},
+			pdb: &v1.PodDisruptionBudgetSpec{
+				MaxUnavailable: "1",
 			},
 		},
 		{
 			name:           "valid PDB configuration - min available set to integer",
 			shouldSucceed:  true,
 			featureEnabled: true,
-			cluster: &v1.Cluster{
-				Spec: v1.ClusterSpec{
-					ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
-						SchedulingCustomization: &v1.AgentSchedulingCustomization{
-							PodDisruptionBudget: &v1.PodDisruptionBudgetSpec{
-								MinAvailable: "1",
-							},
-						},
-					},
-				},
+			pdb: &v1.PodDisruptionBudgetSpec{
+				MinAvailable: "1",
 			},
 		},
 		{
 			name:           "valid PDB configuration - min available set to integer",
 			shouldSucceed:  true,
 			featureEnabled: true,
-			cluster: &v1.Cluster{
-				Spec: v1.ClusterSpec{
-					ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
-						SchedulingCustomization: &v1.AgentSchedulingCustomization{
-							PodDisruptionBudget: &v1.PodDisruptionBudgetSpec{
-								MinAvailable:   "1",
-								MaxUnavailable: "0",
-							},
-						},
-					},
-				},
+			pdb: &v1.PodDisruptionBudgetSpec{
+				MinAvailable:   "1",
+				MaxUnavailable: "0",
 			},
 		},
 		{
 			name:           "valid PDB configuration - max unavailable set to integer",
 			shouldSucceed:  true,
 			featureEnabled: true,
-			cluster: &v1.Cluster{
-				Spec: v1.ClusterSpec{
-					ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
-						SchedulingCustomization: &v1.AgentSchedulingCustomization{
-							PodDisruptionBudget: &v1.PodDisruptionBudgetSpec{
-								MinAvailable:   "0",
-								MaxUnavailable: "1",
-							},
-						},
-					},
-				},
+			pdb: &v1.PodDisruptionBudgetSpec{
+				MinAvailable:   "0",
+				MaxUnavailable: "1",
 			},
 		},
 		{
 			name:           "valid PDB configuration - max unavailable set to percentage",
 			shouldSucceed:  true,
 			featureEnabled: true,
-			cluster: &v1.Cluster{
-				Spec: v1.ClusterSpec{
-					ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
-						SchedulingCustomization: &v1.AgentSchedulingCustomization{
-							PodDisruptionBudget: &v1.PodDisruptionBudgetSpec{
-								MaxUnavailable: "50%",
-							},
-						},
-					},
-				},
+			pdb: &v1.PodDisruptionBudgetSpec{
+				MaxUnavailable: "50%",
 			},
 		},
 		{
 			name:           "valid PDB configuration - min available set to percentage",
 			shouldSucceed:  true,
 			featureEnabled: true,
-			cluster: &v1.Cluster{
-				Spec: v1.ClusterSpec{
-					ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
-						SchedulingCustomization: &v1.AgentSchedulingCustomization{
-							PodDisruptionBudget: &v1.PodDisruptionBudgetSpec{
-								MinAvailable: "50%",
-							},
-						},
-					},
-				},
+			pdb: &v1.PodDisruptionBudgetSpec{
+				MinAvailable: "50%",
 			},
 		},
 		{
 			name:           "valid PDB configuration - updating from percentage to int",
 			shouldSucceed:  true,
 			featureEnabled: true,
-			oldCluster: &v1.Cluster{
-				Spec: v1.ClusterSpec{
-					ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
-						SchedulingCustomization: &v1.AgentSchedulingCustomization{
-							PodDisruptionBudget: &v1.PodDisruptionBudgetSpec{
-								MinAvailable: "50%",
-							},
-						},
-					},
-				},
+			oldPdb: &v1.PodDisruptionBudgetSpec{
+				MinAvailable: "50%",
 			},
-			cluster: &v1.Cluster{
-				Spec: v1.ClusterSpec{
-					ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
-						SchedulingCustomization: &v1.AgentSchedulingCustomization{
-							PodDisruptionBudget: &v1.PodDisruptionBudgetSpec{
-								MinAvailable: "1",
-							},
-						},
-					},
-				},
+			pdb: &v1.PodDisruptionBudgetSpec{
+				MinAvailable: "1",
 			},
 		},
 		{
 			name:           "invalid PDB reconfiguration - feature is disabled",
 			shouldSucceed:  false,
 			featureEnabled: false,
-			oldCluster: &v1.Cluster{
-				Spec: v1.ClusterSpec{
-					ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
-						SchedulingCustomization: &v1.AgentSchedulingCustomization{
-							PodDisruptionBudget: &v1.PodDisruptionBudgetSpec{
-								MinAvailable: "50%",
-							},
-						},
-					},
-				},
+			oldPdb: &v1.PodDisruptionBudgetSpec{
+				MinAvailable: "50%",
 			},
-			cluster: &v1.Cluster{
-				Spec: v1.ClusterSpec{
-					ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
-						SchedulingCustomization: &v1.AgentSchedulingCustomization{
-							PodDisruptionBudget: &v1.PodDisruptionBudgetSpec{
-								MinAvailable: "1",
-							},
-						},
-					},
-				},
+			pdb: &v1.PodDisruptionBudgetSpec{
+				MinAvailable: "1",
 			},
 		},
 		{
 			name:           "invalid PDB creation - feature is disabled",
 			shouldSucceed:  false,
 			featureEnabled: false,
-			oldCluster: &v1.Cluster{
-				Spec: v1.ClusterSpec{},
-			},
-			cluster: &v1.Cluster{
-				Spec: v1.ClusterSpec{
-					ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
-						SchedulingCustomization: &v1.AgentSchedulingCustomization{
-							PodDisruptionBudget: &v1.PodDisruptionBudgetSpec{
-								MinAvailable: "1",
-							},
-						},
-					},
-				},
+			oldPdb:         nil,
+			pdb: &v1.PodDisruptionBudgetSpec{
+				MinAvailable: "1",
 			},
 		},
 		{
 			name:           "valid PDB reconfiguration - field is removed while feature is disabled",
 			shouldSucceed:  true,
 			featureEnabled: false,
-			oldCluster: &v1.Cluster{
-				Spec: v1.ClusterSpec{
-					ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
-						SchedulingCustomization: &v1.AgentSchedulingCustomization{
-							PodDisruptionBudget: &v1.PodDisruptionBudgetSpec{
-								MinAvailable: "50%",
-							},
-						},
-					},
-				},
+			oldPdb: &v1.PodDisruptionBudgetSpec{
+				MinAvailable: "50%",
 			},
-			cluster: &v1.Cluster{
-				Spec: v1.ClusterSpec{},
-			},
+			pdb: nil,
 		},
 		{
 			name:           "valid update - field is unchanged while feature is disabled",
 			shouldSucceed:  true,
 			featureEnabled: false,
-			oldCluster: &v1.Cluster{
-				Spec: v1.ClusterSpec{
-					ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
-						SchedulingCustomization: &v1.AgentSchedulingCustomization{
-							PodDisruptionBudget: &v1.PodDisruptionBudgetSpec{
-								MinAvailable: "50%",
-							},
-						},
-					},
-				},
+			oldPdb: &v1.PodDisruptionBudgetSpec{
+				MinAvailable: "50%",
 			},
-			cluster: &v1.Cluster{
-				Spec: v1.ClusterSpec{
-					ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
-						SchedulingCustomization: &v1.AgentSchedulingCustomization{
-							PodDisruptionBudget: &v1.PodDisruptionBudgetSpec{
-								MinAvailable: "50%",
-							},
-						},
-					},
-				},
+			pdb: &v1.PodDisruptionBudgetSpec{
+				MinAvailable: "50%",
 			},
 		},
 	}
 
 	t.Parallel()
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			a := provisioningAdmitter{
-				featureCache: createMockFeatureCache(ctrl, common.SchedulingCustomizationFeatureName, tt.featureEnabled),
-			}
+	for _, agentType := range common.AllAgentTypes {
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				a := provisioningAdmitter{
+					featureCache: createMockFeatureCache(ctrl, common.SchedulingCustomizationFeatureName, tt.featureEnabled),
+				}
 
-			response, err := a.validatePodDisruptionBudget(tt.oldCluster, tt.cluster)
-			assert.Equal(t, tt.shouldSucceed, response.Allowed)
-			assert.NoError(t, err)
-		})
+				var (
+					oldCluster, cluster *v1.Cluster
+				)
+
+				switch agentType {
+				case common.AgentTypeCluster:
+					oldCluster = &v1.Cluster{
+						Spec: v1.ClusterSpec{
+							ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
+								SchedulingCustomization: &v1.AgentSchedulingCustomization{
+									PodDisruptionBudget: tt.oldPdb,
+								},
+							},
+						},
+					}
+					cluster = &v1.Cluster{
+						Spec: v1.ClusterSpec{
+							ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
+								SchedulingCustomization: &v1.AgentSchedulingCustomization{
+									PodDisruptionBudget: tt.pdb,
+								},
+							},
+						},
+					}
+				case common.AgentTypeFleet:
+					oldCluster = &v1.Cluster{
+						Spec: v1.ClusterSpec{
+							FleetAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
+								SchedulingCustomization: &v1.AgentSchedulingCustomization{
+									PodDisruptionBudget: tt.oldPdb,
+								},
+							},
+						},
+					}
+					cluster = &v1.Cluster{
+						Spec: v1.ClusterSpec{
+							FleetAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
+								SchedulingCustomization: &v1.AgentSchedulingCustomization{
+									PodDisruptionBudget: tt.pdb,
+								},
+							},
+						},
+					}
+				}
+
+				response, err := a.validatePodDisruptionBudget(oldCluster, cluster)
+				assert.Equal(t, tt.shouldSucceed, response.Allowed)
+				assert.NoError(t, err)
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/52535 and https://github.com/rancher/rancher/issues/52437

<!-- If your PR depends on changes from other PRs, link them here and describe why they are needed for your solution section. -->

## Problem

A new feature is being introduced to Rancher which allows users to define a Pod Disruption Budget and Priority Class on the v1.Cluster and v3.Cluster objects to better ensure HA of the fleet agent. In order to prevent use of the new fields added to the cluster objects when the feature is disabled, as well as to prevent incorrect configuration of the PC and PDB, additional validation needs to be added to the webhook.

https://github.com/rancher/webhook/pull/702 implemented the same checks for the cattle cluster agent.


## Solution

Add additional logic to the validators for the v1.Cluster, v3.Cluster, and settings resources.


## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [x] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [x] Docs