### PR TITLE
fix: Prevent duplicate ProjectRoleTemplateBinding creation

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -495,6 +495,48 @@ changed:
 
 In addition, as in the create validation, both a user subject and a group subject cannot be specified.
 
+#### Duplicate ProjectRoleTemplateBinding Prevention
+
+On creation, the webhook prevents the creation of a `ProjectRoleTemplateBinding` if another one already exists with the same subject and role in the same project.
+This ensures that a user or group is not granted the same project-level role multiple times.
+
+A binding is considered a duplicate if another non-deleting `ProjectRoleTemplateBinding` exists in the same namespace with the exact same values for:
+- `roleTemplateName`
+- The subject, which is determined by one of the following fields:
+  - `userName`
+  - `userPrincipalName`
+  - `groupName`
+  - `groupPrincipalName`
+
+If a conflicting binding exists but is already marked for deletion (has a non-nil `DeletionTimestamp`), it is ignored, allowing the creation to proceed.
+
+### Mutation Checks
+
+#### On create
+
+When a `ProjectRoleTemplateBinding` is created using the `generateName` pattern (i.e. `metadata.name` is empty), the webhook replaces the server-generated random name with a deterministic `metadata.name` based on a hash of the binding's content.
+
+When the client sets an explicit `metadata.name`, the mutator does nothing. This preserves backward compatibility for public API consumers and customer automations that depend on specific resource names. The validating webhook's [duplicate check](#duplicate-projectroletemplatebinding-prevention) provides additional protection against duplicate bindings created with different explicit names.
+
+The deterministic name is computed as:
+
+```
+prefix + lowercase(base32(sha256(subject + "/" + roleTemplateName + "/" + projectName))[:10])
+```
+
+The prefix is taken from `metadata.generateName` if set, otherwise defaults to `prtb-`.
+
+The subject is resolved using the following priority order:
+1. `UserPrincipalName`
+2. `UserName`
+3. `GroupPrincipalName`
+4. `GroupName`
+5. `ServiceAccount`
+
+If no subject is set, the mutator passes the request through without modification (the validating webhook will reject it).
+
+This ensures that two identical concurrent requests produce the same resource name. The Kubernetes API server will reject the second request with a `409 Conflict`, preventing duplicate bindings even when requests race past the validating webhook.
+
 ## RoleTemplate
 
 ### Validation Checks

--- a/pkg/resources/management.cattle.io/v3/projectroletemplatebinding/ProjectRoleTemplateBinding.md
+++ b/pkg/resources/management.cattle.io/v3/projectroletemplatebinding/ProjectRoleTemplateBinding.md
@@ -41,3 +41,46 @@ changed:
 - GroupPrincipalName
 
 In addition, as in the create validation, both a user subject and a group subject cannot be specified.
+
+### Duplicate ProjectRoleTemplateBinding Prevention
+
+On creation, the webhook prevents the creation of a `ProjectRoleTemplateBinding` if another one already exists with the same subject and role in the same project.
+This ensures that a user or group is not granted the same project-level role multiple times.
+
+A binding is considered a duplicate if another non-deleting `ProjectRoleTemplateBinding` exists in the same namespace with the exact same values for:
+- `roleTemplateName`
+- The subject, which is determined by one of the following fields:
+  - `userName`
+  - `userPrincipalName`
+  - `groupName`
+  - `groupPrincipalName`
+
+If a conflicting binding exists but is already marked for deletion (has a non-nil `DeletionTimestamp`), it is ignored, allowing the creation to proceed.
+
+## Mutation Checks
+
+### On create
+
+When a `ProjectRoleTemplateBinding` is created using the `generateName` pattern (i.e. `metadata.name` is empty), the webhook replaces the server-generated random name with a deterministic `metadata.name` based on a hash of the binding's content.
+
+When the client sets an explicit `metadata.name`, the mutator does nothing. This preserves backward compatibility for public API consumers and customer automations that depend on specific resource names. The validating webhook's [duplicate check](#duplicate-projectroletemplatebinding-prevention) provides additional protection against duplicate bindings created with different explicit names.
+
+The deterministic name is computed as:
+
+```
+prefix + lowercase(base32(sha256(subject + "/" + roleTemplateName + "/" + projectName))[:10])
+```
+
+The prefix is taken from `metadata.generateName` if set, otherwise defaults to `prtb-`.
+
+The subject is resolved using the following priority order:
+1. `UserPrincipalName`
+2. `UserName`
+3. `GroupPrincipalName`
+4. `GroupName`
+5. `ServiceAccount`
+
+If no subject is set, the mutator passes the request through without modification (the validating webhook will reject it).
+
+This ensures that two identical concurrent requests using `generateName` produce the same resource name. The Kubernetes API server will reject the second request with a `409 Conflict`, preventing duplicate bindings even when requests race past the validating webhook.
+

