### PR TITLE
fix: register ProxyEndpoint in codegen

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -555,7 +555,22 @@ The subject is resolved using the following priority order:
 
 If no subject is set, the mutator passes the request through without modification (the validating webhook will reject it).
 
-This ensures that two identical concurrent requests produce the same resource name. The Kubernetes API server will reject the second request with a `409 Conflict`, preventing duplicate bindings even when requests race past the validating webhook.
+This ensures that two identical concurrent requests using `generateName` produce the same resource name. The Kubernetes API server will reject the second request with a `409 Conflict`, preventing duplicate bindings even when requests race past the validating webhook.
+
+## ProxyEndpoint
+
+### Validation Checks
+
+#### Overly Broad Wildcard Check
+
+Users may only create route entries within a ProxyEndpoint CR which
+
++ Are Absolute domains (`www.myapi.com`)
++ Are partial, inline, wildcards (`www.%.myapi.com`)
++ Are prefix wildcards (`*.myapi.com`, `*myapi.com`)
++ Do not include protocols (`https://`, etc.)
+
+Some of these checks are also done before a request is sent to the webhook, using kubebuilder Pattern comments on the CRD itself. Others, such as the overly broad wildcard check (e.g. `%.com`, `subdomain.%.com`), are done in the webhook as a regular expression would not be sufficient. In the event that the webhook is not running, the Rancher proxy also verifies that the route is not overly broad and silently ignores it if it is.  
 
 ## RoleTemplate
 
@@ -682,22 +697,6 @@ When a UserAttribute is updated, the following checks take place:
 - If set, `lastLogin` must be a valid date time according to RFC3339 (e.g. `2023-11-29T00:00:00Z`).
 - If set, `disableAfter` must be zero or a positive duration (e.g. `240h`).
 - If set, `deleteAfter` must be zero or a positive duration (e.g. `240h`).
-
-## ProxyEndpoint
-
-### Validation Checks
-
-#### On Create
-
-##### Domain Route Broadness
-
-Any domain included in a ProxyEndpoint Route entry must not be overly broad. If the domain includes an overly broad wildcard (e.g. `*.com`, `*.example.%.co.uk`, `%.co.uk`, etc.) it will be denied.
-
-#### On Update
-
-##### Domain Route Broadness
-
-Any domain included in a ProxyEndpoint Route entry must not be overly broad. If the domain includes an overly broad wildcard (e.g. `*.com`, `*.example.%.co.uk`, `%.co.uk`, etc.) it will be denied.
 
 # provisioning.cattle.io/v1
 

