### PR TITLE
Add support for image pull secrets

### DIFF
--- a/charts/rancher-webhook/templates/_helpers.tpl
+++ b/charts/rancher-webhook/templates/_helpers.tpl
@@ -20,3 +20,26 @@ app: rancher-webhook
 {{- define "linux-node-selector" -}}
 kubernetes.io/os: linux
 {{- end -}}
+
+{{/*
+Renders imagePullSecrets, accepting either object references ({ name: <secret> })
+or plain strings.
+*/}}
+{{- define "rancher-webhook.imagePullSecrets" -}}
+{{- $pullSecrets := list -}}
+{{- range .Values.global.cattle.imagePullSecrets -}}
+  {{- if kindIs "map" . -}}
+    {{- if .name -}}
+      {{- $pullSecrets = append $pullSecrets .name -}}
+    {{- end -}}
+  {{- else if not (empty .) -}}
+    {{- $pullSecrets = append $pullSecrets . -}}
+  {{- end -}}
+{{- end -}}
+{{- if not (empty $pullSecrets) -}}
+imagePullSecrets:
+  {{- range $pullSecrets | uniq }}
+  - name: {{ . }}
+  {{- end }}
+{{- end -}}
+{{- end -}}

--- a/charts/rancher-webhook/templates/deployment.yaml
+++ b/charts/rancher-webhook/templates/deployment.yaml
@@ -83,3 +83,4 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{.Values.priorityClassName}}"
       {{- end }}
+      {{- include "rancher-webhook.imagePullSecrets" . | nindent 6 }}

--- a/charts/rancher-webhook/tests/deployment_test.yaml
+++ b/charts/rancher-webhook/tests/deployment_test.yaml
@@ -88,3 +88,38 @@ tests:
           path: spec.template.spec.hostNetwork
       - notExists:
           path: spec.template.spec.dnsPolicy
+
+  - it: should not set imagePullSecrets by default
+    asserts:
+      - notExists:
+          path: spec.template.spec.imagePullSecrets
+
+  - it: should set imagePullSecrets when configured with plain strings
+    set:
+      global.cattle.imagePullSecrets:
+        - my-registry-secret
+        - another-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.imagePullSecrets
+          content:
+            name: my-registry-secret
+      - contains:
+          path: spec.template.spec.imagePullSecrets
+          content:
+            name: another-secret
+
+  - it: should set imagePullSecrets when configured with object references
+    set:
+      global.cattle.imagePullSecrets:
+        - name: my-registry-secret
+        - name: another-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.imagePullSecrets
+          content:
+            name: my-registry-secret
+      - contains:
+          path: spec.template.spec.imagePullSecrets
+          content:
+            name: another-secret

--- a/charts/rancher-webhook/values.yaml
+++ b/charts/rancher-webhook/values.yaml
@@ -6,6 +6,9 @@ image:
 global:
   cattle:
     systemDefaultRegistry: ""
+    # imagePullSecrets:
+    #   - name: secret1
+    imagePullSecrets: []
   hostNetwork: false
 
 mcm:

--- a/charts/rancher-webhook/values.yaml
+++ b/charts/rancher-webhook/values.yaml
@@ -6,8 +6,6 @@ image:
 global:
   cattle:
     systemDefaultRegistry: ""
-    # imagePullSecrets:
-    #   - name: secret1
     imagePullSecrets: []
   hostNetwork: false
 


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/54806

## Problem
The webhook chart does not accept image pull secrets, preventing it from being deployed into environments which only have access to an authenticated image registry (e.g. secure air-gap environments) and cannot configure registry credentials at the container runtime level.

## Solution
Add `global.cattle.imagePullSecrets` to `values.yaml` and use it when deploying the webhook. A template helper was added to allow users to pass either a simple list of strings, or complete object references (e.g. `name: <secret>`). 

## CheckList
- [x] Test
Updated the helm unit test to account for this new field and the potential ways values can be provided

- [x] Docs
There doesn't seem to be a chart README, so no documentation updates. 