### PR TITLE
Fix User validator

### DIFF
--- a/pkg/resources/management.cattle.io/v3/users/validator.go
+++ b/pkg/resources/management.cattle.io/v3/users/validator.go
@@ -249,7 +249,7 @@ func (a *admitter) hiddenLocalAuthProvider() (bool, error) {
 	}
 
 	// Check for active external auth provider, query etcd
-	acList, err := a.authConfigCache.List(nil)
+	acList, err := a.authConfigCache.List(labels.Everything())
 	if err != nil {
 		return false, err
 	}

--- a/pkg/resources/management.cattle.io/v3/users/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/users/validator_test.go
@@ -150,7 +150,7 @@ func Test_CheckLocalUser(t *testing.T) {
 
 	eapActive := func() controllerv3.AuthConfigCache {
 		ac := fake.NewMockNonNamespacedCacheInterface[*v3.AuthConfig](ctrl)
-		ac.EXPECT().List(gomock.Any()).Return([]*v3.AuthConfig{
+		ac.EXPECT().List(labels.Everything()).Return([]*v3.AuthConfig{
 			{ObjectMeta: metav1.ObjectMeta{Name: "oidc"}, Enabled: true},
 		}, nil)
 		return ac
@@ -285,7 +285,7 @@ func Test_HiddenLocalAuthProvider(t *testing.T) {
 			featureCache: policyOn,
 			authConfigCache: func() controllerv3.AuthConfigCache {
 				ac := fake.NewMockNonNamespacedCacheInterface[*v3.AuthConfig](ctrl)
-				ac.EXPECT().List(gomock.Any()).Return(nil, fmt.Errorf("some error"))
+				ac.EXPECT().List(labels.Everything()).Return(nil, fmt.Errorf("some error"))
 				return ac
 			},
 			hide:      false,
@@ -295,7 +295,7 @@ func Test_HiddenLocalAuthProvider(t *testing.T) {
 			featureCache: policyOn,
 			authConfigCache: func() controllerv3.AuthConfigCache {
 				ac := fake.NewMockNonNamespacedCacheInterface[*v3.AuthConfig](ctrl)
-				ac.EXPECT().List(gomock.Any()).Return([]*v3.AuthConfig{}, nil)
+				ac.EXPECT().List(labels.Everything()).Return([]*v3.AuthConfig{}, nil)
 				return ac
 			},
 			hide:      false,
@@ -305,7 +305,7 @@ func Test_HiddenLocalAuthProvider(t *testing.T) {
 			featureCache: policyOn,
 			authConfigCache: func() controllerv3.AuthConfigCache {
 				ac := fake.NewMockNonNamespacedCacheInterface[*v3.AuthConfig](ctrl)
-				ac.EXPECT().List(gomock.Any()).Return([]*v3.AuthConfig{
+				ac.EXPECT().List(labels.Everything()).Return([]*v3.AuthConfig{
 					{ObjectMeta: metav1.ObjectMeta{Name: "local"}, Enabled: true},
 				}, nil)
 				return ac
@@ -317,7 +317,7 @@ func Test_HiddenLocalAuthProvider(t *testing.T) {
 			featureCache: policyOn,
 			authConfigCache: func() controllerv3.AuthConfigCache {
 				ac := fake.NewMockNonNamespacedCacheInterface[*v3.AuthConfig](ctrl)
-				ac.EXPECT().List(gomock.Any()).Return([]*v3.AuthConfig{
+				ac.EXPECT().List(labels.Everything()).Return([]*v3.AuthConfig{
 					{ObjectMeta: metav1.ObjectMeta{Name: "oidc"}, Enabled: false},
 				}, nil)
 				return ac
@@ -329,7 +329,7 @@ func Test_HiddenLocalAuthProvider(t *testing.T) {
 			featureCache: policyOn,
 			authConfigCache: func() controllerv3.AuthConfigCache {
 				ac := fake.NewMockNonNamespacedCacheInterface[*v3.AuthConfig](ctrl)
-				ac.EXPECT().List(gomock.Any()).Return([]*v3.AuthConfig{
+				ac.EXPECT().List(labels.Everything()).Return([]*v3.AuthConfig{
 					{ObjectMeta: metav1.ObjectMeta{Name: "local"}, Enabled: true},
 					{ObjectMeta: metav1.ObjectMeta{Name: "oidc"}, Enabled: true},
 				}, nil)
@@ -786,7 +786,7 @@ func Test_Admit(t *testing.T) {
 					Status: v3.FeatureStatus{Default: true},
 				}, nil)
 				mockAuthConfig := fake.NewMockNonNamespacedCacheInterface[*v3.AuthConfig](ctrl)
-				mockAuthConfig.EXPECT().List(gomock.Any()).Return([]*v3.AuthConfig{
+				mockAuthConfig.EXPECT().List(labels.Everything()).Return([]*v3.AuthConfig{
 					{ObjectMeta: metav1.ObjectMeta{Name: "oidc"}, Enabled: true},
 				}, nil)
 				a.featureCache = mockFeature


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/46078 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from other PRs, link them here and describe why they are needed for your solution section. -->
## Problem
<!-- Describe the root cause of the issue you are resolving. 
This may include what behavior is observed and why it is not desirable. If this is a new feature, describe why we need it and how it will be used. -->

A nil labels.Selector passed to the cache List method causes a nil pointer dereference (#1410). The webhook panics on any admission request that reaches the local auth provider check.

## Solution
<!-- Describe what you changed to fix the issue. 
Relate your changes to the original bug/feature and explain why this addresses the issue. -->

The selector is replaced with labels.Everything(), which lists all AuthConfig objects as intended.

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [ ] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [ ] Docs