### PR TITLE
Fix User validator for hide-local-auth-provider feature

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -755,7 +755,7 @@ When a Token is updated, the following checks take place:
 
 Verifies there aren't any other users with the same username.
 
-Verifies that a new user is not linked to the `local` auth provider when the feature `auto-hide-local-auth-provider` is set to `true`, and an external auth provider is active.
+Verifies that a new user is not linked to the `local` auth provider when the feature `hide-local-auth-provider` is set to `true`, and an external auth provider is active.
 
 #### Update and Delete
 
@@ -763,7 +763,7 @@ When a user is updated or deleted, a check occurs to ensure that the user making
 
 If the user making the request has the verb `manage-users` for the resource `users`, then it is allowed to bypass the check. Note that the wildcard `*` includes the `manage-users` verb.
 
-Verifies that the modified or deleted user is not linked to the `local` auth provider when the feature `auto-hide-local-auth-provider` is set to `true`, and an external auth provider is active.
+Verifies that the modified or deleted user is not linked to the `local` auth provider when the feature `hide-local-auth-provider` is set to `true`, and an external auth provider is active.
 
 #### Invalid Fields - Update
 

--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -54,6 +54,11 @@ func New(ctx context.Context, rest *rest.Config, mcmEnabled bool) (*Clients, err
 		return nil, err
 	}
 
+	// Pre-register informers used by validators before Start so they are included
+	// in the initial cache sync barrier. Without this, lazily-registered informers
+	// may not be synced when the HTTP server begins serving admission requests.
+	_ = mgmt.Management().V3().AuthConfig().Cache()
+
 	if err = mgmt.Start(ctx, 5); err != nil {
 		return nil, err
 	}

--- a/pkg/resources/management.cattle.io/v3/users/User.md
+++ b/pkg/resources/management.cattle.io/v3/users/User.md
@@ -4,7 +4,7 @@
 
 Verifies there aren't any other users with the same username.
 
-Verifies that a new user is not linked to the `local` auth provider when the feature `auto-hide-local-auth-provider` is set to `true`, and an external auth provider is active.
+Verifies that a new user is not linked to the `local` auth provider when the feature `hide-local-auth-provider` is set to `true`, and an external auth provider is active.
 
 ### Update and Delete
 
@@ -12,7 +12,7 @@ When a user is updated or deleted, a check occurs to ensure that the user making
 
 If the user making the request has the verb `manage-users` for the resource `users`, then it is allowed to bypass the check. Note that the wildcard `*` includes the `manage-users` verb.
 
-Verifies that the modified or deleted user is not linked to the `local` auth provider when the feature `auto-hide-local-auth-provider` is set to `true`, and an external auth provider is active.
+Verifies that the modified or deleted user is not linked to the `local` auth provider when the feature `hide-local-auth-provider` is set to `true`, and an external auth provider is active.
 
 ### Invalid Fields - Update
 

--- a/pkg/resources/management.cattle.io/v3/users/validator.go
+++ b/pkg/resources/management.cattle.io/v3/users/validator.go
@@ -110,11 +110,22 @@ func (a *admitter) Admit(request *admission.Request) (*admissionv1.AdmissionResp
 		return &admissionv1.AdmissionResponse{Allowed: true}, nil
 	}
 
