### PR TITLE
[main] Allow update "env" setting with another "env" setting

### DIFF
--- a/pkg/resources/management.cattle.io/v3/setting/validator.go
+++ b/pkg/resources/management.cattle.io/v3/setting/validator.go
@@ -125,8 +125,8 @@ var ReadOnlySettings = []string{
 }
 
 func (a *admitter) admitUpdate(oldSetting, newSetting *v3.Setting) (*admissionv1.AdmissionResponse, error) {
-	if oldSetting.Source == "env" {
-		return admission.ResponseBadRequest("setting cannot be updated since its value is sourced from an environment variable"), nil
+	if oldSetting.Source == "env" && newSetting.Source != "env" {
+		return admission.ResponseBadRequest(fmt.Sprintf("setting with source \"%s\" cannot update setting with source \"env\"", newSetting.Source)), nil
 	}
 
 	if slices.Contains(ReadOnlySettings, oldSetting.Name) {

--- a/pkg/resources/management.cattle.io/v3/setting/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/setting/validator_test.go
@@ -45,7 +45,7 @@ func (s *SettingSuite) TestAdmitUpdateGuards() {
 		allowed    bool
 	}{
 		{
-			name: "reject update when sourced from env",
+			name: "reject update on setting with source env when new source is not env",
 			oldSetting: &v3.Setting{
 				ObjectMeta: metav1.ObjectMeta{Name: setting.UserRetentionCron},
 				Source:     "env",
@@ -54,6 +54,19 @@ func (s *SettingSuite) TestAdmitUpdateGuards() {
 				ObjectMeta: metav1.ObjectMeta{Name: setting.UserRetentionCron},
 				Value:      "0 0 * * *",
 			},
+		},
+		{
+			name: "allow update on setting with source env when new source is env",
+			oldSetting: &v3.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: setting.UserRetentionCron},
+				Source:     "env",
+			},
+			newSetting: &v3.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: setting.UserRetentionCron},
+				Value:      "0 0 * * *",
+				Source:     "env",
+			},
+			allowed: true,
 		},
 		{
 			name: "reject read-only setting",


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from other PRs, link them here and describe why they are needed for your solution section. -->

## Problem
<!-- Describe the root cause of the issue you are resolving. 
This may include what behavior is observed and why it is not desirable. If this is a new feature, describe why we need it and how it will be used. -->

Some rancher setting like `agent-image` are likely to be changed by users via helm or directly with environment variables. Since the current validations prevent all updates to "env" sourced Settings, this is not possible without manually deleting those settings. This breaks the rancher/rancher provisioning tests and changes existing behavior.

## Solution
<!-- Describe what you changed to fix the issue. 
Relate your changes to the original bug/feature and explain why this addresses the issue. -->

Allow changes to "env" sourced Settings when the new setting is also "env" sourced.

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [x] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [x] Docs