### PR TITLE
[main] Add webhook configuration support to rancher-webhook chart

### DIFF
--- a/charts/rancher-webhook/templates/deployment.yaml
+++ b/charts/rancher-webhook/templates/deployment.yaml
@@ -4,6 +4,7 @@ kind: Deployment
 metadata:
   name: rancher-webhook
 spec:
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       app: rancher-webhook
@@ -49,6 +50,10 @@ spec:
         image: '{{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}'
         name: rancher-webhook
         imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"
+        {{- with .Values.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         ports:
         - name: https
           containerPort: {{ .Values.port | default 9443 }}
@@ -84,3 +89,7 @@ spec:
       priorityClassName: "{{.Values.priorityClassName}}"
       {{- end }}
       {{- include "rancher-webhook.imagePullSecrets" . | nindent 6 }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/rancher-webhook/templates/pdb.yaml
+++ b/charts/rancher-webhook/templates/pdb.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.podDisruptionBudget .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: rancher-webhook
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: rancher-webhook
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- else if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+{{- end }}

--- a/charts/rancher-webhook/tests/deployment_test.yaml
+++ b/charts/rancher-webhook/tests/deployment_test.yaml
@@ -123,3 +123,68 @@ tests:
           path: spec.template.spec.imagePullSecrets
           content:
             name: another-secret
+
+  - it: should default to 1 replica
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 1
+
+  - it: should set replica count when replicaCount is specified
+    set:
+      replicaCount: 3
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3
+
+  - it: should set default podAntiAffinity
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.affinity.podAntiAffinity
+      - isNotNull:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution
+
+  - it: should allow overriding affinity
+    values:
+      - ./fixtures/affinity-override.yaml
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution
+      - isNull:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution
+
+  - it: should allow disabling affinity by setting it to null
+    values:
+      - ./fixtures/affinity-disabled.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.affinity
+
+  - it: should not set resources by default
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].resources
+
+  - it: should set resources when specified
+    set:
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 500m
+          memory: 256Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 100m
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 128Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 500m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 256Mi

--- a/charts/rancher-webhook/tests/fixtures/affinity-disabled.yaml
+++ b/charts/rancher-webhook/tests/fixtures/affinity-disabled.yaml
@@ -1,0 +1,1 @@
+affinity: ~

--- a/charts/rancher-webhook/tests/fixtures/affinity-override.yaml
+++ b/charts/rancher-webhook/tests/fixtures/affinity-override.yaml
@@ -1,0 +1,8 @@
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution: ~
+    requiredDuringSchedulingIgnoredDuringExecution:
+    - labelSelector:
+        matchLabels:
+          app: rancher-webhook
+      topologyKey: kubernetes.io/hostname

--- a/charts/rancher-webhook/tests/pdb_test.yaml
+++ b/charts/rancher-webhook/tests/pdb_test.yaml
@@ -1,0 +1,57 @@
+suite: Test PodDisruptionBudget
+templates:
+  - pdb.yaml
+
+tests:
+  - it: should not render a PDB by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render a PDB when podDisruptionBudget.enabled is true
+    set:
+      podDisruptionBudget.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: metadata.name
+          value: rancher-webhook
+      - equal:
+          path: spec.selector.matchLabels.app
+          value: rancher-webhook
+
+  - it: should use minAvailable by default when PDB is enabled
+    set:
+      podDisruptionBudget.enabled: true
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - notExists:
+          path: spec.maxUnavailable
+
+  - it: should use a custom minAvailable value
+    set:
+      podDisruptionBudget.enabled: true
+      podDisruptionBudget.minAvailable: 2
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 2
+      - notExists:
+          path: spec.maxUnavailable
+
+  - it: should use maxUnavailable when minAvailable is unset
+    set:
+      podDisruptionBudget.enabled: true
+      podDisruptionBudget.minAvailable: 0
+      podDisruptionBudget.maxUnavailable: 1
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+      - notExists:
+          path: spec.minAvailable

--- a/charts/rancher-webhook/values.yaml
+++ b/charts/rancher-webhook/values.yaml
@@ -29,3 +29,39 @@ auth:
   clientCA: ""
   # Allowlist of CNs for kube-apiserver client certs. If empty, any cert signed by the CA provided in clientCA will be accepted.
   allowedCNs: []
+
+# replicaCount sets the number of webhook pod replicas. The webhook supports multi-replica operation
+# via leader election (for webhook config management) and shared TLS certificates, so increasing
+# this value improves availability without requiring additional configuration.
+replicaCount: 1
+
+# resources sets CPU/memory requests and limits for the webhook container.
+resources: {}
+#  limits:
+#    cpu: 500m
+#    memory: 128Mi
+#  requests:
+#    cpu: 250m
+#    memory: 64Mi
+
+# affinity rules for the webhook deployment. Defaults to a preferred podAntiAffinity that
+# encourages the scheduler to place replicas on different nodes. Set to null (~) to disable.
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - weight: 100
+      podAffinityTerm:
+        labelSelector:
+          matchExpressions:
+          - key: app
+            operator: In
+            values:
+            - rancher-webhook
+        topologyKey: kubernetes.io/hostname
+
+# podDisruptionBudget configures a PodDisruptionBudget to limit voluntary disruptions.
+# Recommended when replicaCount > 1 to prevent all replicas from being evicted simultaneously.
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+  # maxUnavailable: 1  # alternative to minAvailable; only one of the two should be set


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/54090

## Problem

The rancher-webhook Helm chart does not support configuring replica count, tolerations, affinity, resource requirements, or pod disruption budgets. These must be set for the webhook to run in an HA or topology-aware configuration.

## Solution

Update the rancher-webhook chart to template all `WebhookDeploymentCustomization` fields:

- `replicaCount` — controls pod replicas (default 1)
- `tolerations` / `nodeSelector` — scheduling constraints
- `affinity` — default preferred pod anti-affinity spreads replicas across nodes
- `resources` — CPU/memory requests and limits
- `podDisruptionBudget` — optional PDB with minAvailable/maxUnavailable (disabled by default)

Values are supplied by Rancher via the systemcharts controller (local) or a downstream ConfigMap (see rancher/rancher#54335 also see this PR for testing notes when they are available).