--- a/pkg/resources/management.cattle.io/v3/projectroletemplatebinding/mutator.go
+++ b/pkg/resources/management.cattle.io/v3/projectroletemplatebinding/mutator.go
@@ -1,0 +1,123 @@
+package projectroletemplatebinding
+
+import (
+	"crypto/sha256"
+	"encoding/base32"
+	"fmt"
+	"strings"
+
+	apisv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/webhook/pkg/admission"
+	objectsv3 "github.com/rancher/webhook/pkg/generated/objects/management.cattle.io/v3"
+	"github.com/rancher/webhook/pkg/patch"
+	admissionv1 "k8s.io/api/admission/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/trace"
+)
+
+// NewMutator returns a new mutator for ProjectRoleTemplateBindings.
+func NewMutator() *Mutator {
+	return &Mutator{}
+}
+
+// Mutator implements admission.MutatingAdmissionHandler for ProjectRoleTemplateBindings.
+// On CREATE, when the generateName pattern is in use (metadata.name is empty), it creates
+// a deterministic name derived from the binding's content.
+// Two identical concurrent requests will produce the same name, causing the K8s
+// API server to reject the second with a 409 Conflict.
+//
+// When metadata.name is already set (i.e. the client explicitly chose a name), the mutator
+// does nothing.
+type Mutator struct{}
+
+// GVR returns the GroupVersionResource for this CRD.
+func (m *Mutator) GVR() schema.GroupVersionResource {
+	return gvr
+}
+
+// Operations returns list of operations handled by this mutator.
+func (m *Mutator) Operations() []admissionregistrationv1.OperationType {
+	return []admissionregistrationv1.OperationType{admissionregistrationv1.Create}
+}
+
+// MutatingWebhook returns the MutatingWebhook used for this CRD.
+func (m *Mutator) MutatingWebhook(clientConfig admissionregistrationv1.WebhookClientConfig) []admissionregistrationv1.MutatingWebhook {
+	mutatingWebhook := admission.NewDefaultMutatingWebhook(m, clientConfig, admissionregistrationv1.NamespacedScope, m.Operations())
+	return []admissionregistrationv1.MutatingWebhook{*mutatingWebhook}
+}
+
+// Admit handles the webhook admission request sent to this webhook.
+// On CREATE, when metadata.generateName is set, it computes a deterministic name
+// based on a hash of the binding's subject, roleTemplateName, and projectName.
+func (m *Mutator) Admit(request *admission.Request) (*admissionv1.AdmissionResponse, error) {
+	listTrace := trace.New("ProjectRoleTemplateBinding Mutator Admit", trace.Field{Key: "user", Value: request.UserInfo.Username})
+	defer listTrace.LogIfLong(admission.SlowTraceDuration)
+
+	prtb, err := objectsv3.ProjectRoleTemplateBindingFromRequest(&request.AdmissionRequest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get %s from request: %w", gvr.Resource, err)
+	}
+
+	// Skip when the client explicitly set a name.
+	if prtb.Name != "" {
+		return &admissionv1.AdmissionResponse{Allowed: true}, nil
+	}
+
+	// Reject if neither name nor generateName is set.
+	if prtb.GenerateName == "" {
+		return admission.ResponseBadRequest("metadata.name or metadata.generateName must be set"), nil
+	}
+
+	subject := resolveSubject(prtb)
+	if subject == "" {
+		// No subject found; let the validating webhook handle the error.
+		return &admissionv1.AdmissionResponse{Allowed: true}, nil
+	}
+
+	deterministicName := GenerateDeterministicName(prtb.GenerateName, subject, prtb.RoleTemplateName, prtb.ProjectName)
+	prtb.Name = deterministicName
+	prtb.GenerateName = ""
+
+	response := &admissionv1.AdmissionResponse{}
+	if err := patch.CreatePatch(request.Object.Raw, prtb, response); err != nil {
+		return nil, fmt.Errorf("failed to create patch: %w", err)
+	}
+	response.Allowed = true
+	return response, nil
+}
+
+// resolveSubject determines the binding subject using the same priority order as the
+// validating webhook: UserPrincipalName → UserName → GroupPrincipalName → GroupName → ServiceAccount.
+func resolveSubject(prtb *apisv3.ProjectRoleTemplateBinding) string {
+	switch {
+	case prtb.UserPrincipalName != "":
+		return prtb.UserPrincipalName
+	case prtb.UserName != "":
+		return prtb.UserName
+	case prtb.GroupPrincipalName != "":
+		return prtb.GroupPrincipalName
+	case prtb.GroupName != "":
+		return prtb.GroupName
+	case prtb.ServiceAccount != "":
+		return prtb.ServiceAccount
+	default:
+		return ""
+	}
+}
+
+// GenerateDeterministicName computes a deterministic PRTB name from the given prefix, subject,
+// roleTemplateName, and projectName. The formula is:
+//
+//	prefix + lowercase(base32(sha256(subject + "/" + roleTemplateName + "/" + projectName))[:10])
+//
+// WARNING: Changing this formula will break idempotency for existing clients. Treat the
+// output format as a stable API contract.
+func GenerateDeterministicName(prefix, subject, roleTemplateName, projectName string) string {
+	input := subject + "/" + roleTemplateName + "/" + projectName
+	hash := sha256.Sum256([]byte(input))
+	encoded := base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(hash[:])
+	// Take first 10 characters and lowercase.
+	suffix := strings.ToLower(encoded[:10])
+	return prefix + suffix
+}