--- a/pkg/codegen/main.go
+++ b/pkg/codegen/main.go
@@ -93,6 +93,7 @@ func main() {
 				&v3.ProjectRoleTemplateBinding{},
 				&v3.NodeDriver{},
 				&v3.Project{},
+				&v3.ProxyEndpoint{},
 				&v3.Setting{},
 				&v3.AuthConfig{},
 				&v3.User{},

--- a/pkg/generated/objects/management.cattle.io/v3/objects.go
+++ b/pkg/generated/objects/management.cattle.io/v3/objects.go
@@ -591,6 +591,59 @@ func ProjectFromRequest(request *admissionv1.AdmissionRequest) (*v3.Project, err
 	return object, nil
 }
 
+// ProxyEndpointOldAndNewFromRequest gets the old and new ProxyEndpoint objects, respectively, from the webhook request.
+// If the request is a Delete operation, then the new object is the zero value for ProxyEndpoint.
+// Similarly, if the request is a Create operation, then the old object is the zero value for ProxyEndpoint.
+func ProxyEndpointOldAndNewFromRequest(request *admissionv1.AdmissionRequest) (*v3.ProxyEndpoint, *v3.ProxyEndpoint, error) {
+	if request == nil {
+		return nil, nil, fmt.Errorf("nil request")
+	}
+
+	object := &v3.ProxyEndpoint{}
+	oldObject := &v3.ProxyEndpoint{}
+
+	if request.Operation != admissionv1.Delete {
+		err := json.Unmarshal(request.Object.Raw, object)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to unmarshal request object: %w", err)
+		}
+	}
+
+	if request.Operation == admissionv1.Create {
+		return oldObject, object, nil
+	}
+
+	err := json.Unmarshal(request.OldObject.Raw, oldObject)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to unmarshal request oldObject: %w", err)
+	}
+
+	return oldObject, object, nil
+}
+
+// ProxyEndpointFromRequest returns a ProxyEndpoint object from the webhook request.
+// If the operation is a Delete operation, then the old object is returned.
+// Otherwise, the new object is returned.
+func ProxyEndpointFromRequest(request *admissionv1.AdmissionRequest) (*v3.ProxyEndpoint, error) {
+	if request == nil {
+		return nil, fmt.Errorf("nil request")
+	}
+
+	object := &v3.ProxyEndpoint{}
+	raw := request.Object.Raw
+
+	if request.Operation == admissionv1.Delete {
+		raw = request.OldObject.Raw
+	}
+
+	err := json.Unmarshal(raw, object)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal request object: %w", err)
+	}
+
+	return object, nil
+}
+
 // SettingOldAndNewFromRequest gets the old and new Setting objects, respectively, from the webhook request.
 // If the request is a Delete operation, then the new object is the zero value for Setting.
 // Similarly, if the request is a Create operation, then the old object is the zero value for Setting.
@@ -748,51 +801,4 @@ func UserFromRequest(request *admissionv1.AdmissionRequest) (*v3.User, error) {
 	}
 
 	return object, nil
-}
-
-func ProxyEndpointFromRequest(request *admissionv1.AdmissionRequest) (*v3.ProxyEndpoint, error) {
-	if request == nil {
-		return nil, fmt.Errorf("nil request")
-	}
-
-	obj := &v3.ProxyEndpoint{}
-	raw := request.Object.Raw
-
-	if request.Operation == admissionv1.Delete {
-		raw = request.OldObject.Raw
-	}
-
-	err := json.Unmarshal(raw, obj)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal request object: %w", err)
-	}
-
-	return obj, nil
-}
-
-func ProxyEndpointOldAndNewFromRequest(request *admissionv1.AdmissionRequest) (*v3.ProxyEndpoint, *v3.ProxyEndpoint, error) {
-	if request == nil {
-		return nil, nil, fmt.Errorf("nil request")
-	}
-
-	object := &v3.ProxyEndpoint{}
-	oldObject := &v3.ProxyEndpoint{}
-
-	if request.Operation != admissionv1.Delete {
-		err := json.Unmarshal(request.Object.Raw, object)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to unmarshal request object: %w", err)
-		}
-	}
-
-	if request.Operation == admissionv1.Create {
-		return oldObject, object, nil
-	}
-
-	err := json.Unmarshal(request.OldObject.Raw, oldObject)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to unmarshal request oldObject: %w", err)
-	}
-
-	return oldObject, object, nil
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from other PRs, link them here and describe why they are needed for your solution section. -->
## Problem
Discovered while working on #1424: running `go run ./pkg/codegen` was silently removing `ProxyEndpointFromRequest` and `ProxyEndpointOldAndNewFromRequest` from `objects.go`, causing a build [failure](https://github.com/rancher/webhook/actions/runs/25345350207/job/74313750315):

```
pkg/resources/management.cattle.io/v3/proxyendpoint/validator.go:54:64: undefined: v3.ProxyEndpointFromRequest
```

The root cause was that `ProxyEndpoint` was never registered in the `generateObjectsFromRequest` types list in `main.go`, so the codegen template was unaware of it and would overwrite the file without it.

## Solution
Added `&v3.ProxyEndpoint{}` to the `generateObjectsFromRequest` and re-ran codegen. The helpers are now properly template-generated and should survive future codegen runs.

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [ ] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [x] Docs