### PR TITLE
[release/v0.7] Split release workflow into Cut release and On release

### DIFF
--- a/.github/workflows/cut-release.yaml
+++ b/.github/workflows/cut-release.yaml
@@ -1,0 +1,118 @@
+name: Cut release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g. v0.5.1)'
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
+      - name: Validate version format
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if ! [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Version '$VERSION' must match v<major>.<minor>.<patch>[-prerelease]"
+            exit 1
+          fi
+
+      - name: Resolve allowed minor from VERSION.md
+        id: minor
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          table=$(gh api "repos/$GITHUB_REPOSITORY/contents/VERSION.md" --jq .content | base64 -d)
+          allowed=$(grep -F "| $GITHUB_REF_NAME |" <<< "$table" | cut -d'|' -f3 | tr -d ' ')
+          if [ -z "$allowed" ]; then
+            echo "::error::Branch '$GITHUB_REF_NAME' not found in default-branch VERSION.md"
+            exit 1
+          fi
+          echo "Branch '$GITHUB_REF_NAME' is allowed minor '$allowed'"
+          echo "allowed=$allowed" >> "$GITHUB_OUTPUT"
+
+      - name: Validate version matches branch's allowed minor
+        env:
+          VERSION: ${{ inputs.version }}
+          ALLOWED: ${{ steps.minor.outputs.allowed }}
+        run: |
+          if [[ "$VERSION" != "${ALLOWED}."* ]]; then
+            echo "::error::Version $VERSION does not belong to branch $GITHUB_REF_NAME (allowed minor: $ALLOWED)"
+            exit 1
+          fi
+
+      - name: Validate version is next-sequential
+        env:
+          VERSION: ${{ inputs.version }}
+          ALLOWED: ${{ steps.minor.outputs.allowed }}
+        run: |
+          v_core="${VERSION%%-*}"
+          latest=$(git tag -l "${ALLOWED}.*" | grep -v -- '-' | sort --version-sort | tail -n1 || true)
+          if [ -z "$latest" ]; then
+            if [ "$v_core" != "${ALLOWED}.0" ]; then
+              echo "::error::No prior ${ALLOWED} tags; first version must be ${ALLOWED}.0 (got $v_core)"
+              exit 1
+            fi
+            echo "First release on ${ALLOWED} line: OK"
+          else
+            patch="${latest##*.}"
+            expected="${ALLOWED}.$((patch + 1))"
+            if [ "$v_core" != "$expected" ]; then
+              echo "::error::Latest ${ALLOWED} tag is $latest; next must be $expected (got $v_core)"
+              exit 1
+            fi
+            echo "Next sequential after $latest: OK"
+          fi
+
+      - name: Validate tag does not already exist
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if git rev-parse "$VERSION" >/dev/null 2>&1; then
+            echo "::error::Tag '$VERSION' already exists"
+            exit 1
+          fi
+
+  tag:
+    needs: validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Configure git identity
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - name: Create and push tag
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          git tag -a "$VERSION" -m "Release $VERSION"
+          git push origin "$VERSION"
+
+      - name: Trigger On release workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          gh workflow run release.yaml --repo "$GITHUB_REPOSITORY" --ref "$VERSION"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,20 +1,27 @@
-name: release
+name: On release
 
 on:
-  push:
-    tags:
-      - v*
   workflow_dispatch:
 
-permissions:
-  contents: write
+permissions: {}
 
 env:
   REGISTRY: docker.io
   REPO: rancher
 
 jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure ref is a tag
+        run: |
+          if [ "$GITHUB_REF_TYPE" != "tag" ]; then
+            echo "::error::This workflow must be dispatched on a tag ref (got ${GITHUB_REF_TYPE} '${GITHUB_REF}')"
+            exit 1
+          fi
+
   build:
+    needs: guard
     name: build and package
     runs-on: ubuntu-latest
     strategy:
@@ -24,14 +31,17 @@ jobs:
         - arm64
     steps:
 
-    - name : Checkout repository
-      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-      # https://github.com/actions/checkout/releases/tag/v4.1.1
+    - name: Checkout repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Build Binary
+      env:
+        GIT_TAG: ${{ github.ref_name }}
       run: make build ARCH=${{ matrix.arch }}
 
     - name: Package Helm Chart
+      env:
+        GIT_TAG: ${{ github.ref_name }}
       run: make package-helm
 
     - name: Prepare Artifacts
@@ -43,7 +53,7 @@ jobs:
 
     - name: Upload artifacts
       # https://github.com/actions/upload-artifact/commit/65462800fd760344b1a7b4382951275a0abb4808
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: webhook-artifacts-${{ matrix.arch }}
         path: |
@@ -54,52 +64,53 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
 
-    - name : Checkout repository
+    - name: Checkout repository
        # https://github.com/actions/checkout/releases/tag/v4.1.1
-      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-    - name: package-helm
+    - name: Package Helm Chart
+      env:
+        GIT_TAG: ${{ github.ref_name }}
       run: make package-helm
 
     - name: Download the amd64 artifacts
-      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       # https://github.com/actions/download-artifact/releases/tag/v4.1.7
       with:
         name: webhook-artifacts-amd64
         path: dist/artifacts
 
     - name: Download the arm64 artifacts
-      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       # https://github.com/actions/download-artifact/releases/tag/v4.1.7
       with:
         name: webhook-artifacts-arm64
         path: dist/artifacts
 
-    - name: Get the version
-      run: |
-        source ./scripts/version
-        echo "TAG=$(echo $TAG | sed 's/-amd64$//')" >> $GITHUB_ENV
-
     - name: Upload the files
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        VERSION: ${{ github.ref_name }}
       run: |
         ls -lR dist
         cd dist/artifacts
-        gh --repo "${{ github.repository }}" release create ${{ github.ref_name }} --prerelease --verify-tag --generate-notes webhook-linux-* sha256sum-*.txt rancher-webhook*.tgz
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        flags="--verify-tag --generate-notes"
+        [[ "$VERSION" == *-rc* ]] && flags="$flags --prerelease"
+        gh --repo "$GITHUB_REPOSITORY" release create "$VERSION" $flags webhook-linux-* sha256sum-*.txt rancher-webhook*.tgz
 
   publish:
+    needs: guard
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write # Required for cosign signing
     steps:
-      - name : Checkout repository
-        # https://github.com/actions/checkout/releases/tag/v4.1.1
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: "Read vault secrets"
         uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
@@ -112,12 +123,12 @@ jobs:
             secret/data/github/repo/${{ github.repository }}/rancher-prime-stg-registry/credentials password | PRIME_STG_REGISTRY_PASSWORD
 
       - name: Publish image
-        uses: rancher/ecm-distro-tools/actions/publish-image@master
+        uses: rancher/ecm-distro-tools/actions/publish-image@dcb1a0f50ca91f9f9a1f34fa335a9182686234d5 # v0.66.3
         with:
           image: rancher-webhook
           tag: ${{ github.ref_name }}
           platforms: linux/amd64,linux/arm64
-          
+
           public-registry: docker.io
           public-repo: rancher
           public-username: ${{ env.DOCKER_USERNAME }}
@@ -130,4 +141,3 @@ jobs:
           prime-registry: ${{ env.PRIME_STG_REGISTRY }}
           prime-username: ${{ env.PRIME_STG_REGISTRY_USERNAME }}
           prime-password: ${{ env.PRIME_STG_REGISTRY_PASSWORD }}
-

--- a/README.md
+++ b/README.md
@@ -200,3 +200,13 @@ limitations under the License.
 # Versioning
 
 See [VERSION.md](VERSION.md).
+
+# Releasing
+
+Releases are cut by triggering the [Cut release workflow](.github/workflows/cut-release.yaml)
+from the GitHub Actions tab. Select this release branch and provide the version
+(e.g. `v0.7.10`) as input. The workflow validates the version against
+[VERSION.md](VERSION.md) on the default branch, creates the annotated tag, and
+dispatches the [On release workflow](.github/workflows/release.yaml) on the new
+tag, which builds and publishes the binaries, Helm chart, and container image,
+and creates the GitHub release.


### PR DESCRIPTION
# Issue rancher/rancher#54790

Backport of #1414 + #1428 to release/v0.7.

## Summary

Splits the release workflow into two `workflow_dispatch` workflows:

- **`.github/workflows/cut-release.yaml`** ("Cut release") — entry point. Validates the version against `VERSION.md` (read from the default branch), creates and pushes the annotated tag, then dispatches the On release workflow at the new tag ref.
- **`.github/workflows/release.yaml`** ("On release") — `workflow_dispatch`. Builds, creates the GitHub release, and publishes the image. A guard job rejects any dispatch on a non-tag ref.

## Why

The publish-image action's cosign provenance check verifies a SAN of the form:

```
^https://github.com/<org>/webhook/.github/workflows/release.(yml|yaml)@refs/tags/<tag>$
```

Dispatching On release at the new tag ref produces a SAN matching `refs/tags/v*`.

A `push: tags` trigger does not work here: GitHub blocks workflow runs triggered by `GITHUB_TOKEN` from starting other runs via push events, so the tag pushed by Cut release does not fire On release. `workflow_dispatch` is exempt from that restriction, which is why the second workflow uses `workflow_dispatch` and Cut release calls `gh workflow run release.yaml --ref <tag>`.