--- a/pkg/resources/management.cattle.io/v3/projectroletemplatebinding/mutator_test.go
+++ b/pkg/resources/management.cattle.io/v3/projectroletemplatebinding/mutator_test.go
@@ -1,0 +1,343 @@
+package projectroletemplatebinding_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"unicode"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	apisv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/webhook/pkg/admission"
+	"github.com/rancher/webhook/pkg/resources/management.cattle.io/v3/projectroletemplatebinding"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/admission/v1"
+	v1authentication "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestGenerateDeterministicName(t *testing.T) {
+	t.Parallel()
+
+	t.Run("deterministic - same inputs produce same output", func(t *testing.T) {
+		t.Parallel()
+		name1 := projectroletemplatebinding.GenerateDeterministicName("prtb-", "user1", "admin-role", "cluster-id:project-id")
+		name2 := projectroletemplatebinding.GenerateDeterministicName("prtb-", "user1", "admin-role", "cluster-id:project-id")
+		assert.Equal(t, name1, name2, "same inputs should produce the same name")
+	})
+
+	t.Run("different subjects produce different names", func(t *testing.T) {
+		t.Parallel()
+		name1 := projectroletemplatebinding.GenerateDeterministicName("prtb-", "user1", "admin-role", "cluster-id:project-id")
+		name2 := projectroletemplatebinding.GenerateDeterministicName("prtb-", "user2", "admin-role", "cluster-id:project-id")
+		assert.NotEqual(t, name1, name2, "different subjects should produce different names")
+	})
+
+	t.Run("different roleTemplateNames produce different names", func(t *testing.T) {
+		t.Parallel()
+		name1 := projectroletemplatebinding.GenerateDeterministicName("prtb-", "user1", "admin-role", "cluster-id:project-id")
+		name2 := projectroletemplatebinding.GenerateDeterministicName("prtb-", "user1", "read-role", "cluster-id:project-id")
+		assert.NotEqual(t, name1, name2, "different roleTemplateNames should produce different names")
+	})
+
+	t.Run("different projectNames produce different names", func(t *testing.T) {
+		t.Parallel()
+		name1 := projectroletemplatebinding.GenerateDeterministicName("prtb-", "user1", "admin-role", "cluster-id:project-id")
+		name2 := projectroletemplatebinding.GenerateDeterministicName("prtb-", "user1", "admin-role", "cluster-id:other-project")
+		assert.NotEqual(t, name1, name2, "different projectNames should produce different names")
+	})
+
+	t.Run("name starts with prtb- prefix", func(t *testing.T) {
+		t.Parallel()
+		name := projectroletemplatebinding.GenerateDeterministicName("prtb-", "user1", "admin-role", "cluster-id:project-id")
+		assert.True(t, len(name) > 5 && name[:5] == "prtb-", "name should start with 'prtb-'")
+	})
+
+	t.Run("total length is 15 characters", func(t *testing.T) {
+		t.Parallel()
+		name := projectroletemplatebinding.GenerateDeterministicName("prtb-", "user1", "admin-role", "cluster-id:project-id")
+		assert.Equal(t, 15, len(name), "name should be 15 characters: 'prtb-' (5) + 10 hash chars")
+	})
+
+	t.Run("all characters are valid K8s name characters", func(t *testing.T) {
+		t.Parallel()
+		name := projectroletemplatebinding.GenerateDeterministicName("prtb-", "user1", "admin-role", "cluster-id:project-id")
+		for _, c := range name {
+			valid := unicode.IsLower(c) || unicode.IsDigit(c) || c == '-'
+			assert.True(t, valid, "character '%c' should be a valid K8s name character (lowercase alphanumeric or '-')", c)
+		}
+	})
+
+	t.Run("custom prefix is used", func(t *testing.T) {
+		t.Parallel()
+		name := projectroletemplatebinding.GenerateDeterministicName("custom-", "user1", "admin-role", "cluster-id:project-id")
+		assert.True(t, len(name) > 7 && name[:7] == "custom-", "name should start with 'custom-'")
+	})
+}
+
+func TestMutatorAdmit(t *testing.T) {
+	t.Parallel()
+
+	mutator := projectroletemplatebinding.NewMutator()
+
+	tests := []struct {
+		name       string
+		prtb       func() *apisv3.ProjectRoleTemplateBinding
+		wantPatch  bool
+		wantName   string
+		wantDenied bool
+		wantError  bool
+	}{
+		{
+			name: "CREATE with generateName and empty name - should set deterministic name",
+			prtb: func() *apisv3.ProjectRoleTemplateBinding {
+				prtb := newMutatorBasePRTB()
+				prtb.Name = ""
+				prtb.GenerateName = "prtb-"
+				return prtb
+			},
+			wantPatch: true,
+			wantName:  projectroletemplatebinding.GenerateDeterministicName("prtb-", "user1", "admin-role", fmt.Sprintf("%s:%s", clusterID, projectID)),
+		},
+		{
+			name: "CREATE with explicit name - should pass through without mutation",
+			prtb: func() *apisv3.ProjectRoleTemplateBinding {
+				prtb := newMutatorBasePRTB()
+				prtb.Name = "ui-chosen-name"
+				prtb.GenerateName = ""
+				return prtb
+			},
+			wantPatch: false,
+		},
+		{
+			name: "CREATE with both name and generateName set - should pass through without mutation",
+			prtb: func() *apisv3.ProjectRoleTemplateBinding {
+				prtb := newMutatorBasePRTB()
+				prtb.Name = "ui-chosen-name"
+				prtb.GenerateName = "prtb-"
+				return prtb
+			},
+			wantPatch: false,
+		},
+		{
+			name: "CREATE with both name and generateName empty - should reject",
+			prtb: func() *apisv3.ProjectRoleTemplateBinding {
+				prtb := newMutatorBasePRTB()
+				prtb.Name = ""
+				prtb.GenerateName = ""
+				return prtb
+			},
+			wantDenied: true,
+		},
+		{
+			name: "CREATE with custom generateName prefix - should use that prefix",
+			prtb: func() *apisv3.ProjectRoleTemplateBinding {
+				prtb := newMutatorBasePRTB()
+				prtb.Name = ""
+				prtb.GenerateName = "custom-"
+				return prtb
+			},
+			wantPatch: true,
+			wantName:  projectroletemplatebinding.GenerateDeterministicName("custom-", "user1", "admin-role", fmt.Sprintf("%s:%s", clusterID, projectID)),
+		},
+		{
+			name: "CREATE with name already correct - should not patch (idempotent)",
+			prtb: func() *apisv3.ProjectRoleTemplateBinding {
+				prtb := newMutatorBasePRTB()
+				prtb.Name = projectroletemplatebinding.GenerateDeterministicName("prtb-", "user1", "admin-role", fmt.Sprintf("%s:%s", clusterID, projectID))
+				prtb.GenerateName = ""
+				return prtb
+			},
+			wantPatch: false,
+		},
+		{
+			name: "subject priority: UserPrincipalName takes precedence over UserName",
+			prtb: func() *apisv3.ProjectRoleTemplateBinding {
+				prtb := newMutatorBasePRTB()
+				prtb.Name = ""
+				prtb.GenerateName = "prtb-"
+				prtb.UserPrincipalName = "local://user1"
+				prtb.UserName = "user1"
+				return prtb
+			},
+			wantPatch: true,
+			wantName:  projectroletemplatebinding.GenerateDeterministicName("prtb-", "local://user1", "admin-role", fmt.Sprintf("%s:%s", clusterID, projectID)),
+		},
+		{
+			name: "subject priority: UserName when UserPrincipalName is empty",
+			prtb: func() *apisv3.ProjectRoleTemplateBinding {
+				prtb := newMutatorBasePRTB()
+				prtb.Name = ""
+				prtb.GenerateName = "prtb-"
+				prtb.UserPrincipalName = ""
+				prtb.UserName = "user1"
+				return prtb
+			},
+			wantPatch: true,
+			wantName:  projectroletemplatebinding.GenerateDeterministicName("prtb-", "user1", "admin-role", fmt.Sprintf("%s:%s", clusterID, projectID)),
+		},
+		{
+			name: "subject priority: GroupPrincipalName",
+			prtb: func() *apisv3.ProjectRoleTemplateBinding {
+				prtb := newMutatorBasePRTB()
+				prtb.Name = ""
+				prtb.GenerateName = "prtb-"
+				prtb.UserPrincipalName = ""
+				prtb.UserName = ""
+				prtb.GroupPrincipalName = "ldap://cn=admins"
+				prtb.GroupName = "admins"
+				return prtb
+			},
+			wantPatch: true,
+			wantName:  projectroletemplatebinding.GenerateDeterministicName("prtb-", "ldap://cn=admins", "admin-role", fmt.Sprintf("%s:%s", clusterID, projectID)),
+		},
+		{
+			name: "subject priority: GroupName when GroupPrincipalName is empty",
+			prtb: func() *apisv3.ProjectRoleTemplateBinding {
+				prtb := newMutatorBasePRTB()
+				prtb.Name = ""
+				prtb.GenerateName = "prtb-"
+				prtb.UserPrincipalName = ""
+				prtb.UserName = ""
+				prtb.GroupPrincipalName = ""
+				prtb.GroupName = "admins"
+				return prtb
+			},
+			wantPatch: true,
+			wantName:  projectroletemplatebinding.GenerateDeterministicName("prtb-", "admins", "admin-role", fmt.Sprintf("%s:%s", clusterID, projectID)),
+		},
+		{
+			name: "subject priority: ServiceAccount",
+			prtb: func() *apisv3.ProjectRoleTemplateBinding {
+				prtb := newMutatorBasePRTB()
+				prtb.Name = ""
+				prtb.GenerateName = "prtb-"
+				prtb.UserPrincipalName = ""
+				prtb.UserName = ""
+				prtb.GroupPrincipalName = ""
+				prtb.GroupName = ""
+				prtb.ServiceAccount = "system:serviceaccount:default:mysa"
+				return prtb
+			},
+			wantPatch: true,
+			wantName:  projectroletemplatebinding.GenerateDeterministicName("prtb-", "system:serviceaccount:default:mysa", "admin-role", fmt.Sprintf("%s:%s", clusterID, projectID)),
+		},
+		{
+			name: "no subject set - should pass through without mutation",
+			prtb: func() *apisv3.ProjectRoleTemplateBinding {
+				prtb := newMutatorBasePRTB()
+				prtb.Name = ""
+				prtb.GenerateName = "prtb-"
+				prtb.UserPrincipalName = ""
+				prtb.UserName = ""
+				prtb.GroupPrincipalName = ""
+				prtb.GroupName = ""
+				prtb.ServiceAccount = ""
+				return prtb
+			},
+			wantPatch: false,
+		},
+	}
+
+	for i := range tests {
+		test := tests[i]
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			req := createMutatorPRTBRequest(t, test.prtb())
+			resp, err := mutator.Admit(req)
+			if test.wantError {
+				require.Error(t, err, "expected error from Admit")
+				return
+			}
+			require.NoError(t, err, "Admit failed")
+
+			if test.wantDenied {
+				require.False(t, resp.Allowed, "response should be denied")
+				return
+			}
+			require.True(t, resp.Allowed, "response should be allowed")
+
+			if test.wantPatch {
+				require.NotNil(t, resp.Patch, "expected a patch in the response")
+
+				patchObj, err := jsonpatch.DecodePatch(resp.Patch)
+				require.NoError(t, err, "failed to decode patch from response")
+
+				patchedJS, err := patchObj.Apply(req.Object.Raw)
+				require.NoError(t, err, "failed to apply patch to Object")
+
+				gotObj := &apisv3.ProjectRoleTemplateBinding{}
+				err = json.Unmarshal(patchedJS, gotObj)
+				require.NoError(t, err, "failed to unmarshal patched Object")
+
+				assert.Equal(t, test.wantName, gotObj.Name, "patched name should match expected deterministic name")
+				assert.Empty(t, gotObj.GenerateName, "generateName should be cleared after mutation")
+			} else {
+				assert.Nil(t, resp.Patch, "expected no patch in the response")
+			}
+		})
+	}
+}
+
+func TestMutatorUnexpectedErrors(t *testing.T) {
+	t.Parallel()
+	mutator := projectroletemplatebinding.NewMutator()
+	req := &admission.Request{
+		AdmissionRequest: v1.AdmissionRequest{
+			UID:       "1",
+			Operation: v1.Create,
+			Object:    runtime.RawExtension{},
+		},
+		Context: context.Background(),
+	}
+	_, err := mutator.Admit(req)
+	require.Error(t, err, "Admit should fail on bad request object")
+}
+
+func newMutatorBasePRTB() *apisv3.ProjectRoleTemplateBinding {
+	return &apisv3.ProjectRoleTemplateBinding{
+		TypeMeta: metav1.TypeMeta{Kind: "ProjectRoleTemplateBinding", APIVersion: "management.cattle.io/v3"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "PRTB-new",
+			GenerateName:      "prtb-",
+			Namespace:         projectID,
+			UID:               "6534e4ef-f07b-4c61-b88d-95a92cce4852",
+			ResourceVersion:   "1",
+			Generation:        1,
+			CreationTimestamp: metav1.Time{},
+			ManagedFields:     []metav1.ManagedFieldsEntry{},
+		},
+		UserName:         "user1",
+		RoleTemplateName: "admin-role",
+		ProjectName:      fmt.Sprintf("%s:%s", clusterID, projectID),
+	}
+}
+
+func createMutatorPRTBRequest(t *testing.T, prtb *apisv3.ProjectRoleTemplateBinding) *admission.Request {
+	t.Helper()
+	gvk := metav1.GroupVersionKind{Group: "management.cattle.io", Version: "v3", Kind: "ProjectRoleTemplateBinding"}
+	gvr := metav1.GroupVersionResource{Group: "management.cattle.io", Version: "v3", Resource: "projectroletemplatebindings"}
+	req := &admission.Request{
+		AdmissionRequest: v1.AdmissionRequest{
+			UID:             "1",
+			Kind:            gvk,
+			Resource:        gvr,
+			RequestKind:     &gvk,
+			RequestResource: &gvr,
+			Name:            prtb.Name,
+			Namespace:       prtb.Namespace,
+			Operation:       v1.Create,
+			UserInfo:        v1authentication.UserInfo{Username: "admin-userid", UID: ""},
+			Object:          runtime.RawExtension{},
+			OldObject:       runtime.RawExtension{},
+		},
+		Context: context.Background(),
+	}
+	var err error
+	req.Object.Raw, err = json.Marshal(prtb)
+	assert.NoError(t, err, "Failed to marshal PRTB while creating request")
+	return req
+}

