### PR TITLE
[release/v0.8] Bump Go to 1.25.10

### DIFF
--- a/.golangci.json
+++ b/.golangci.json
@@ -1,27 +1,39 @@
 {
+	"version": "2",
 	"linters": {
-		"disable-all": true,
+		"default": "none",
 		"enable": [
 			"govet",
 			"revive",
-			"goimports",
 			"misspell",
-			"ineffassign",
+			"ineffassign"
+		],
+		"settings": {
+			"revive": {
+				"rules": [
+					{"name": "exported", "disabled": true},
+					{"name": "package-comments", "disabled": true}
+				]
+			}
+		},
+		"exclusions": {
+			"paths": [
+				"pkg/generated"
+			]
+		}
+	},
+	"formatters": {
+		"enable": [
+			"goimports",
 			"gofmt"
-		]
+		],
+		"exclusions": {
+			"paths": [
+				"pkg/generated"
+			]
+		}
 	},
 	"run": {
-		"deadline": "5m"
-	},
-	"issues": {
-		"exclude-rules": [
-			{
-				"linters": "revive",
-				"text": "should have comment or be unexported"
-			}
-		],
-		"exclude-dirs": [
-			"pkg/generated"
-		]
+		"timeout": "10m"
 	}
 }

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -50,11 +50,11 @@ RUN cat coverage.out | awk 'BEGIN {cov=0; stat=0;} $3!="" { cov+=($3==1?$2:0); s
 # ===============
 FROM build AS validate
 # renovate: datasource=github-releases depName=golangci/golangci-lint
-ARG GOLANGCI_LINT_VERSION=1.64.6
-# renovate: datasource=github-release-attachments depName=golangci/golangci-lint digestVersion=v1.64.6
-ARG GOLANGCI_LINT_SUM_amd64=71e290acbacb7b3ba4f68f0540fb74dc180c4336ac8a6f3bdcd7fcc48b15148d
-# renovate: datasource=github-release-attachments depName=golangci/golangci-lint digestVersion=v1.64.6
-ARG GOLANGCI_LINT_SUM_arm64=99a7ff13dec7a8781a68408b6ecb8a1c5e82786cba3189eaa91d5cdcc24362ce
+ARG GOLANGCI_LINT_VERSION=2.12.2
+# renovate: datasource=github-release-attachments depName=golangci/golangci-lint digestVersion=v2.12.2
+ARG GOLANGCI_LINT_SUM_amd64=8df580d2670fed8fa984aac0507099af8df275e665215f5c7a2ae3943893a553
+# renovate: datasource=github-release-attachments depName=golangci/golangci-lint digestVersion=v2.12.2
+ARG GOLANGCI_LINT_SUM_arm64=44cd40a8c76c86755375adfeea52cfd3533cb43d7bd647771e0ae065e166df3a
 RUN set -e; \
     ARCH=$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/'); \
     TARBALL="golangci-lint-${GOLANGCI_LINT_VERSION}-linux-${ARCH}.tar.gz"; \

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,7 +1,7 @@
 # ===============
 # Build Stage
 # ===============
-FROM --platform=$BUILDPLATFORM registry.suse.com/bci/golang:1.24@sha256:ae722bb8954485d10eb26d90c14d521d90810d8b0c84c3c72b58cbb1fc1ee284 AS build
+FROM --platform=$BUILDPLATFORM rancher/hardened-build-base:v1.25.10b1@sha256:92ecda122083602ae6e698244dbc91e7108a37d636486325e00940d8e98ab858 AS build
 
 # Set up build cache
 ENV GOMODCACHE=/root/.cache/go/modcache

--- a/pkg/codegen/main.go
+++ b/pkg/codegen/main.go
@@ -135,7 +135,7 @@ func generateObjectsFromRequest(outputDir string, groups map[string]args.Group) 
 			ti := typeInfo{
 				Type: rt.String(),
 			}
-			if rt.Kind() == reflect.Ptr {
+			if rt.Kind() == reflect.Pointer {
 				// PkgPath returns an empty string for pointers
 				// Elem returns a Type associated to the dereferenced type.
 				rt = rt.Elem()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -6,7 +6,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -337,7 +336,7 @@ func certAuth() func(next http.Handler) http.Handler {
 }
 
 func getVerifyOptions() *x509.VerifyOptions {
-	caCert, err := ioutil.ReadFile(caFile)
+	caCert, err := os.ReadFile(caFile)
 	if err != nil {
 		logrus.Infof("could not read client CA file at %s, incoming requests will not be authenticated", caFile)
 		return nil


### PR DESCRIPTION
## Summary
- Bump bci/golang base image from 1.24 to 1.25.10
- Upgrade golangci-lint from v1.64.6 to v2.12.2 (required for Go 1.25 compatibility)
- Migrate .golangci.json to v2 format
- Replace deprecated reflect.Ptr with reflect.Pointer