### PR TITLE
Prevent major/minor Go version bumps on release branches

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -57,6 +57,13 @@
       "enabled": false
     },
     {
+      "description": "Do not bump the Go minor/major version on release branches - prevents immortal PRs from deps that require a newer Go",
+      "matchDepNames": ["go"],
+      "matchUpdateTypes": ["major", "minor"],
+      "matchBaseBranches": ["/^release\\//"],
+      "enabled": false
+    },
+    {
       "description": "Group all GitHub Actions updates into a single PR per branch",
       "matchManagers": ["github-actions"],
       "groupName": "GitHub Actions",


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/44967