### PR TITLE
Bump main to v0.12 (Rancher v2.16)

### DIFF
--- a/VERSION.md
+++ b/VERSION.md
@@ -2,7 +2,8 @@ Rancher's Webhook follows a pre-release (v0.x) strategy of semver. There no comp
 
 | Webhook Branch | Webhook Minor version | Rancher Minor Version |
 |----------------|-----------------------|-----------------------|
-| main | v0.11 | v2.15 |
+| main | v0.12 | v2.16 |
+| release/v0.11 | v0.11 | v2.15 |
 | release/v0.10 | v0.10 | v2.14 |
 | release/v0.9 | v0.9 | v2.13 |
 | release/v0.8 | v0.8 | v2.12 |

--- a/charts/rancher-webhook/Chart.yaml
+++ b/charts/rancher-webhook/Chart.yaml
@@ -10,6 +10,6 @@ annotations:
   catalog.cattle.io/release-name: rancher-webhook
   catalog.cattle.io/os: linux
   catalog.cattle.io/permits-os: linux,windows
-  catalog.cattle.io/rancher-version: ">= 2.15.0-0 < 2.16.0-0"
+  catalog.cattle.io/rancher-version: ">= 2.16.0-0 < 2.17.0-0"
   catalog.cattle.io/kube-version: "< 1.37.0-0"
   catalog.cattle.io/managed: "true"


### PR DESCRIPTION
Following rancher/rancher branching for v2.15 (release/v2.15), this bumps webhook main to track the next minor.

- `VERSION.md`: main → v0.12 (Rancher v2.16); record release/v0.11 (Rancher v2.15).
- `charts/rancher-webhook/Chart.yaml`: `catalog.cattle.io/rancher-version` → `>= 2.16.0-0 < 2.17.0-0`.

Both are bundled together so `validate-rancher-version` stays green (VERSION.md main Rancher column and the chart annotation must agree). This must land before tagging `v0.12.0-rc.1`, so the release tgz carries the correct 2.16 annotation into rancher/charts dev-v2.16.

Part of the release/v0.11 branch-out.