### PR TITLE
[main] Remove EOL release/v0.6 from Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,8 +7,7 @@
     "release/v0.10",
     "release/v0.9",
     "release/v0.8",
-    "release/v0.7",
-    "release/v0.6"
+    "release/v0.7"
   ],
   "prHourlyLimit": 2,
   "enabledManagers": [


### PR DESCRIPTION
## Summary
- Remove `release/v0.6` from Renovate `baseBranchPatterns` since v0.6 is EOL