--- a/pkg/resources/management.cattle.io/v3/projectroletemplatebinding/validator.go
+++ b/pkg/resources/management.cattle.io/v3/projectroletemplatebinding/validator.go
@@ -15,6 +15,8 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	k8validation "k8s.io/kubernetes/pkg/registry/rbac/validation"
@@ -30,7 +32,7 @@ var gvr = schema.GroupVersionResource{
 // NewValidator returns a new validator used for validation PRTB.
 func NewValidator(prtb *resolvers.PRTBRuleResolver, crtb *resolvers.CRTBRuleResolver,
 	defaultResolver k8validation.AuthorizationRuleResolver, roleTemplateResolver *auth.RoleTemplateResolver,
-	clusterCache v3.ClusterCache, projectCache v3.ProjectCache) *Validator {
+	clusterCache v3.ClusterCache, projectCache v3.ProjectCache, prtbCache v3.ProjectRoleTemplateBindingCache) *Validator {
 	clusterResolver := resolvers.NewAggregateRuleResolver(defaultResolver, crtb)
 	projectResolver := resolvers.NewAggregateRuleResolver(defaultResolver, prtb)
 	return &Validator{
@@ -40,6 +42,7 @@ func NewValidator(prtb *resolvers.PRTBRuleResolver, crtb *resolvers.CRTBRuleReso
 			roleTemplateResolver: roleTemplateResolver,
 			clusterCache:         clusterCache,
 			projectCache:         projectCache,
+			prtbCache:            prtbCache,
 		},
 	}
 }
@@ -75,6 +78,7 @@ type admitter struct {
 	roleTemplateResolver *auth.RoleTemplateResolver
 	clusterCache         v3.ClusterCache
 	projectCache         v3.ProjectCache
+	prtbCache            v3.ProjectRoleTemplateBindingCache
 }
 
 // Admit is the entrypoint for the validator. Admit will return an error if it's unable to process the request.
@@ -107,6 +111,17 @@ func (a *admitter) Admit(request *admission.Request) (*admissionv1.AdmissionResp
 				return admission.ResponseBadRequest(err.Error()), nil
 			}
 			return nil, fmt.Errorf("failed to validate fields on create: %w", err)
+		}
+		if err := a.validateDuplicates(prtb); err != nil {
+			return &admissionv1.AdmissionResponse{
+				Allowed: false,
+				Result: &metav1.Status{
+					Message: err.Error(),
+					Status:  metav1.StatusFailure,
+					Reason:  metav1.StatusReasonConflict,
+					Code:    409,
+				},
+			}, nil
 		}
 	}
 