+	// Check manage-users verb before Update/Delete operation checks so that the bypass
+	// applies to checkLocalUser, allowing admins to update or delete local users for
+	// migration cleanup. Create is intentionally excluded — the feature always blocks
+	// creation of local users regardless of the privilege.
+	hasManageUsers, err := auth.RequestUserHasVerb(request, gvr, a.sar, manageUsersVerb, "", "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to check if requester has manage-users verb: %w", err)
+	}
+
 	fieldPath := field.NewPath("user")
 	if request.Operation == admissionv1.Update {
-		response, err := a.checkLocalUser("update", newUser)
-		if response != nil || err != nil {
-			return response, err
+		if !hasManageUsers {
+			response, err := a.checkLocalUser("update", newUser)
+			if response != nil || err != nil {
+				return response, err
+			}
 		}
 
 		if err := validateUpdateFields(oldUser, newUser, fieldPath); err != nil {
@@ -134,20 +145,16 @@ func (a *admitter) Admit(request *admission.Request) (*admissionv1.AdmissionResp
 		}
 	}
 	if request.Operation == admissionv1.Delete {
-		response, err := a.checkLocalUser("delete", oldUser)
-		if response != nil || err != nil {
-			return response, err
+		if !hasManageUsers {
+			response, err := a.checkLocalUser("delete", oldUser)
+			if response != nil || err != nil {
+				return response, err
+			}
 		}
 
 		if oldUser.Name == request.UserInfo.Username {
 			return admission.ResponseBadRequest("can't delete yourself"), nil
 		}
-	}
-
-	// Check if requester has manage-user verb
-	hasManageUsers, err := auth.RequestUserHasVerb(request, gvr, a.sar, manageUsersVerb, "", "")
-	if err != nil {
-		return nil, fmt.Errorf("failed to check if requester has manage-users verb: %w", err)
 	}
 
 	if hasManageUsers {
@@ -204,10 +211,10 @@ func (a *admitter) checkUsernameUniqueness(username string) (*admissionv1.Admiss
 	return nil, nil
 }
 
-// checkLocalUser rejects the user in the request if it is linked to the local
-// auth provider and the local auth provider is hidden.
+// checkLocalUser rejects the admission request when the target user is a
+// local-only user and the local auth provider is currently hidden.
 func (a *admitter) checkLocalUser(operation string, user *v3.User) (*admissionv1.AdmissionResponse, error) {
-	hidden, err := a.hiddenLocalAuthProvider()
+	hidden, err := a.isLocalAuthProviderHidden()
 	if err != nil {
 		return nil, err
 	}
@@ -221,26 +228,23 @@ func (a *admitter) checkLocalUser(operation string, user *v3.User) (*admissionv1
 	logrus.Debugf("[user-validation] %s: checking user %q", operation, user.Name)
 
 	if len(user.PrincipalIDs) == 0 {
-		// reject local user (dashboard)
 		logrus.Debugf("[user-validation] %s: rejected local user %q (no principals)", operation, user.Name)
 		return admission.ResponseBadRequest("can't " + operation + " user '" + user.Name + "' for disabled local provider"), nil
 	}
 	if len(user.PrincipalIDs) == 1 && strings.HasPrefix(user.PrincipalIDs[0], "local:") {
-		// reject other local user in creation
 		logrus.Debugf("[user-validation] %s: rejected local user %q (local principal)", operation, user.Name)
 		return admission.ResponseBadRequest("can't " + operation + " user '" + user.Name + "' for disabled local provider"), nil
 	}
-	// user is not local (default admin or system). pass to regular checks.
+	// User has external principals (e.g. default admin, system user) — not local-only.
 	logrus.Debugf("[user-validation] %s: continue for non-local user %q", operation, user.Name)
 	return nil, nil
 }
 
-// hiddenLocalAuthProvider determines if the local auth provider is hidden or
-// not. It is hidden when both the auto-hide policy and an external auth
-// provider are active.
-func (a *admitter) hiddenLocalAuthProvider() (bool, error) {
-	// Check policy first, fast
-	hide, err := a.hideLocalAuthProvider()
+// isLocalAuthProviderHidden reports whether the local auth provider is currently
+// hidden — true when the hide policy feature is enabled and at least one
+// external auth provider is active.
+func (a *admitter) isLocalAuthProviderHidden() (bool, error) {
+	hide, err := a.isHideLocalAuthProviderPolicyEnabled()
 	if err != nil {
 		return false, err
 	}
@@ -248,12 +252,16 @@ func (a *admitter) hiddenLocalAuthProvider() (bool, error) {
 		return false, nil
 	}
 
-	// Check for active external auth provider, query etcd
 	acList, err := a.authConfigCache.List(labels.Everything())
 	if err != nil {
 		return false, err
 	}
 
+	// Note: this checks the Enabled flag from etcd, not live provider health. If an
+	// enabled external provider is unreachable (e.g. OIDC cert expired, LDAP down),
+	// the webhook still treats it as active and blocks local user operations. Operators
+	// must disable the external provider via Rancher UI to restore local auth access
+	// during provider outages.
 	externalActive := false
 	for _, ac := range acList {
 		if ac.Enabled && ac.Name != "local" {
@@ -265,13 +273,12 @@ func (a *admitter) hiddenLocalAuthProvider() (bool, error) {
 	return externalActive, nil
 }
 
-// hideLocalAuthProvider retrieves the current value of the hide policy
-// feature. A missing feature is treated as off. This can happen if the new
-// webhook is run against an older rancher backend.
-func (a *admitter) hideLocalAuthProvider() (bool, error) {
+// isHideLocalAuthProviderPolicyEnabled reports whether the hide-local-auth-provider feature
+// is enabled. A missing feature resource is treated as disabled — this can
+// occur when a newer webhook runs against an older Rancher backend.
+func (a *admitter) isHideLocalAuthProviderPolicyEnabled() (bool, error) {
 	feature, err := a.featureCache.Get(common.HideLocalAuthProvider)
 	if err != nil {
-		// treat `feature not found` as `feature exists with (default) value OFF`
 		if apierrors.IsNotFound(err) {
 			return false, nil
 		}

--- a/pkg/resources/management.cattle.io/v3/users/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/users/validator_test.go
@@ -346,7 +346,7 @@ func Test_HiddenLocalAuthProvider(t *testing.T) {
 				featureCache:    spec.featureCache(),
 				authConfigCache: spec.authConfigCache(),
 			}
-			hide, err := a.hiddenLocalAuthProvider()
+			hide, err := a.isLocalAuthProviderHidden()
 			if spec.expectErr {
 				assert.Error(t, err)
 			} else {
@@ -433,7 +433,7 @@ func Test_HideLocalAuthProvider(t *testing.T) {
 			a := &admitter{
 				featureCache: spec.featureCache(),
 			}
-			hide, err := a.hideLocalAuthProvider()
+			hide, err := a.isHideLocalAuthProviderPolicyEnabled()
 			if spec.expectErr {
 				assert.Error(t, err)
 			} else {
@@ -472,26 +472,33 @@ func Test_Admit(t *testing.T) {
 		mockUserCache    func() controllerv3.UserCache
 		wantErr          bool
 		lapHidden        bool
+		// skipLocalUserCheck indicates that checkLocalUser will not be called for
+		// this test case (e.g. manage-users bypass, or SAR error before the check).
+		// When true, no featureCache mock expectations are set up.
+		skipLocalUserCheck bool
 	}{
 		{
-			name:            "User has manage-users verb. delete operation",
-			oldUser:         defaultUser.DeepCopy(),
-			requestUserName: managerUserName,
-			allowed:         true,
+			name:               "User has manage-users verb. delete operation",
+			oldUser:            defaultUser.DeepCopy(),
+			requestUserName:    managerUserName,
+			allowed:            true,
+			skipLocalUserCheck: true,
 		},
 		{
-			name:            "User has manage-users verb. update operation",
-			requestUserName: managerUserName,
-			oldUser:         defaultUser.DeepCopy(),
-			newUser:         defaultUser.DeepCopy(),
-			allowed:         true,
+			name:               "User has manage-users verb. update operation",
+			requestUserName:    managerUserName,
+			oldUser:            defaultUser.DeepCopy(),
+			newUser:            defaultUser.DeepCopy(),
+			allowed:            true,
+			skipLocalUserCheck: true,
 		},
 		{
-			name:            "error checking manage-users verb",
-			requestUserName: sarErrorUser,
-			oldUser:         defaultUser.DeepCopy(),
-			allowed:         false,
-			wantErr:         true,
+			name:               "error checking manage-users verb",
+			requestUserName:    sarErrorUser,
+			oldUser:            defaultUser.DeepCopy(),
+			allowed:            false,
+			wantErr:            true,
+			skipLocalUserCheck: true,
 		},
 		{
 			name:            "error getting rules for User",
@@ -709,7 +716,8 @@ func Test_Admit(t *testing.T) {
 				}, nil)
 				return mock
 			},
-			allowed: false,
+			allowed:            false,
+			skipLocalUserCheck: true,
 		},
 		{
 			name: "setting a unique username on update is allowed",
@@ -732,7 +740,8 @@ func Test_Admit(t *testing.T) {
 				}, nil)
 				return mock
 			},
-			allowed: true,
+			allowed:            true,
+			skipLocalUserCheck: true,
 		},
 		// verify that `checkLocalUser` is in the code paths for create,
 		// update and delete requests.  the full set of checks done by
@@ -773,32 +782,57 @@ func Test_Admit(t *testing.T) {
 			lapHidden: true,
 			allowed:   false,
 		},
+		// verify manage-users bypass: update and delete are allowed, create is still blocked.
+		{
+			name:               "manage-users allows delete of local user when feature is on",
+			oldUser:            &v3.User{ObjectMeta: metav1.ObjectMeta{Name: "a-local-user"}},
+			requestUserName:    managerUserName,
+			allowed:            true,
+			skipLocalUserCheck: true,
+		},
+		{
+			name:               "manage-users allows update of local user when feature is on",
+			oldUser:            &v3.User{ObjectMeta: metav1.ObjectMeta{Name: "a-local-user"}},
+			newUser:            &v3.User{ObjectMeta: metav1.ObjectMeta{Name: "a-local-user"}},
+			requestUserName:    managerUserName,
+			allowed:            true,
+			skipLocalUserCheck: true,
+		},
+		{
+			name:            "create is still blocked with manage-users when feature is on",
+			newUser:         &v3.User{ObjectMeta: metav1.ObjectMeta{Name: "a-local-user"}},
+			requestUserName: managerUserName,
+			lapHidden:       true,
+			allowed:         false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a := &admitter{
 				sar: fakeSAR,
 			}
-			if tt.lapHidden {
-				// policy on, eap active, hiding local auth provider
-				mockFeature := fake.NewMockNonNamespacedCacheInterface[*v3.Feature](ctrl)
-				mockFeature.EXPECT().Get(common.HideLocalAuthProvider).Return(&v3.Feature{
-					Status: v3.FeatureStatus{Default: true},
-				}, nil)
-				mockAuthConfig := fake.NewMockNonNamespacedCacheInterface[*v3.AuthConfig](ctrl)
-				mockAuthConfig.EXPECT().List(labels.Everything()).Return([]*v3.AuthConfig{
-					{ObjectMeta: metav1.ObjectMeta{Name: "oidc"}, Enabled: true},
-				}, nil)
-				a.featureCache = mockFeature
-				a.authConfigCache = mockAuthConfig
-			} else {
-				// policy off, authconfigs not queried, visible local auth provider
-				mockFeature := fake.NewMockNonNamespacedCacheInterface[*v3.Feature](ctrl)
-				mockFeature.EXPECT().Get(common.HideLocalAuthProvider).Return(&v3.Feature{
-					Status: v3.FeatureStatus{Default: false},
-				}, nil)
-				a.featureCache = mockFeature
-				a.authConfigCache = nil
+			if !tt.skipLocalUserCheck {
+				if tt.lapHidden {
+					// policy on, eap active, hiding local auth provider
+					mockFeature := fake.NewMockNonNamespacedCacheInterface[*v3.Feature](ctrl)
+					mockFeature.EXPECT().Get(common.HideLocalAuthProvider).Return(&v3.Feature{
+						Status: v3.FeatureStatus{Default: true},
+					}, nil)
+					mockAuthConfig := fake.NewMockNonNamespacedCacheInterface[*v3.AuthConfig](ctrl)
+					mockAuthConfig.EXPECT().List(labels.Everything()).Return([]*v3.AuthConfig{
+						{ObjectMeta: metav1.ObjectMeta{Name: "oidc"}, Enabled: true},
+					}, nil)
+					a.featureCache = mockFeature
+					a.authConfigCache = mockAuthConfig
+				} else {
+					// policy off, authconfigs not queried, visible local auth provider
+					mockFeature := fake.NewMockNonNamespacedCacheInterface[*v3.Feature](ctrl)
+					mockFeature.EXPECT().Get(common.HideLocalAuthProvider).Return(&v3.Feature{
+						Status: v3.FeatureStatus{Default: false},
+					}, nil)
+					a.featureCache = mockFeature
+					a.authConfigCache = nil
+				}
 			}
 
 			// Handle fake resolver


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/46078 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from other PRs, link them here and describe why they are needed for your solution section. -->
## Problem
<!-- Describe the root cause of the issue you are resolving. 
This may include what behavior is observed and why it is not desirable. If this is a new feature, describe why we need it and how it will be used. -->

There were a few issues identified since #1410:

- When the hide-local-auth-provider feature was active, the local user check ran before the manage-users bypass, so users with the manage-users verb could not delete or update local users.
- The AuthConfig informer was registered after the management factory's sync barrier ran, leaving a startup window where the informer cache was empty. During that window, the local user check saw no active external providers and skipped the guard silently. 
- The feature name in docs didn't match the code.

## Solution
<!-- Describe what you changed to fix the issue. 
Relate your changes to the original bug/feature and explain why this addresses the issue. -->

- The manage-users check is now done before the local user check for update and delete operations, so the bypass applies to both. Create operations keep the check unconditional — the feature should always block creating new local users regardless of privilege.
- The informer is now pre-registered before the sync call.
- The feature name in the docs is updated to match the code.

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [ ] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [ ] Docs