### PR TITLE
Bump github.com/rancher/norman to v0.9.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/rancher/dynamiclistener v0.8.0
 	github.com/rancher/jsonpath v0.0.0-20250620213443-ad24535cf0c1
-	github.com/rancher/lasso v0.2.7
+	github.com/rancher/lasso v0.2.8
 	github.com/rancher/rancher/pkg/apis v0.0.0-20260211194119-d0c9ffaf3cb0
 	github.com/rancher/rke v1.8.13
 	github.com/rancher/wrangler/v3 v3.5.0-rc.2
@@ -107,7 +107,7 @@ require (
 	github.com/rancher/eks-operator v1.13.0-rc.4 // indirect
 	github.com/rancher/fleet/pkg/apis v0.15.0-alpha.6 // indirect
 	github.com/rancher/gke-operator v1.13.0-rc.3 // indirect
-	github.com/rancher/norman v0.9.2
+	github.com/rancher/norman v0.9.3
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/x448/float16 v0.8.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -150,10 +150,10 @@ github.com/rancher/gke-operator v1.13.0-rc.3 h1:a6U+7+XIbJPH2CE7/vFUx6RpThNbFl7f
 github.com/rancher/gke-operator v1.13.0-rc.3/go.mod h1:TroxpmqMh63Hf4H5bC+2GYcgOCQp9kIUDfyKdNAMo6Q=
 github.com/rancher/jsonpath v0.0.0-20250620213443-ad24535cf0c1 h1:vRtxuvIF0UarXIAwGYNwSFoRYJadVnOrD8kx2qrZyN8=
 github.com/rancher/jsonpath v0.0.0-20250620213443-ad24535cf0c1/go.mod h1:xavYr3cNyyAeA72nMVB60+q/EJ8Anu+loQWFJyXOeP8=
-github.com/rancher/lasso v0.2.7 h1:N56Pm8KJSk7gRVYILSGb35QBfjcDDeGFMfwUCivsbeg=
-github.com/rancher/lasso v0.2.7/go.mod h1:L3ol8PdO21KoMhNa3RWjpR3ZBnE70JCAod1nJuOvT1E=
-github.com/rancher/norman v0.9.2 h1:cSNxHSnkX6vn7G7AkI9q+jUII0tPf/Hcnh7jB+yuI/g=
-github.com/rancher/norman v0.9.2/go.mod h1:K/LReJLm1ZK1JtuyoP3FblcEWu3Stoc3l/PGz1RZphU=
+github.com/rancher/lasso v0.2.8 h1:AhAk1AKz9ZpvPlFj07JKRYGzIxaPNywUs2LpSwcyGDU=
+github.com/rancher/lasso v0.2.8/go.mod h1:HyENYowaiGY9jnsyxLnhGfoOBZlU3y+lws8qCYyuBOc=
+github.com/rancher/norman v0.9.3 h1:dxNbxtea6GEXWshrCcxQxjodZNSuyIxBlJ472OBiMcQ=
+github.com/rancher/norman v0.9.3/go.mod h1:la3oS4sgFfRvQVxAQxAwSkXnO8kaAIyhBscnHIVtqN8=
 github.com/rancher/rancher/pkg/apis v0.0.0-20260211194119-d0c9ffaf3cb0 h1:ZH9VeY2iUVZN0YFU59dhBiHbdOpFJMvVo91k0fwwMME=
 github.com/rancher/rancher/pkg/apis v0.0.0-20260211194119-d0c9ffaf3cb0/go.mod h1:fEL3ATWhwqdn7VYVAQBhmdpKehY5lDeGNlq2NnOpUPk=
 github.com/rancher/rke v1.8.13 h1:DDJ6bj1ucPRmmCQkJ39tiP40st3UlVduBp4/tuhk2L0=


### PR DESCRIPTION
Automated bump of `github.com/rancher/norman` to `v0.9.3` on `main`.

Tracker: https://github.com/tomleb/frameworks-automation/issues/118

This PR was opened by the release-automation reconciler. CI will run on push; review and merge as usual.
