### PR TITLE
fix: skip snapshot fetching for local snapshot restore

### DIFF
--- a/pkg/resources/provisioning.cattle.io/v1/cluster/validator_test.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/validator_test.go
@@ -3112,14 +3112,10 @@ func TestValidateETCDSnapshotRestore(t *testing.T) {
 			expectedDenyMsg: fmt.Sprintf("invalid ETCD snapshot metadata for %s/%s", testNamespace, invalidMetadataSnapshotName),
 		},
 		{
-			name:       "should allow restore mode 'none' even with invalid metadata",
-			request:    baseRequest(),
-			oldCluster: baseCluster(),
-			newCluster: withRestore(baseCluster(), "none", invalidMetadataSnapshotName),
-			mockSetup: func(mockCache *fake.MockCacheInterface[*rkev1.ETCDSnapshot]) {
-				mockCache.EXPECT().Get(testNamespace, invalidMetadataSnapshotName).
-					Return(invalidMetadataSnapshot, nil)
-			},
+			name:          "should allow restore mode 'none' without fetching snapshot",
+			request:       baseRequest(),
+			oldCluster:    baseCluster(),
+			newCluster:    withRestore(baseCluster(), "none", invalidMetadataSnapshotName),
 			expectAllowed: true,
 		},
 		{


### PR DESCRIPTION
## Issue: [https://github.com/rancher/rancher/issues/52574](https://github.com/rancher/rancher/issues/52574)

## Problem

The webhook validates `spec.rkeConfig.etcdSnapshotRestore` by resolving the referenced `ETCDSnapshot` object and using its metadata to enforce allowed restore modes.

This breaks the Rancher provisioning test `Test_Operation_SetB_Custom_EtcdSnapshotOperationsOnNewCombinedNode` in `rancher/rancher`. That test restores a cluster on a **new controlplane+etcd node** using a **local snapshot file**. In this workflow, the restore can be triggered using only the snapshot file name, and there may be **no corresponding `ETCDSnapshot` CR** that the webhook can resolve at admission time.

As a result, the webhook denies a valid "restore from file" request because snapshot metadata is not available.

## Solution

Skip snapshot-metadata validation when `RestoreRKEConfig == "none"`.

Reasoning:

* The webhook lookup is needed only to validate restore modes that **depend on snapshot metadata**.
* When `RestoreRKEConfig` is `"none"`, the restore does **not** attempt to restore Kubernetes version or cluster configuration. It is effectively a "data-only" restore and does not require any snapshot metadata to validate restore-mode options.
* Because of that, rejecting `"none"` restores due to a missing `ETCDSnapshot` CR is overly strict and breaks the file-based restore workflow. Allowing only this case keeps backward compatibility without weakening the validation for the modes that actually need metadata.

Implementation notes:

* Add an early allow-return when `newRestore.RestoreRKEConfig == "none"`.
* Keep the current strict validation for other restore modes (`kubernetesVersion` and `all`), including the requirement to resolve the `ETCDSnapshot` object.

## Testing

## Engineering Testing

### Manual Testing

* **Baseline (without this PR)**

  * Ran `Test_Operation_SetB_Custom_EtcdSnapshotOperationsOnNewCombinedNode`.
  * **Observed (bug):** webhook denies the restore request because it cannot resolve an `ETCDSnapshot` object for the restore name.
  * `etcdsnapshot.go:270: admission webhook \"rancher.cattle.io.clusters.provisioning.cattle.io\" denied the request: etcd restore references missing snapshot on-demand-control-etcd-test-node-1768264577 in namespace test-ns-64g8t`

* **With this PR**

  * Re-ran the same test.
  * **Observed (fixed):** restore with `RestoreRKEConfig == "none"` is allowed even when there is no `ETCDSnapshot` CR to resolve, and the test completes successfully.

### Automated Testing

* **Provisioning**

  * Verified the Rancher provisioning test above passes when restoring from a local snapshot file.

* **Unit/Validation**

  * Updated unit coverage for `validateETCDSnapshotRestore` to ensure:

    * `RestoreRKEConfig == "none"` is allowed even when the referenced `ETCDSnapshot` is not found, and `ETCDSnapshot` cache fetch is not even called.
    
## QA Testing Considerations

1. **Restore from local snapshot file (file-based restore)**

   * Create a cluster, take a snapshot, replace the etcd node, and restore from a local snapshot file using:

     * `RestoreRKEConfig: none`
   * **Expect:** webhook allows the request and the restore proceeds.

2. **Restore modes that depend on snapshot metadata**

   * Attempt restores using `RestoreRKEConfig: kubernetesVersion` and `RestoreRKEConfig: all`.
   * **Expect:** webhook continues to enforce restore-mode restrictions using snapshot metadata, and rejects invalid combinations.

3. **Snapshot CR present vs absent**

   * Run restores where an `ETCDSnapshot` CR exists and where it does not.
   * **Expect:** `"none"` mode is allowed in both cases; other modes remain strict and require the snapshot metadata to be available.