@@ -248,4 +263,44 @@ func onlyOneTrue(values ...bool) bool {
 		}
 	}
 	return trueCount == 1
+}
+
+func (a *admitter) validateDuplicates(newPRTB *apisv3.ProjectRoleTemplateBinding) error {
+	roleTemplate, err := a.roleTemplateResolver.RoleTemplateCache().Get(newPRTB.RoleTemplateName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// If the role template doesn't exist, let it pass. The create validation will catch it.
+			return nil
+		}
+		return fmt.Errorf("failed to get RoleTemplate %s: %w", newPRTB.RoleTemplateName, err)
+	}
+	if roleTemplate.Context != "project" {
+		return nil
+	}
+
+	existingPRTBs, err := a.prtbCache.List(newPRTB.Namespace, labels.Everything())
+	if err != nil {
+		return fmt.Errorf("failed to list PRTBs: %w", err)
+	}
+	for _, existingPRTB := range existingPRTBs {
+		if existingPRTB.Name == newPRTB.Name && existingPRTB.Namespace == newPRTB.Namespace {
+			continue
+		}
+		if existingPRTB.DeletionTimestamp != nil {
+			continue
+		}
+		if existingPRTB.RoleTemplateName == newPRTB.RoleTemplateName && isPRTBDuplicate(existingPRTB, newPRTB) {
+			return fmt.Errorf("duplicate prtb not allowed")
+		}
+	}
+
+	return nil
+}
+
+// isPRTBDuplicate checks if the given newPRTB and existingPRTB target the same user or group.
+func isPRTBDuplicate(existingPRTB *apisv3.ProjectRoleTemplateBinding, newPRTB *apisv3.ProjectRoleTemplateBinding) bool {
+	return (newPRTB.UserPrincipalName != "" && existingPRTB.UserPrincipalName != "" && newPRTB.UserPrincipalName == existingPRTB.UserPrincipalName) ||
+		(newPRTB.UserName != "" && existingPRTB.UserName != "" && newPRTB.UserName == existingPRTB.UserName) ||
+		(newPRTB.GroupPrincipalName != "" && existingPRTB.GroupPrincipalName != "" && newPRTB.GroupPrincipalName == existingPRTB.GroupPrincipalName) ||
+		(newPRTB.GroupName != "" && existingPRTB.GroupName != "" && newPRTB.GroupName == existingPRTB.GroupName)
 }

