### PR TITLE
[release/v0.9] Bump Go to 1.25.10

### DIFF
--- a/.golangci.json
+++ b/.golangci.json
@@ -1,27 +1,39 @@
 {
+	"version": "2",
 	"linters": {
-		"disable-all": true,
+		"default": "none",
 		"enable": [
 			"govet",
 			"revive",
-			"goimports",
 			"misspell",
-			"ineffassign",
+			"ineffassign"
+		],
+		"settings": {
+			"revive": {
+				"rules": [
+					{"name": "exported", "disabled": true},
+					{"name": "package-comments", "disabled": true}
+				]
+			}
+		},
+		"exclusions": {
+			"paths": [
+				"pkg/generated"
+			]
+		}
+	},
+	"formatters": {
+		"enable": [
+			"goimports",
 			"gofmt"
-		]
+		],
+		"exclusions": {
+			"paths": [
+				"pkg/generated"
+			]
+		}
 	},
 	"run": {
-            "timeout": "10m"
-	},
-	"issues": {
-		"exclude-rules": [
-			{
-				"linters": ["revive"],
-				"text": "should have comment or be unexported"
-			}
-		],
-		"exclude-dirs": [
-			"pkg/generated"
-		]
+		"timeout": "10m"
 	}
 }

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -50,11 +50,11 @@ RUN cat coverage.out | awk 'BEGIN {cov=0; stat=0;} $3!="" { cov+=($3==1?$2:0); s
 # ===============
 FROM build AS validate
 # renovate: datasource=github-releases depName=golangci/golangci-lint
-ARG GOLANGCI_LINT_VERSION=1.64.8
-# renovate: datasource=github-release-attachments depName=golangci/golangci-lint digestVersion=v1.64.8
-ARG GOLANGCI_LINT_SUM_amd64=b6270687afb143d019f387c791cd2a6f1cb383be9b3124d241ca11bd3ce2e54e
-# renovate: datasource=github-release-attachments depName=golangci/golangci-lint digestVersion=v1.64.8
-ARG GOLANGCI_LINT_SUM_arm64=a6ab58ebcb1c48572622146cdaec2956f56871038a54ed1149f1386e287789a5
+ARG GOLANGCI_LINT_VERSION=2.12.2
+# renovate: datasource=github-release-attachments depName=golangci/golangci-lint digestVersion=v2.12.2
+ARG GOLANGCI_LINT_SUM_amd64=8df580d2670fed8fa984aac0507099af8df275e665215f5c7a2ae3943893a553
+# renovate: datasource=github-release-attachments depName=golangci/golangci-lint digestVersion=v2.12.2
+ARG GOLANGCI_LINT_SUM_arm64=44cd40a8c76c86755375adfeea52cfd3533cb43d7bd647771e0ae065e166df3a
 RUN set -e; \
     ARCH=$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/'); \
     TARBALL="golangci-lint-${GOLANGCI_LINT_VERSION}-linux-${ARCH}.tar.gz"; \

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,7 +1,7 @@
 # ===============
 # Build Stage
 # ===============
-FROM --platform=$BUILDPLATFORM rancher/hardened-build-base:v1.24.13b1@sha256:82181c7e36e07a0e91dc5332b0e9e2ce384eb947e0bbd364f3dc5eb78cb1bcba AS build
+FROM --platform=$BUILDPLATFORM rancher/hardened-build-base:v1.25.10b1@sha256:92ecda122083602ae6e698244dbc91e7108a37d636486325e00940d8e98ab858 AS build
 
 # Set up build cache
 ENV GOMODCACHE=/root/.cache/go/modcache

--- a/pkg/codegen/main.go
+++ b/pkg/codegen/main.go
@@ -141,7 +141,7 @@ func generateObjectsFromRequest(outputDir string, groups map[string]args.Group) 
 			ti := typeInfo{
 				Type: rt.String(),
 			}
-			if rt.Kind() == reflect.Ptr {
+			if rt.Kind() == reflect.Pointer {
 				// PkgPath returns an empty string for pointers
 				// Elem returns a Type associated with the dereferenced type.
 				rt = rt.Elem()


### PR DESCRIPTION
## Summary
- Bump hardened-build-base from v1.24.13b1 to v1.25.10b1
- Upgrade golangci-lint from v1.64.8 to v2.12.2 (required for Go 1.25 compatibility)
- Migrate .golangci.json to v2 format
- Replace deprecated reflect.Ptr with reflect.Pointer