### PR TITLE
Add a daily scheduled workflow that fans out sync-deps workflow

### DIFF
--- a/.github/workflows/sync-deps-scheduled.yaml
+++ b/.github/workflows/sync-deps-scheduled.yaml
@@ -1,0 +1,46 @@
+name: Sync dependencies (scheduled)
+
+on:
+  schedule:
+    # 09:00 UTC daily
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: sync-deps-scheduled
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  compute-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      include: ${{ steps.build.outputs.include }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Build matrix from VERSION.md
+        id: build
+        run: |
+          include=$(awk -F'[|[:space:]]+' '
+            $2 == "main" || $2 ~ /^release\// {
+              rancher = ($2 == "main") ? "main" : "release/" $4
+              printf "{\"webhook_ref\":\"%s\",\"rancher_ref\":\"%s\"}\n", $2, rancher
+              if (++n >= 6) exit
+            }' VERSION.md | jq -cs .)
+          echo "include=$include" >> "$GITHUB_OUTPUT"
+          echo "Computed matrix: [$include]"
+
+  sync:
+    needs: compute-matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.compute-matrix.outputs.include) }}
+    uses: ./.github/workflows/sync-deps.yaml
+    with:
+      webhook_ref: ${{ matrix.webhook_ref }}
+      rancher_ref: ${{ matrix.rancher_ref }}

--- a/.github/workflows/sync-deps.yaml
+++ b/.github/workflows/sync-deps.yaml
@@ -11,10 +11,29 @@ on:
         description: "Repository for rancher/rancher"
         required: true
         default: "rancher/rancher"
+  workflow_call:
+    inputs:
+      webhook_ref:
+        description: "Webhook branch to sync"
+        required: true
+        type: string
+      rancher_ref:
+        description: "Version of rancher/rancher to compare"
+        required: true
+        type: string
+      rancher_repository:
+        description: "Repository for rancher/rancher"
+        required: false
+        type: string
+        default: "rancher/rancher"
 
 env:
-  RANCHER_REF: "${{ github.event.inputs.rancher_ref }}"
-  WEBHOOK_REF: "${{ github.ref_name }}"
+  RANCHER_REF: "${{ inputs.rancher_ref }}"
+  WEBHOOK_REF: "${{ inputs.webhook_ref || github.ref_name }}"
+
+concurrency:
+  group: sync-deps-${{ inputs.webhook_ref || github.ref_name }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -53,7 +72,7 @@ jobs:
       - name : Checkout rancher repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: "${{ github.event.inputs.rancher_repository }}"
+          repository: "${{ inputs.rancher_repository }}"
           ref: "${{ env.RANCHER_REF }}"
           path: rancher
 
@@ -73,14 +92,15 @@ jobs:
       - name: Run sync-deps script
         run: |
           cd webhook
-          BRANCH="sync-deps-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          safe_ref=$(echo "$WEBHOOK_REF" | tr '/' '-')
+          BRANCH="automation/sync-deps-${safe_ref}"
           echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
-          git checkout -b "$BRANCH"
+          git checkout -B "$BRANCH" "origin/$WEBHOOK_REF"
           ./.github/workflows/scripts/sync-deps.sh ../rancher "changes.md"
           if [ -f changes.md ]; then
             git add go.mod go.sum
             git commit -m "Sync dependencies"
-            git push origin "$BRANCH"
+            git push --force origin "$BRANCH"
           fi
 
       - name: Create PR
@@ -97,12 +117,22 @@ jobs:
           The workflow was triggered by $GITHUB_TRIGGERING_ACTOR.
           EOF
           )
-          gh pr create \
-            --title "[$WEBHOOK_REF] Sync webhook dependencies" \
-            --body "$body" \
-            --reviewer "$GITHUB_TRIGGERING_ACTOR" \
+          existing=$(gh pr list \
             --repo "${{ github.repository }}" \
-            --head "${{ github.repository_owner }}:$BRANCH" \
-            --base "$WEBHOOK_REF"
+            --head "$BRANCH" \
+            --base "$WEBHOOK_REF" \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh pr edit "$existing" --body "$body"
+          else
+            gh pr create \
+              --title "[$WEBHOOK_REF] Sync webhook dependencies" \
+              --body "$body" \
+              --repo "${{ github.repository }}" \
+              --head "${{ github.repository_owner }}:$BRANCH" \
+              --base "$WEBHOOK_REF"
+          fi
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Why
Automate the manual "run sync-deps per branch" step from the release checklist. Daily cron surfaces dep drift continuously instead of all at once at un-RC time.

## What
- New `sync-deps-scheduled.yaml` — daily 09:00 UTC, fans out across supported webhook branches.
- `sync-deps.yaml` refactored to be reusable (`workflow_call`) and idempotent (one stable branch + PR per webhook ref).

## How
- Scheduled workflow parses `VERSION.md` (main + 5 newest `release/*`) into a matrix and calls `sync-deps.yaml` per pair.
- `sync-deps.yaml` uses branch `automation/sync-deps-<ref>` with force-push, upserts the PR via `gh pr list` + `edit`/`create`, and serializes per-ref via `concurrency:`.

Manual `workflow_dispatch` behavior is unchanged.
