### PR TITLE
feat: add mutating webook for generating names for CRTB

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -301,6 +301,26 @@ A binding is considered a duplicate if another `ClusterRoleTemplateBinding` exis
   - `groupName`
   - `groupPrincipalName`
 
+### Mutations
+
+#### Deterministic Name Generation
+
+On `CREATE`, when `metadata.generateName` is set and `metadata.name` is empty, the mutating webhook replaces the server-side random name generation with a deterministic name derived from the binding's content. The generated name is:
+
+```
+<generateName prefix> + lowercase(base32(sha256(subject + "/" + roleTemplateName + "/" + clusterName))[:10])
+```
+
+The subject is selected using the following priority order:
+1. `userPrincipalName`
+2. `userName`
+3. `groupPrincipalName`
+4. `groupName`
+
+This ensures that two identical concurrent requests produce the same `metadata.name`, causing the Kubernetes API server to reject the second request with a `409 Conflict`. This prevents duplicate `ClusterRoleTemplateBinding` resources from being created by race conditions.
+
+If `metadata.name` is already set (i.e. the caller explicitly chose a name), no mutation is performed.
+
 ## Feature
 
 ### Validation Checks

--- a/pkg/resources/management.cattle.io/v3/clusterroletemplatebinding/ClusterRoleTemplateBinding.md
+++ b/pkg/resources/management.cattle.io/v3/clusterroletemplatebinding/ClusterRoleTemplateBinding.md
@@ -49,3 +49,24 @@ A binding is considered a duplicate if another `ClusterRoleTemplateBinding` exis
   - `userPrincipalName`
   - `groupName`
   - `groupPrincipalName`
+
+## Mutations
+
+### Deterministic Name Generation
+
+On `CREATE`, when `metadata.generateName` is set and `metadata.name` is empty, the mutating webhook replaces the server-side random name generation with a deterministic name derived from the binding's content. The generated name is:
+
+```
+<generateName prefix> + lowercase(base32(sha256(subject + "/" + roleTemplateName + "/" + clusterName))[:10])
+```
+
+The subject is selected using the following priority order:
+1. `userPrincipalName`
+2. `userName`
+3. `groupPrincipalName`
+4. `groupName`
+
+This ensures that two identical concurrent requests produce the same `metadata.name`, causing the Kubernetes API server to reject the second request with a `409 Conflict`. This prevents duplicate `ClusterRoleTemplateBinding` resources from being created by race conditions.
+
+If `metadata.name` is already set (i.e. the caller explicitly chose a name), no mutation is performed.
+