--- a/pkg/resources/management.cattle.io/v3/projectroletemplatebinding/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/projectroletemplatebinding/validator_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	apisv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/webhook/pkg/admission"
@@ -190,6 +191,7 @@ func (p *ProjectRoleTemplateBindingSuite) TestPrivilegeEscalation() {
 	},
 	}, nil).AnyTimes()
 	prtbCache.EXPECT().GetByIndex(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	prtbCache.EXPECT().List(gomock.Any(), gomock.Any()).Return([]*apisv3.ProjectRoleTemplateBinding{}, nil).AnyTimes()
 	crtbCache := fake.NewMockCacheInterface[*apisv3.ClusterRoleTemplateBinding](ctrl)
 	crtbCache.EXPECT().AddIndexer(gomock.Any(), gomock.Any())
 	crtbCache.EXPECT().GetByIndex(gomock.Any(), resolvers.GetUserKey(crtbUser, clusterID)).Return([]*apisv3.ClusterRoleTemplateBinding{
@@ -220,7 +222,7 @@ func (p *ProjectRoleTemplateBindingSuite) TestPrivilegeEscalation() {
 			ClusterName: clusterID,
 		},
 	}, nil).AnyTimes()
-	validator := projectroletemplatebinding.NewValidator(prtbResolver, crtbResolver, resolver, roleResolver, clusterCache, projectCache)
+	validator := projectroletemplatebinding.NewValidator(prtbResolver, crtbResolver, resolver, roleResolver, clusterCache, projectCache, prtbCache)
 	type args struct {
 		oldPRTB  func() *apisv3.ProjectRoleTemplateBinding
 		newPRTB  func() *apisv3.ProjectRoleTemplateBinding
@@ -395,7 +397,7 @@ func (p *ProjectRoleTemplateBindingSuite) TestValidationOnUpdate() {
 		},
 	}, nil).AnyTimes()
 
