### PR TITLE
[release/v0.10] Add and use push-prime-image target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,15 +81,18 @@ push-image:
 	@bash -c 'source scripts/version && \
 	docker buildx build \
 		$${IID_FILE_FLAG} \
+		$(BUILDX_ARGS) \
 		--file package/Dockerfile \
 		--build-arg VERSION=$${VERSION} \
 		--build-arg COMMIT=$${COMMIT} \
 		--platform=$${TARGET_PLATFORMS} \
-		--sbom=true \
-		--attest type=provenance,mode=max \
 		-t $${REPO}/rancher-webhook:$${TAG} \
 		--push \
 		. '
+
+push-prime-image:
+	BUILDX_ARGS="--sbom=true --attest type=provenance,mode=max" \
+	$(MAKE) push-image
 
 # ci target is for CI, ensuring tests and validation run first
 ci: test validate image package-helm


### PR DESCRIPTION
# Issue rancher/rancher#54790

Backport of #1304 to release/v0.10.

## Why

The Cut release split PR (#1434) brought `prime-make-target: push-prime-image` into the On release workflow on this branch, but the corresponding `push-prime-image` Makefile target was never added — the workflow now invokes a target that doesn't exist on release/v0.10.

#1304 adds the target. With this backport applied, `prime-make-target: push-prime-image` resolves correctly.

## Notes on the other PRs in this chain

- #1220 (sbom + provenance for push-image): already present on release/v0.10. The cherry-pick was a no-op.
- #1332 (identity-registry org variable): already present on release/v0.10 — it was included verbatim when #1434 copied main's `release.yaml`. The cherry-pick was a no-op.