--- a/pkg/resources/management.cattle.io/v3/clusterroletemplatebinding/mutator.go
+++ b/pkg/resources/management.cattle.io/v3/clusterroletemplatebinding/mutator.go
@@ -1,0 +1,107 @@
+package clusterroletemplatebinding
+
+import (
+	"crypto/sha256"
+	"encoding/base32"
+	"fmt"
+	"strings"
+
+	"github.com/rancher/webhook/pkg/admission"
+	objectsv3 "github.com/rancher/webhook/pkg/generated/objects/management.cattle.io/v3"
+	"github.com/rancher/webhook/pkg/patch"
+	admissionv1 "k8s.io/api/admission/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/trace"
+)
+
+// Mutator implements admission.MutatingAdmissionWebhook.
+type Mutator struct{}
+
+// NewMutator returns a new mutator for ClusterRoleTemplateBindings.
+func NewMutator() *Mutator {
+	return &Mutator{}
+}
+
+// GVR returns the GroupVersionResource for this CRD.
+func (m *Mutator) GVR() schema.GroupVersionResource {
+	return gvr
+}
+
+// Operations returns list of operations handled by this mutator.
+func (m *Mutator) Operations() []admissionregistrationv1.OperationType {
+	return []admissionregistrationv1.OperationType{admissionregistrationv1.Create}
+}
+
+// MutatingWebhook returns the MutatingWebhook used for this CRD.
+func (m *Mutator) MutatingWebhook(clientConfig admissionregistrationv1.WebhookClientConfig) []admissionregistrationv1.MutatingWebhook {
+	mutatingWebhook := admission.NewDefaultMutatingWebhook(m, clientConfig, admissionregistrationv1.NamespacedScope, m.Operations())
+	return []admissionregistrationv1.MutatingWebhook{*mutatingWebhook}
+}
+
+// Admit handles the webhook admission request sent to this webhook.
+func (m *Mutator) Admit(request *admission.Request) (*admissionv1.AdmissionResponse, error) {
+	listTrace := trace.New("ClusterRoleTemplateBinding Mutator Admit", trace.Field{Key: "user", Value: request.UserInfo.Username})
+	defer listTrace.LogIfLong(admission.SlowTraceDuration)
+
+	if request.Operation != admissionv1.Create {
+		return &admissionv1.AdmissionResponse{Allowed: true}, nil
+	}
+
+	crtb, err := objectsv3.ClusterRoleTemplateBindingFromRequest(&request.AdmissionRequest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get %s from request: %w", gvr.Resource, err)
+	}
+
+	// Only mutate when generateName is in use: name must be empty and generateName must be set.
+	// This ensures we never overwrite a name explicitly provided by the caller.
+	if crtb.Name != "" {
+		return &admissionv1.AdmissionResponse{Allowed: true}, nil
+	}
+	if crtb.GenerateName == "" {
+		return admission.ResponseBadRequest("metadata.name and metadata.generateName are both empty"), nil
+	}
+
+	subject := getSubject(crtb.UserPrincipalName, crtb.UserName, crtb.GroupPrincipalName, crtb.GroupName)
+	if subject == "" {
+		return admission.ResponseBadRequest("no subject found: one of userPrincipalName, userName, groupPrincipalName, or groupName must be set"), nil
+	}
+
+	crtb.Name = GenerateDeterministicName(crtb.GenerateName, subject, crtb.RoleTemplateName, crtb.ClusterName)
+	crtb.GenerateName = ""
+
+	response := &admissionv1.AdmissionResponse{}
+	if err := patch.CreatePatch(request.Object.Raw, crtb, response); err != nil {
+		return nil, fmt.Errorf("failed to create patch: %w", err)
+	}
+	response.Allowed = true
+	return response, nil
+}
+
+// getSubject returns the binding subject using the following priority:
+// UserPrincipalName > UserName > GroupPrincipalName > GroupName.
+func getSubject(userPrincipalName, userName, groupPrincipalName, groupName string) string {
+	switch {
+	case userPrincipalName != "":
+		return userPrincipalName
+	case userName != "":
+		return userName
+	case groupPrincipalName != "":
+		return groupPrincipalName
+	case groupName != "":
+		return groupName
+	default:
+		return ""
+	}
+}
+
+// GenerateDeterministicName computes a deterministic resource name from the given prefix and
+// binding content. The name is: prefix + lowercase(base32(sha256(subject/roleTemplateName/clusterName))[:10]).
+// This produces names that are valid K8s resource names and ensures that two identical binding
+// requests yield the same name, causing the API server to reject the second with a 409 Conflict.
+func GenerateDeterministicName(prefix, subject, roleTemplateName, clusterName string) string {
+	hash := sha256.Sum256([]byte(subject + "/" + roleTemplateName + "/" + clusterName))
+	encoded := base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(hash[:])
+	suffix := strings.ToLower(encoded[:10])
+	return prefix + suffix
+}

