### PR TITLE
chore: bump go to 1.25.5

### DIFF
--- a/.golangci.json
+++ b/.golangci.json
@@ -1,27 +1,56 @@
 {
-	"linters": {
-		"disable-all": true,
-		"enable": [
-			"govet",
-			"revive",
-			"goimports",
-			"misspell",
-			"ineffassign",
-			"gofmt"
-		]
-	},
-	"run": {
-            "timeout": "10m"
-	},
-	"issues": {
-		"exclude-rules": [
-			{
-				"linters": ["revive"],
-				"text": "should have comment or be unexported"
-			}
-		],
-		"exclude-dirs": [
-			"pkg/generated"
-		]
-	}
+  "formatters": {
+    "enable": [
+      "gofmt",
+      "goimports"
+    ],
+    "exclusions": {
+      "generated": "lax",
+      "paths": [
+        "pkg/generated",
+        "third_party$",
+        "builtin$",
+        "examples$"
+      ]
+    }
+  },
+  "linters": {
+    "default": "none",
+    "enable": [
+      "govet",
+      "ineffassign",
+      "misspell",
+      "revive"
+    ],
+    "exclusions": {
+      "generated": "lax",
+      "paths": [
+        "pkg/generated",
+        "third_party$",
+        "builtin$",
+        "examples$"
+      ],
+      "presets": [
+        "comments",
+        "common-false-positives",
+        "legacy",
+        "std-error-handling"
+      ],
+      "rules": [
+        {
+          "linters": [
+            "revive"
+          ],
+          "text": "should have comment or be unexported"
+        },
+        {
+          "linters": [
+            "revive"
+          ],
+          "text": "avoid meaningless package names"
+        }
+      ]
+    }
+  },
+  "version": "2"
 }

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/rancher/webhook
 
-go 1.24.0
+go 1.25.0
 
-toolchain go1.24.2
+toolchain go1.25.5
 
 replace (
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.34.1

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,7 +1,7 @@
 # ===============
 # Build Stage
 # ===============
-FROM --platform=$BUILDPLATFORM registry.suse.com/bci/golang:1.24 AS build
+FROM --platform=$BUILDPLATFORM registry.suse.com/bci/golang:1.25 AS build
 
 # Set up build cache
 ENV GOMODCACHE=/root/.cache/go/modcache
@@ -49,7 +49,7 @@ RUN cat coverage.out | awk 'BEGIN {cov=0; stat=0;} $3!="" { cov+=($3==1?$2:0); s
 # Validate Stage
 # ===============
 FROM build AS validate
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin v1.64.8
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin v2.7.1
 COPY . .
 RUN --mount=type=cache,target=/root/.cache,id=rancher golangci-lint run
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from other PRs, link them here and describe why they are needed for your solution section. -->
## Problem
<!-- Describe the root cause of the issue you are resolving. 
This may include what behavior is observed and why it is not desirable. If this is a new feature, describe why we need it and how it will be used. -->

Go was bumped to 1.25 for rancher/rancher main and #1191 requires updating rancher/rancher/pkg/apis.
The latest stable BCI image contains Go 1.25.5.

```sh
docker inspect registry.suse.com/bci/golang:1.25 | grep GOLANG_VERSION
                "GOLANG_VERSION=1.25.5",
```

## Solution
<!-- Describe what you changed to fix the issue. 
Relate your changes to the original bug/feature and explain why this addresses the issue. -->

- Bump Go to v1.25.5.
- Bump golangci-lint to version compatible with Go 1.25
- Migrate golangci config file to v2 format

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [ ] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [ ] Docs