### PR TITLE
Remove EOL branches from VERSION.md

### DIFF
--- a/VERSION.md
+++ b/VERSION.md
@@ -7,7 +7,3 @@ Rancher's Webhook follows a pre-release (v0.x) strategy of semver. There no comp
 | release/v0.9 | v0.9 | v2.13 |
 | release/v0.8 | v0.8 | v2.12 |
 | release/v0.7 | v0.7 | v2.11 |
-| release/v0.6 | v0.6 | v2.10 |
-| release/v0.5 | v0.5 | v2.9 |
-| release/v0.4 | v0.4 | v2.8 |
-| release/v0.3 | v0.3 | v2.7 |


### PR DESCRIPTION
- Remove EOL webhook branches (v0.6, v0.5, v0.4, v0.3) from VERSION.md
- The sync-deps-scheduled workflow reads VERSION.md to build its matrix, so this stops the daily sync job from running against EOL branches.