--- a/pkg/resources/management.cattle.io/v3/clusterroletemplatebinding/mutator_test.go
+++ b/pkg/resources/management.cattle.io/v3/clusterroletemplatebinding/mutator_test.go
@@ -1,0 +1,261 @@
+package clusterroletemplatebinding_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	apisv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/webhook/pkg/admission"
+	"github.com/rancher/webhook/pkg/resources/management.cattle.io/v3/clusterroletemplatebinding"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	v1authentication "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestGenerateDeterministicName(t *testing.T) {
+	t.Parallel()
+
+	t.Run("deterministic", func(t *testing.T) {
+		name1 := clusterroletemplatebinding.GenerateDeterministicName("crtb-", "user1", "admin-role", "c-123")
+		name2 := clusterroletemplatebinding.GenerateDeterministicName("crtb-", "user1", "admin-role", "c-123")
+		assert.Equal(t, name1, name2, "same inputs must produce the same name")
+	})
+
+	t.Run("different subjects produce different names", func(t *testing.T) {
+		name1 := clusterroletemplatebinding.GenerateDeterministicName("crtb-", "user1", "admin-role", "c-123")
+		name2 := clusterroletemplatebinding.GenerateDeterministicName("crtb-", "user2", "admin-role", "c-123")
+		assert.NotEqual(t, name1, name2)
+	})
+
+	t.Run("different roleTemplates produce different names", func(t *testing.T) {
+		name1 := clusterroletemplatebinding.GenerateDeterministicName("crtb-", "user1", "admin-role", "c-123")
+		name2 := clusterroletemplatebinding.GenerateDeterministicName("crtb-", "user1", "read-role", "c-123")
+		assert.NotEqual(t, name1, name2)
+	})
+
+	t.Run("different clusterNames produce different names", func(t *testing.T) {
+		name1 := clusterroletemplatebinding.GenerateDeterministicName("crtb-", "user1", "admin-role", "c-123")
+		name2 := clusterroletemplatebinding.GenerateDeterministicName("crtb-", "user1", "admin-role", "c-456")
+		assert.NotEqual(t, name1, name2)
+	})
+
+	t.Run("valid k8s name characters", func(t *testing.T) {
+		name := clusterroletemplatebinding.GenerateDeterministicName("crtb-", "user1", "admin-role", "c-123")
+		assert.True(t, strings.HasPrefix(name, "crtb-"), "name should start with the prefix")
+		// The suffix (after prefix) should only contain lowercase alphanumeric characters (base32 lowercase).
+		suffix := strings.TrimPrefix(name, "crtb-")
+		assert.Len(t, suffix, 10, "suffix should be 10 characters")
+		for _, c := range suffix {
+			assert.True(t, (c >= 'a' && c <= 'z') || (c >= '2' && c <= '7'),
+				"character %c is not a valid lowercase base32 character", c)
+		}
+	})
+
+	t.Run("uses provided prefix", func(t *testing.T) {
+		name := clusterroletemplatebinding.GenerateDeterministicName("myprefix-", "user1", "admin-role", "c-123")
+		assert.True(t, strings.HasPrefix(name, "myprefix-"))
+	})
+}
+
+func TestMutatorAdmit(t *testing.T) {
+	t.Parallel()
+	mutator := clusterroletemplatebinding.NewMutator()
+
+	t.Run("skips when name is already set", func(t *testing.T) {
+		crtb := &apisv3.ClusterRoleTemplateBinding{
+			TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleTemplateBinding", APIVersion: "management.cattle.io/v3"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-explicit-name",
+				Namespace: "c-123",
+			},
+			UserName:         "user1",
+			RoleTemplateName: "admin-role",
+			ClusterName:      "c-123",
+		}
+
+		req := createMutatingCRTBRequest(t, crtb, admissionv1.Create)
+		resp, err := mutator.Admit(req)
+		require.NoError(t, err)
+		assert.True(t, resp.Allowed)
+		assert.Nil(t, resp.Patch, "no patch expected when name is already set")
+	})
+
+	t.Run("rejects when both name and generateName are empty", func(t *testing.T) {
+		crtb := &apisv3.ClusterRoleTemplateBinding{
+			TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleTemplateBinding", APIVersion: "management.cattle.io/v3"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "",
+				Namespace: "c-123",
+			},
+			UserName:         "user1",
+			RoleTemplateName: "admin-role",
+			ClusterName:      "c-123",
+		}
+
+		req := createMutatingCRTBRequest(t, crtb, admissionv1.Create)
+		resp, err := mutator.Admit(req)
+		require.NoError(t, err)
+		assert.False(t, resp.Allowed, "should reject when both name and generateName are empty")
+	})
+
+	t.Run("mutates on CREATE with generateName", func(t *testing.T) {
+		crtb := &apisv3.ClusterRoleTemplateBinding{
+			TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleTemplateBinding", APIVersion: "management.cattle.io/v3"},
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "crtb-",
+				Namespace:    "c-123",
+			},
+			UserName:         "user1",
+			RoleTemplateName: "admin-role",
+			ClusterName:      "c-123",
+		}
+
+		req := createMutatingCRTBRequest(t, crtb, admissionv1.Create)
+		resp, err := mutator.Admit(req)
+		require.NoError(t, err)
+		assert.True(t, resp.Allowed)
+		assert.NotNil(t, resp.Patch, "patch expected when generateName is used")
+
+		expectedName := clusterroletemplatebinding.GenerateDeterministicName("crtb-", "user1", "admin-role", "c-123")
+		assert.Contains(t, string(resp.Patch), expectedName)
+	})
+
+	t.Run("subject priority: userPrincipalName over userName", func(t *testing.T) {
+		crtb := &apisv3.ClusterRoleTemplateBinding{
+			TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleTemplateBinding", APIVersion: "management.cattle.io/v3"},
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "crtb-",
+				Namespace:    "c-123",
+			},
+			UserPrincipalName: "local://user1",
+			UserName:          "user1",
+			RoleTemplateName:  "admin-role",
+			ClusterName:       "c-123",
+		}
+
+		req := createMutatingCRTBRequest(t, crtb, admissionv1.Create)
+		resp, err := mutator.Admit(req)
+		require.NoError(t, err)
+		assert.True(t, resp.Allowed)
+		assert.NotNil(t, resp.Patch)
+
+		// The name should be based on userPrincipalName, not userName.
+		expectedName := clusterroletemplatebinding.GenerateDeterministicName("crtb-", "local://user1", "admin-role", "c-123")
+		assert.Contains(t, string(resp.Patch), expectedName)
+	})
+
+	t.Run("subject priority: groupPrincipalName over groupName", func(t *testing.T) {
+		crtb := &apisv3.ClusterRoleTemplateBinding{
+			TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleTemplateBinding", APIVersion: "management.cattle.io/v3"},
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "crtb-",
+				Namespace:    "c-123",
+			},
+			GroupPrincipalName: "ldap://admins",
+			GroupName:          "admins",
+			RoleTemplateName:   "admin-role",
+			ClusterName:        "c-123",
+		}
+
+		req := createMutatingCRTBRequest(t, crtb, admissionv1.Create)
+		resp, err := mutator.Admit(req)
+		require.NoError(t, err)
+		assert.True(t, resp.Allowed)
+		assert.NotNil(t, resp.Patch)
+
+		expectedName := clusterroletemplatebinding.GenerateDeterministicName("crtb-", "ldap://admins", "admin-role", "c-123")
+		assert.Contains(t, string(resp.Patch), expectedName)
+	})
+
+	t.Run("rejects when no subject fields are set", func(t *testing.T) {
+		crtb := &apisv3.ClusterRoleTemplateBinding{
+			TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleTemplateBinding", APIVersion: "management.cattle.io/v3"},
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "crtb-",
+				Namespace:    "c-123",
+			},
+			RoleTemplateName: "admin-role",
+			ClusterName:      "c-123",
+		}
+
+		req := createMutatingCRTBRequest(t, crtb, admissionv1.Create)
+		resp, err := mutator.Admit(req)
+		require.NoError(t, err)
+		assert.False(t, resp.Allowed, "should reject when no subject is set")
+	})
+
+	t.Run("passes through non-CREATE operations", func(t *testing.T) {
+		crtb := &apisv3.ClusterRoleTemplateBinding{
+			TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleTemplateBinding", APIVersion: "management.cattle.io/v3"},
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "crtb-",
+				Namespace:    "c-123",
+			},
+			UserName:         "user1",
+			RoleTemplateName: "admin-role",
+			ClusterName:      "c-123",
+		}
+
+		req := createMutatingCRTBRequest(t, crtb, admissionv1.Update)
+		resp, err := mutator.Admit(req)
+		require.NoError(t, err)
+		assert.True(t, resp.Allowed)
+		assert.Nil(t, resp.Patch, "no patch expected on update")
+	})
+
+	t.Run("two identical requests produce the same name", func(t *testing.T) {
+		makeCRTB := func() *apisv3.ClusterRoleTemplateBinding {
+			return &apisv3.ClusterRoleTemplateBinding{
+				TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleTemplateBinding", APIVersion: "management.cattle.io/v3"},
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "crtb-",
+					Namespace:    "c-123",
+				},
+				UserName:         "user1",
+				RoleTemplateName: "admin-role",
+				ClusterName:      "c-123",
+			}
+		}
+
+		req1 := createMutatingCRTBRequest(t, makeCRTB(), admissionv1.Create)
+		resp1, err := mutator.Admit(req1)
+		require.NoError(t, err)
+
+		req2 := createMutatingCRTBRequest(t, makeCRTB(), admissionv1.Create)
+		resp2, err := mutator.Admit(req2)
+		require.NoError(t, err)
+
+		assert.Equal(t, string(resp1.Patch), string(resp2.Patch), "identical requests should produce the same patch")
+	})
+}
+
+func createMutatingCRTBRequest(t *testing.T, crtb *apisv3.ClusterRoleTemplateBinding, op admissionv1.Operation) *admission.Request {
+	t.Helper()
+	gvk := metav1.GroupVersionKind{Group: "management.cattle.io", Version: "v3", Kind: "ClusterRoleTemplateBinding"}
+	gvr := metav1.GroupVersionResource{Group: "management.cattle.io", Version: "v3", Resource: "clusterroletemplatebindings"}
+
+	raw, err := json.Marshal(crtb)
+	require.NoError(t, err, "failed to marshal CRTB")
+
+	return &admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			UID:             "1",
+			Kind:            gvk,
+			Resource:        gvr,
+			RequestKind:     &gvk,
+			RequestResource: &gvr,
+			Name:            crtb.Name,
+			Namespace:       crtb.Namespace,
+			Operation:       op,
+			UserInfo:        v1authentication.UserInfo{Username: "test-user", UID: ""},
+			Object:          runtime.RawExtension{Raw: raw},
+			OldObject:       runtime.RawExtension{},
+		},
+		Context: context.Background(),
+	}
+}

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -114,7 +114,8 @@ func Mutation(clients *clients.Clients) ([]admission.MutatingAdmissionHandler, e
 		projects := project.NewMutator(clients.Core.Namespace().Cache(), clients.Management.RoleTemplate().Cache(), clients.Management.Project().Cache())
 		grbs := globalrolebinding.NewMutator(clients.Management.GlobalRole().Cache())
 		prtbs := projectroletemplatebinding.NewMutator()
-		mutators = append(mutators, secrets, projects, grbs, prtbs)
+		crtbs := clusterroletemplatebinding.NewMutator()
+		mutators = append(mutators, secrets, projects, grbs, prtbs, crtbs)
 	}
 
 	return mutators, nil


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/54007

