### PR TITLE
Replace push:tags release trigger with validated workflow_dispatch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,20 +1,106 @@
-name: release
+name: Release
 
 on:
-  push:
-    tags:
-      - v*
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g. v0.5.1)'
+        required: true
+        type: string
 
-permissions:
-  contents: write
+permissions: {}
 
 env:
   REGISTRY: docker.io
   REPO: rancher
 
 jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
+      - name: Validate version format
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if ! [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Version '$VERSION' must match v<major>.<minor>.<patch>[-prerelease]"
+            exit 1
+          fi
+
+      - name: Resolve allowed minor from VERSION.md
+        id: minor
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          table=$(gh api "repos/$GITHUB_REPOSITORY/contents/VERSION.md" --jq .content | base64 -d)
+          allowed=$(awk -F'|' -v b="$GITHUB_REF_NAME" '
+            /^\|[-: |]+\|?[[:space:]]*$/ { in_table = 1; next }
+            in_table && NF >= 4 {
+              gsub(/^ +| +$/, "", $2)
+              gsub(/^ +| +$/, "", $3)
+              if ($2 == b) { print $3; exit }
+            }
+          ' <<< "$table")
+          if [ -z "$allowed" ]; then
+            echo "::error::Branch '$GITHUB_REF_NAME' not found in default-branch VERSION.md"
+            exit 1
+          fi
+          echo "Branch '$GITHUB_REF_NAME' is allowed minor '$allowed'"
+          echo "allowed=$allowed" >> "$GITHUB_OUTPUT"
+
+      - name: Validate version matches branch's allowed minor
+        env:
+          VERSION: ${{ inputs.version }}
+          ALLOWED: ${{ steps.minor.outputs.allowed }}
+        run: |
+          if [[ "$VERSION" != "${ALLOWED}."* ]]; then
+            echo "::error::Version $VERSION does not belong to branch $GITHUB_REF_NAME (allowed minor: $ALLOWED)"
+            exit 1
+          fi
+
+      - name: Validate version is next-sequential
+        env:
+          VERSION: ${{ inputs.version }}
+          ALLOWED: ${{ steps.minor.outputs.allowed }}
+        run: |
+          v_core="${VERSION%%-*}"
+          latest=$(git tag -l "${ALLOWED}.*" | grep -v -- '-' | sort -V | tail -n1 || true)
+          if [ -z "$latest" ]; then
+            if [ "$v_core" != "${ALLOWED}.0" ]; then
+              echo "::error::No prior ${ALLOWED} tags; first version must be ${ALLOWED}.0 (got $v_core)"
+              exit 1
+            fi
+            echo "First release on ${ALLOWED} line: OK"
+          else
+            patch="${latest##*.}"
+            expected="${ALLOWED}.$((patch + 1))"
+            if [ "$v_core" != "$expected" ]; then
+              echo "::error::Latest ${ALLOWED} tag is $latest; next must be $expected (got $v_core)"
+              exit 1
+            fi
+            echo "Next sequential after $latest: OK"
+          fi
+
+      - name: Validate tag does not already exist
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if git rev-parse "$VERSION" >/dev/null 2>&1; then
+            echo "::error::Tag '$VERSION' already exists"
+            exit 1
+          fi
+
   build:
+    needs: validate
     name: build and package
     runs-on: ubuntu-latest
     strategy:
@@ -24,13 +110,17 @@ jobs:
         - arm64
     steps:
 
-    - name : Checkout repository
+    - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Build Binary
+      env:
+        GIT_TAG: ${{ inputs.version }}
       run: make build ARCH=${{ matrix.arch }}
 
     - name: Package Helm Chart
+      env:
+        GIT_TAG: ${{ inputs.version }}
       run: make package-helm
 
     - name: Prepare Artifacts
@@ -51,15 +141,19 @@ jobs:
           dist/artifacts/rancher-webhook-*.tgz
 
   release:
-    needs: build
+    needs: [validate, build]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
 
-    - name : Checkout repository
+    - name: Checkout repository
        # https://github.com/actions/checkout/releases/tag/v4.1.1
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-    - name: package-helm
+    - name: Package Helm Chart
+      env:
+        GIT_TAG: ${{ inputs.version }}
       run: make package-helm
 
     - name: Download the amd64 artifacts
@@ -76,20 +170,31 @@ jobs:
         name: webhook-artifacts-arm64
         path: dist/artifacts
 
-    - name: Get the version
+    - name: Configure git identity
       run: |
-        source ./scripts/version
-        echo "TAG=$(echo $TAG | sed 's/-amd64$//')" >> $GITHUB_ENV
+        git config user.name 'github-actions[bot]'
+        git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+    - name: Create and push tag
+      env:
+        VERSION: ${{ inputs.version }}
+      run: |
+        git tag -a "$VERSION" -m "Release $VERSION"
+        git push origin "$VERSION"
 
     - name: Upload the files
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        VERSION: ${{ inputs.version }}
       run: |
         ls -lR dist
         cd dist/artifacts
-        gh --repo "${{ github.repository }}" release create ${{ github.ref_name }} --prerelease --verify-tag --generate-notes webhook-linux-* sha256sum-*.txt rancher-webhook*.tgz
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        flags="--verify-tag --generate-notes"
+        [[ "$VERSION" == *-rc* ]] && flags="$flags --prerelease"
+        gh --repo "$GITHUB_REPOSITORY" release create "$VERSION" $flags webhook-linux-* sha256sum-*.txt rancher-webhook*.tgz
 
   publish:
+    needs: validate
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -112,9 +217,9 @@ jobs:
         uses: rancher/ecm-distro-tools/actions/publish-image@dcb1a0f50ca91f9f9a1f34fa335a9182686234d5 # v0.66.3
         with:
           image: rancher-webhook
-          tag: ${{ github.ref_name }}
+          tag: ${{ inputs.version }}
           platforms: linux/amd64,linux/arm64
-          
+
           public-registry: docker.io
           public-repo: rancher
           public-username: ${{ env.DOCKER_USERNAME }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
         run: |
-          if ! [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(?:-[a-zA-Z0-9.]+)?$ ]]; then
+          if ! [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
             echo "::error::Version '$VERSION' must match v<major>.<minor>.<patch>[-prerelease]"
             exit 1
           fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
         run: |
-          if ! [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+          if ! [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(?:-[a-zA-Z0-9.]+)?$ ]]; then
             echo "::error::Version '$VERSION' must match v<major>.<minor>.<patch>[-prerelease]"
             exit 1
           fi
@@ -42,14 +42,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           table=$(gh api "repos/$GITHUB_REPOSITORY/contents/VERSION.md" --jq .content | base64 -d)
-          allowed=$(awk -F'|' -v b="$GITHUB_REF_NAME" '
-            /^\|[-: |]+\|?[[:space:]]*$/ { in_table = 1; next }
-            in_table && NF >= 4 {
-              gsub(/^ +| +$/, "", $2)
-              gsub(/^ +| +$/, "", $3)
-              if ($2 == b) { print $3; exit }
-            }
-          ' <<< "$table")
+          allowed=$(grep -F "| $GITHUB_REF_NAME |" <<< "$table" | cut -d'|' -f3 | tr -d ' ')
           if [ -z "$allowed" ]; then
             echo "::error::Branch '$GITHUB_REF_NAME' not found in default-branch VERSION.md"
             exit 1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,7 +66,7 @@ jobs:
           ALLOWED: ${{ steps.minor.outputs.allowed }}
         run: |
           v_core="${VERSION%%-*}"
-          latest=$(git tag -l "${ALLOWED}.*" | grep -v -- '-' | sort -V | tail -n1 || true)
+          latest=$(git tag -l "${ALLOWED}.*" | grep -v -- '-' | sort --version-sort | tail -n1 || true)
           if [ -z "$latest" ]; then
             if [ "$v_core" != "${ALLOWED}.0" ]; then
               echo "::error::No prior ${ALLOWED} tags; first version must be ${ALLOWED}.0 (got $v_core)"

--- a/README.md
+++ b/README.md
@@ -224,3 +224,11 @@ limitations under the License.
 # Versioning
 
 See [VERSION.md](VERSION.md).
+
+# Releasing
+
+Releases are cut by triggering the [Release workflow](.github/workflows/release.yaml)
+from the GitHub Actions tab. Select the appropriate release branch (e.g. `release/v0.5`)
+and provide the version (e.g. `v0.5.1`) as input. The workflow validates the version
+against [VERSION.md](VERSION.md), creates the annotated tag, builds and publishes
+the binaries, Helm chart, and container image, and creates the GitHub release.


### PR DESCRIPTION
# Issue rancher/rancher#54790

Replace the `on: push: tags: v*` trigger with a `workflow_dispatch` workflow that validates the version before creating the tag and GitHub release.

The `validate` job:
- Checks version format (`v<major>.<minor>.<patch>[-prerelease]`)
- Confirms the version prefix matches the branch's allowed minor (read from `VERSION.md` on the default branch)
- Enforces sequential patch ordering within the minor line
- Confirms the tag does not already exist

The `release` job (runs after `validate`):
- Creates and pushes the annotated tag
- Creates the GitHub release with auto-generated notes