### PR TITLE
Pin CI workflows to Rancher release/v2.15

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
         run: |
           mkdir -p "${{ runner.temp}}"
           pushd "${{ runner.temp}}"
-          git clone --depth 1 -b main https://github.com/rancher/rancher.git rancherDir
+          git clone --depth 1 -b release/v2.15 https://github.com/rancher/rancher.git rancherDir
           cd rancherDir
           ./scripts/chart/build chart
           tar cfz "${{ runner.temp }}/rancher.tgz" -C build/chart/rancher .
@@ -68,8 +68,8 @@ jobs:
         run: ./.github/workflows/scripts/start-rancher.sh
         env:
           CHART_PATH: "${{ runner.temp }}/rancher.tgz"
-          RANCHER_IMAGE_TAG: "head"
-          VERSION: "main"
+          RANCHER_IMAGE_TAG: "v2.15-head"
+          VERSION: "release/v2.15"
 
       - name: get vars
         run: cat dist/image_tag >> $GITHUB_ENV

--- a/.github/workflows/release-rancher.yaml
+++ b/.github/workflows/release-rancher.yaml
@@ -5,7 +5,7 @@ on:
       rancher_ref:
         description: "Submit PR against the following rancher/rancher branch (eg: main)"
         required: true
-        default: "main"
+        default: "release/v2.15"
       prev_webhook:
         description: "Previous Webhook version (eg: v0.5.0-rc.13)"
         required: true

--- a/.github/workflows/sync-deps.yaml
+++ b/.github/workflows/sync-deps.yaml
@@ -6,7 +6,7 @@ on:
       rancher_ref:
         description: "Version of rancher/rancher to compare"
         required: true
-        default: "main"
+        default: "release/v2.15"
       rancher_repository:
         description: "Repository for rancher/rancher"
         required: true


### PR DESCRIPTION
For the new `release/v0.11` branch (Rancher v2.15), pin workflow refs to the Rancher 2.15 line:

- `ci.yaml`: `git clone -b release/v2.15`, `RANCHER_IMAGE_TAG: v2.15-head`, `VERSION: release/v2.15`
- `release-rancher.yaml`: `rancher_ref` default `release/v2.15`
- `sync-deps.yaml`: `rancher_ref` default `release/v2.15`

Part of the frameworks branch-out for the new Rancher minor.