-	validator := projectroletemplatebinding.NewValidator(prtbResolver, crtbResolver, resolver, roleResolver, clusterCache, projectCache)
+	validator := projectroletemplatebinding.NewValidator(prtbResolver, crtbResolver, resolver, roleResolver, clusterCache, projectCache, prtbCache)
 	type args struct {
 		oldPRTB  func() *apisv3.ProjectRoleTemplateBinding
 		newPRTB  func() *apisv3.ProjectRoleTemplateBinding
@@ -768,6 +770,7 @@ func (p *ProjectRoleTemplateBindingSuite) TestValidationOnCreate() {
 		prtbCache := fake.NewMockCacheInterface[*apisv3.ProjectRoleTemplateBinding](ctrl)
 		prtbCache.EXPECT().AddIndexer(gomock.Any(), gomock.Any())
 		prtbCache.EXPECT().GetByIndex(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+		prtbCache.EXPECT().List(gomock.Any(), gomock.Any()).Return([]*apisv3.ProjectRoleTemplateBinding{}, nil).AnyTimes()
 		crtbCache := fake.NewMockCacheInterface[*apisv3.ClusterRoleTemplateBinding](ctrl)
 		crtbCache.EXPECT().AddIndexer(gomock.Any(), gomock.Any())
 		crtbCache.EXPECT().GetByIndex(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
@@ -814,7 +817,7 @@ func (p *ProjectRoleTemplateBindingSuite) TestValidationOnCreate() {
 			},
 		}, nil).AnyTimes()
 
-		return projectroletemplatebinding.NewValidator(prtbResolver, crtbResolver, resolver, roleResolver, clusterCache, projectCache)
+		return projectroletemplatebinding.NewValidator(prtbResolver, crtbResolver, resolver, roleResolver, clusterCache, projectCache, prtbCache)
 	}
 
 	type args struct {
@@ -1213,6 +1216,116 @@ func (p *ProjectRoleTemplateBindingSuite) TestValidationOnCreate() {
 			p.Require().NoError(err, "Admit failed")
 			if resp.Allowed != test.allowed {
 				p.Failf("Response was incorrectly validated", "Wanted response.Allowed = %v got %v: result=%+v", test.allowed, resp.Allowed, resp.Result)
+			}
+		})
+	}
+}
+
+func (p *ProjectRoleTemplateBindingSuite) TestValidateDuplicates() {
+	const adminUser = "admin-userid"
+	const memberRole = "read-role"
+
+	tests := []struct {
+		name           string
+		setupPRTBMocks func(prtbCache *fake.MockCacheInterface[*apisv3.ProjectRoleTemplateBinding])
+		newPRTB        *apisv3.ProjectRoleTemplateBinding
+		allowed        bool
+	}{
+		{
+			name: "no duplicate exists",
+			setupPRTBMocks: func(prtbCache *fake.MockCacheInterface[*apisv3.ProjectRoleTemplateBinding]) {
+				prtbCache.EXPECT().List(gomock.Any(), gomock.Any()).Return([]*apisv3.ProjectRoleTemplateBinding{}, nil).AnyTimes()
+			},
+			newPRTB: func() *apisv3.ProjectRoleTemplateBinding {
+				prtb := newBasePRTB()
+				prtb.RoleTemplateName = memberRole
+				return prtb
+			}(),
+			allowed: true,
+		},
+		{
+			name: "exact duplicate exists",
+			setupPRTBMocks: func(prtbCache *fake.MockCacheInterface[*apisv3.ProjectRoleTemplateBinding]) {
+				existing := newBasePRTB()
+				existing.Name = "existing-prtb"
+				existing.RoleTemplateName = memberRole
+				prtbCache.EXPECT().List(gomock.Any(), gomock.Any()).Return([]*apisv3.ProjectRoleTemplateBinding{existing}, nil).AnyTimes()
+			},
+			newPRTB: func() *apisv3.ProjectRoleTemplateBinding {
+				prtb := newBasePRTB()
+				prtb.RoleTemplateName = memberRole
+				return prtb
+			}(),
+			allowed: false,
+		},
+		{
+			name: "duplicate exists but is being deleted",
+			setupPRTBMocks: func(prtbCache *fake.MockCacheInterface[*apisv3.ProjectRoleTemplateBinding]) {
+				deleting := newBasePRTB()
+				deleting.Name = "deleting-prtb"
+				deleting.RoleTemplateName = memberRole
+				deleting.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+				prtbCache.EXPECT().List(gomock.Any(), gomock.Any()).Return([]*apisv3.ProjectRoleTemplateBinding{deleting}, nil).AnyTimes()
+			},
+			newPRTB: func() *apisv3.ProjectRoleTemplateBinding {
+				prtb := newBasePRTB()
+				prtb.RoleTemplateName = memberRole
+				return prtb
+			}(),
+			allowed: true,
+		},
+	}
+
+	for _, test := range tests {
+		p.Run(test.name, func() {
+			subCtrl := gomock.NewController(p.T())
+			defer subCtrl.Finish()
+
+			prtbCache := fake.NewMockCacheInterface[*apisv3.ProjectRoleTemplateBinding](subCtrl)
+			prtbCache.EXPECT().AddIndexer(gomock.Any(), gomock.Any()).AnyTimes()
+			prtbCache.EXPECT().GetByIndex(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+			test.setupPRTBMocks(prtbCache)
+
+			roleTemplate := &apisv3.RoleTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: memberRole},
+				Context:    "project",
+			}
+			roleTemplateCache := fake.NewMockNonNamespacedCacheInterface[*apisv3.RoleTemplate](subCtrl)
+			roleTemplateCache.EXPECT().Get(memberRole).Return(roleTemplate, nil).AnyTimes()
+			roleResolver := auth.NewRoleTemplateResolver(roleTemplateCache, nil)
+
+			crtbCache := fake.NewMockCacheInterface[*apisv3.ClusterRoleTemplateBinding](subCtrl)
+			crtbCache.EXPECT().AddIndexer(gomock.Any(), gomock.Any()).AnyTimes()
+			crtbCache.EXPECT().GetByIndex(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+			clusterCache := fake.NewMockNonNamespacedCacheInterface[*apisv3.Cluster](subCtrl)
+			clusterCache.EXPECT().Get(clusterID).Return(&apisv3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: clusterID},
+			}, nil).AnyTimes()
+
+			projectCache := fake.NewMockCacheInterface[*apisv3.Project](subCtrl)
+			projectCache.EXPECT().Get(clusterID, projectID).Return(&apisv3.Project{
+				ObjectMeta: metav1.ObjectMeta{Namespace: clusterID, Name: projectID},
+				Spec:       apisv3.ProjectSpec{ClusterName: clusterID},
+			}, nil).AnyTimes()
+
+			crtbResolver := resolvers.NewCRTBRuleResolver(crtbCache, roleResolver)
+			prtbResolver := resolvers.NewPRTBRuleResolver(prtbCache, roleResolver)
+
+			dummyDefaultResolver, _ := validation.NewTestRuleResolver(nil, nil, nil, nil)
+			validator := projectroletemplatebinding.NewValidator(prtbResolver, crtbResolver, dummyDefaultResolver, roleResolver, clusterCache, projectCache, prtbCache)
+
+			req := createPRTBRequest(p.T(), nil, test.newPRTB, adminUser)
+			admitters := validator.Admitters()
+			p.Require().NotEmpty(admitters)
+			resp, err := admitters[0].Admit(req)
+
+			p.NoError(err)
+			if test.allowed {
+				p.True(resp.Allowed)
+			} else {
+				p.False(resp.Allowed)
+				p.Contains(resp.Result.Message, "duplicate prtb not allowed")
 			}
 		})
 	}

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -75,7 +75,7 @@ func Validation(clients *clients.Clients) ([]admission.ValidatingAdmissionHandle
 			podsecurityadmissionconfigurationtemplate.NewValidator(clients.Management.Cluster().Cache(), clients.Provisioning.Cluster().Cache()),
 			globalrole.NewValidator(clients.DefaultResolver, grbResolvers, clients.K8s.AuthorizationV1().SubjectAccessReviews(), clients.GlobalRoleResolver),
 			globalrolebinding.NewValidator(clients.DefaultResolver, grbResolvers, clients.K8s.AuthorizationV1().SubjectAccessReviews(), clients.GlobalRoleResolver),
-			projectroletemplatebinding.NewValidator(prtbResolver, crtbResolver, clients.DefaultResolver, clients.RoleTemplateResolver, clients.Management.Cluster().Cache(), clients.Management.Project().Cache()),
+			projectroletemplatebinding.NewValidator(prtbResolver, crtbResolver, clients.DefaultResolver, clients.RoleTemplateResolver, clients.Management.Cluster().Cache(), clients.Management.Project().Cache(), clients.Management.ProjectRoleTemplateBinding().Cache()),
 			clusterroletemplatebinding.NewValidator(crtbResolver, clients.DefaultResolver, clients.RoleTemplateResolver, clients.Management.GlobalRoleBinding().Cache(), clients.Management.Cluster().Cache(), clients.Management.ClusterRoleTemplateBinding().Cache()),
 			roletemplate.NewValidator(clients.DefaultResolver, clients.RoleTemplateResolver, clients.K8s.AuthorizationV1().SubjectAccessReviews(), clients.Management.GlobalRole().Cache()),
 			secret.NewValidator(clients.RBAC.Role().Cache(), clients.RBAC.RoleBinding().Cache()),
@@ -113,7 +113,8 @@ func Mutation(clients *clients.Clients) ([]admission.MutatingAdmissionHandler, e
 		secrets := secret.NewMutator(clients.RBAC.Role(), clients.RBAC.RoleBinding(), clients.Management.Setting().Cache(), clients.Management.User().Cache())
 		projects := project.NewMutator(clients.Core.Namespace().Cache(), clients.Management.RoleTemplate().Cache(), clients.Management.Project().Cache())
 		grbs := globalrolebinding.NewMutator(clients.Management.GlobalRole().Cache())
-		mutators = append(mutators, secrets, projects, grbs)
+		prtbs := projectroletemplatebinding.NewMutator()
+		mutators = append(mutators, secrets, projects, grbs, prtbs)
 	}
 
 	return mutators, nil

--- a/tests/integration/projectRoleTemplateBinding_test.go
+++ b/tests/integration/projectRoleTemplateBinding_test.go
@@ -27,15 +27,16 @@ func (m *IntegrationSuite) TestProjectRoleTemplateBinding() {
 	m.Require().NotEmpty(projectName, "could not find a non-system project to put prtbs in")
 	m.Require().NoError(err)
 	const rtName = "rt-testprtb"
+	fullProjectName := fmt.Sprintf("%s:%s", clusterName, projectName)
 	newObj := func() *v3.ProjectRoleTemplateBinding { return &v3.ProjectRoleTemplateBinding{} }
 	validCreateObj := &v3.ProjectRoleTemplateBinding{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "test-projectroletemplatebinding",
+			Name:      "test-prtb",
 			Namespace: projectName,
 		},
 		UserName:         "bruce-wayne",
 		RoleTemplateName: rtName,
-		ProjectName:      fmt.Sprintf("%s:%s", clusterName, projectName),
+		ProjectName:      fullProjectName,
 	}
 	invalidCreate := func() *v3.ProjectRoleTemplateBinding {
 		invalidCreate := validCreateObj.DeepCopy()


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/54001
## Problem
Multiple ProjectRoleTemplateBindings (PRTBs) are created for the same user and role within the same project. There is no backend validation to enforce uniqueness of the following tuple: (principalId, roleTemplateId, projectId)
Repeated requests (via UI or API) to assign the same user the same role in the same project result in multiple identical PRTBs being created.

## Solution
Added a new mutating admission webhook for ProjectRoleTemplateBinding CREATE requests that computes a deterministic metadata.name based on the binding's content, replacing whatever name or generateName the client provided:
```
name = "prtb-" + lowercase(base32(sha256(subject + "/" + roleTemplateName + "/" + projectName))[:10])
```
- The subject is resolved using the same priority order as the existing validator: UserPrincipalName → UserName → GroupPrincipalName → GroupName → ServiceAccount.
- Uses base32.StdEncoding without padding, lowercased — all characters are valid in K8s resource names.
10 characters of base32 encode 50 bits of entropy (~1/2^50 collision probability).
- Two identical concurrent requests now produce the same resource name, so the K8s API server rejects the second with a 409 Conflict at the etcd level — a race-free guarantee.
- If the name already matches the deterministic value (idempotent), no patch is emitted.
- If no subject can be resolved, the mutator passes through and lets the validating webhook reject the request.

This PR also  introduces a backend validation mechanism to prevent the creation of duplicate PRTB.

- It efficiently lists all existing PRTBs for the target cluster using a cached lister.
- It iterates through the existing bindings and checks if one already exists with the same roleTemplateName and the same subject (matching by userName, userPrincipalID, groupName, or groupPrincipalName).
- If a non-deleted duplicate is found, the API rejects the request with a 409 Conflict error and a descriptive message.
- To solve a race condition observed in the UI (where a user is removed and re-added in the same transaction), the validator checks the DeletionTimestamp of any conflicting binding. If a duplicate is found but is already marked for deletion, it is ignored (continue), allowing the creation to proceed and preventing a transient UI error.


## CheckList
- [x] Test — Added unit tests for GenerateDeterministicName (7 subtests) and Mutator.Admit (11 subtests) covering all mutation paths, subject priority, idempotency, and error handling. Fixed existing flaky setting validator tests.