### PR TITLE
[v0.7] Bump bci-micro base image and Go toolchain to go1.24.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/rancher/webhook
 
 go 1.24.0
 
-toolchain go1.24.6
+toolchain go1.24.13
 
 replace (
 	github.com/google/cel-go => github.com/google/cel-go v0.22.0

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -90,7 +90,7 @@ COPY --from=integration-test-build /dist/rancher-webhook-integration.test /ranch
 # ===============
 # Final Stage
 # ===============
-FROM registry.suse.com/bci/bci-micro:15.7@sha256:5ca1a44ca5be8afd3e4abc721abf1efe6b0fe69b83cf01a0c204c16160913edc
+FROM registry.suse.com/bci/bci-micro:15.7@sha256:bda48a632ca318ff8b38ac3374b8928283c4e4145bcb2b046fd0369f97865fb9
 
 ARG user=webhook
 


### PR DESCRIPTION
# Issue https://github.com/rancher/rancher/issues/54040

- Bumped final stage base image to `registry.suse.com/bci/bci-micro:15.7@sha256:bda48a632ca318ff8b38ac3374b8928283c4e4145bcb2b046fd0369f97865fb9`
- Bumped Go toolchain from `go1.24.6` to `go1.24.13` in `go.mod`