### PR TITLE
Improve inconsistency in RTB validation webhooks

### DIFF
--- a/pkg/resources/management.cattle.io/v3/clusterroletemplatebinding/validator.go
+++ b/pkg/resources/management.cattle.io/v3/clusterroletemplatebinding/validator.go
@@ -127,9 +127,6 @@ func (a *admitter) Admit(request *admission.Request) (*admissionv1.AdmissionResp
 
 	roleTemplate, err := a.roleTemplateResolver.RoleTemplateCache().Get(crtb.RoleTemplateName)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return &admissionv1.AdmissionResponse{Allowed: true}, nil
-		}
 		return nil, fmt.Errorf("failed to get roletemplate '%s': %w", crtb.RoleTemplateName, err)
 	}
 

--- a/pkg/resources/management.cattle.io/v3/projectroletemplatebinding/validator.go
+++ b/pkg/resources/management.cattle.io/v3/projectroletemplatebinding/validator.go
@@ -127,11 +127,6 @@ func (a *admitter) Admit(request *admission.Request) (*admissionv1.AdmissionResp
 
 	roleTemplate, err := a.roleTemplateResolver.RoleTemplateCache().Get(prtb.RoleTemplateName)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return &admissionv1.AdmissionResponse{
-				Allowed: true,
-			}, nil
-		}
 		return nil, fmt.Errorf("failed to get referenced roleTemplate '%s' for PRTB: %w", roleTemplate.Name, err)
 	}
 
@@ -207,6 +202,9 @@ func (a *admitter) validateCreateFields(newPRTB *apisv3.ProjectRoleTemplateBindi
 
 	roleTemplate, err := a.roleTemplateResolver.RoleTemplateCache().Get(newPRTB.RoleTemplateName)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return field.Invalid(fieldPath.Child("roleTemplateName"), newPRTB.RoleTemplateName, "the referenced role template was not found")
+		}
 		return err
 	}
 


### PR DESCRIPTION
## Problem
In both the CRTB and PRTB webhooks, in the `validateCreateFields` functions we check if the RoleTemplate referenced exists. If it doesn't exist we don't allow the RTB to be created.

However, later on in the validation code, we fetch the RoleTemplate so we can check the rules. If the RoleTemplate isn't found, it returns with an "Allow" response. It's not possible to get to that point since the previous check has to pass. This can lead to false positives when scanning and is generally a little confusing.

## Solution
I removed the "Allow" response, instead just returning an error.

I also improved the PRTB check for RoleTemplate by returning a `field.Invalid` response instead of an error. This way it matches the CRTB validation.

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [ ] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [ ] Docs