## Problem

Duplicate CRTBs created if the same user is assigned the same role multiple times during downstream cluster provisioning.

## Solution

This PR adds a **mutating admission webhook** for `ClusterRoleTemplateBinding` resources that replaces the server-side random name generation with a **deterministic name** derived from the binding's content.

On `CREATE`, when `metadata.generateName` is set and `metadata.name` is empty (i.e. the caller expects a generated name), the mutator:

1. Determines the **subject** using the priority order: `userPrincipalName` → `userName` → `groupPrincipalName` → `groupName`.
2. Computes a deterministic name: `<generateName prefix> + lowercase(base32(sha256(subject + "/" + roleTemplateName + "/" + clusterName))[:10])`.
3. Sets `metadata.name` to this value and clears `metadata.generateName`.
4. Returns a JSON patch in the mutating response.

Two identical concurrent requests now produce the **same `metadata.name`**, causing the Kubernetes API server to reject the second with a **409 Conflict** — preventing duplicate CRTBs at the API level.

**Behavior boundaries:**
- If `metadata.name` is already set (i.e. the caller explicitly chose a name), **no mutation is performed**. This preserves backward compatibility for automations and the public API.
- If both `metadata.name` and `metadata.generateName` are empty, the request is **rejected** with a descriptive error.
- If no subject field is set, the request is **rejected** (the downstream validating webhook would also catch this, but failing early is clearer).


## CheckList

- [x] Test — Unit tests added in `mutator_test.go` covering: deterministic name generation, different inputs producing different names, valid K8s name characters, subject priority ordering, pass-through for explicit names, rejection for missing subjects, rejection for empty name+generateName, pass-through for non-CREATE operations, and idempotency of identical requests.
- [x] Docs — `ClusterRoleTemplateBinding.md` and `docs.md` updated to document the new mutating webhook behavior (deterministic name generation) and the duplicate prevention validation.
