### PR TITLE
[release/v0.10] Update bci-micro base image

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -90,7 +90,7 @@ COPY --from=integration-test-build /dist/rancher-webhook-integration.test /ranch
 # ===============
 # Final Stage
 # ===============
-FROM registry.suse.com/bci/bci-micro:15.7@sha256:bda48a632ca318ff8b38ac3374b8928283c4e4145bcb2b046fd0369f97865fb9
+FROM registry.suse.com/bci/bci-micro:15.7@sha256:a0ab4f6803e057fcd3c5b25e57e028ef6b69f2eddbd7273d0f7829fc0ab23630
 
 ARG user=webhook
 


### PR DESCRIPTION
- Bump `bci-micro:15.7` digest to pick up glibc `2.38-150600.14.49.1`
