### PR TITLE
Set the creatorId annotation on dry-run provisioning Cluster creates

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -829,6 +829,15 @@ If the action is an update, and the old cluster had a `nil` `.spec.rkeConfig`, a
 
 Prevent the creation of objects if the secret specified in `.spec.rkeConfig.etcd.s3.cloudCredentialName` does not exist.
 
+##### Pod Security Admission Configuration Template
+
+When `spec.defaultPodSecurityAdmissionConfigurationTemplateName` is set, the referenced
+`PodSecurityAdmissionConfigurationTemplate` must exist and the cluster's Kubernetes version must be 1.23 or above.
+The admission-configuration secret managed by the mutator, and the cluster fields derived from it, are also
+validated — except on server-side dry-run requests, where the mutator does not perform that secret management (see
+Mutation Checks); the template-existence and version checks still run on dry-run. The same applies on update, and
+the check that the secret was removed is skipped on dry-run deletes.
+
 #### On Update
 
 ##### Creator ID Annotation
@@ -933,6 +942,17 @@ When a cluster is created `field.cattle.io/creatorId` is set to the Username fro
 
 If `field.cattle.io/no-creator-rbac` annotation is set, `field.cattle.io/creatorId` does not get set.
 
+This also applies to server-side dry-run creates: the annotation is set in the returned patch, so the Creator ID
+validation passes on a dry-run exactly as it does on a real create.
+
+##### Pod Security Admission Configuration Template
+
+When a cluster is created or updated with `spec.defaultPodSecurityAdmissionConfigurationTemplateName` set, the
+mutator manages an admission-configuration secret for the cluster and sets the machine selector file and
+kube-apiserver argument that mount it; when the field is cleared, the secret is deleted and those fields are
+dropped. On server-side dry-run requests the secret is neither written nor deleted, and the derived fields are not
+set or dropped — the corresponding validation of that state is skipped on dry-run as well (see Validation Checks).
+
 #### On Update
 
 ##### Dynamic Schema Drop
@@ -941,6 +961,9 @@ Check for the presence of the `provisioning.cattle.io/allow-dynamic-schema-drop`
 perform no mutations. If the value is not present or not `"true"`, compare the value of the `dynamicSchemaSpec` field
 for each `machinePool`, to its' previous value. If the values are not identical, revert the value for the
 `dynamicSchemaSpec` for the specific `machinePool`, but do not reject the request.
+
+The revert also applies to server-side dry-run updates, so a dry-run preview matches what a real update would
+persist.
 
 # rbac.authorization.k8s.io/v1
 

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/Cluster.md
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/Cluster.md
@@ -30,6 +30,15 @@ If the action is an update, and the old cluster had a `nil` `.spec.rkeConfig`, a
 
 Prevent the creation of objects if the secret specified in `.spec.rkeConfig.etcd.s3.cloudCredentialName` does not exist.
 
+#### Pod Security Admission Configuration Template
+
+When `spec.defaultPodSecurityAdmissionConfigurationTemplateName` is set, the referenced
+`PodSecurityAdmissionConfigurationTemplate` must exist and the cluster's Kubernetes version must be 1.23 or above.
+The admission-configuration secret managed by the mutator, and the cluster fields derived from it, are also
+validated — except on server-side dry-run requests, where the mutator does not perform that secret management (see
+Mutation Checks); the template-existence and version checks still run on dry-run. The same applies on update, and
+the check that the secret was removed is skipped on dry-run deletes.
+
 ### On Update
 
 #### Creator ID Annotation
@@ -134,6 +143,17 @@ When a cluster is created `field.cattle.io/creatorId` is set to the Username fro
 
 If `field.cattle.io/no-creator-rbac` annotation is set, `field.cattle.io/creatorId` does not get set.
 
+This also applies to server-side dry-run creates: the annotation is set in the returned patch, so the Creator ID
+validation passes on a dry-run exactly as it does on a real create.
+
+#### Pod Security Admission Configuration Template
+
+When a cluster is created or updated with `spec.defaultPodSecurityAdmissionConfigurationTemplateName` set, the
+mutator manages an admission-configuration secret for the cluster and sets the machine selector file and
+kube-apiserver argument that mount it; when the field is cleared, the secret is deleted and those fields are
+dropped. On server-side dry-run requests the secret is neither written nor deleted, and the derived fields are not
+set or dropped — the corresponding validation of that state is skipped on dry-run as well (see Validation Checks).
+
 ### On Update
 
 #### Dynamic Schema Drop
@@ -142,3 +162,6 @@ Check for the presence of the `provisioning.cattle.io/allow-dynamic-schema-drop`
 perform no mutations. If the value is not present or not `"true"`, compare the value of the `dynamicSchemaSpec` field
 for each `machinePool`, to its' previous value. If the values are not identical, revert the value for the
 `dynamicSchemaSpec` for the specific `machinePool`, but do not reject the request.
+
+The revert also applies to server-side dry-run updates, so a dry-run preview matches what a real update would
+persist.

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/mutator.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/mutator.go
@@ -102,11 +102,17 @@ func (m *ProvisioningClusterMutator) MutatingWebhook(clientConfig admissionregis
 
 // Admit is the entrypoint for the mutator. Admit will return an error if it unable to process the request.
 func (m *ProvisioningClusterMutator) Admit(request *admission.Request) (*admissionv1.AdmissionResponse, error) {
-	if request.DryRun != nil && *request.DryRun {
-		return &admissionv1.AdmissionResponse{
-			Allowed: true,
-		}, nil
-	}
+	// Dry-run requests must not skip this handler entirely: the validating
+	// webhook requires the creatorId annotation on dry-run creates too, and
+	// a dry-run's patch should preview what a real request would produce.
+	// Everything that only changes the in-flight request object — the
+	// creatorId annotation, the dynamic-schema revert, the JSON patch — runs
+	// on dry-run; nothing is persisted. Only the PSACT handling is guarded
+	// by dryRun below: it creates or deletes the admission-config secret,
+	// the real side effect the webhook's SideEffects: NoneOnDryRun
+	// registration promises to skip (its validating counterpart skips the
+	// secret-derived checks on dry-run for the same reason).
+	dryRun := request.DryRun != nil && *request.DryRun
 
 	listTrace := trace.New("provisioningCluster Admit", trace.Field{Key: "user", Value: request.UserInfo.Username})
 	defer listTrace.LogIfLong(admission.SlowTraceDuration)
@@ -128,12 +134,15 @@ func (m *ProvisioningClusterMutator) Admit(request *admission.Request) (*admissi
 		common.SetCreatorIDAnnotation(request, cluster)
 	}
 
-	response, err := m.handlePSACT(request, cluster)
-	if err != nil {
-		return nil, err
-	}
-	if response.Result != nil {
-		return response, nil
+	response := &admissionv1.AdmissionResponse{}
+	if !dryRun {
+		response, err = m.handlePSACT(request, cluster)
+		if err != nil {
+			return nil, err
+		}
+		if response.Result != nil {
+			return response, nil
+		}
 	}
 
 	if request.Operation == admissionv1.Update {

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/mutator_test.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/mutator_test.go
@@ -12,6 +12,7 @@ import (
 	data2 "github.com/rancher/wrangler/v3/pkg/data"
 	"github.com/stretchr/testify/assert"
 	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -676,6 +677,86 @@ func TestAdmitPreserveUnknownFields(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Nil(t, response.Patch)
 
+}
+
+func TestAdmitDryRun(t *testing.T) {
+	cluster := &v1.Cluster{}
+	raw, err := json.Marshal(cluster)
+	assert.Nil(t, err)
+
+	m := ProvisioningClusterMutator{}
+
+	// A dry-run Create must return a patch that sets the creatorId
+	// annotation from the request's user. No OldObject — the apiserver
+	// sends none on Create.
+	createReq := &admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Operation: admissionv1.Create,
+			DryRun:    admission.Ptr(true),
+			UserInfo:  authenticationv1.UserInfo{Username: "u-test"},
+			Object:    runtime.RawExtension{Raw: raw},
+		},
+	}
+	response, err := m.Admit(createReq)
+	assert.Nil(t, err)
+	assert.True(t, response.Allowed)
+	assert.Equal(t, []byte(`[{"op":"add","path":"/metadata/annotations","value":{"field.cattle.io/creatorId":"u-test"}}]`), response.Patch)
+
+	// A dry-run Update of an unchanged cluster must return allowed with no
+	// patch: the annotation is only set on Create, and there is nothing for
+	// the dynamic-schema handling to revert.
+	updateReq := &admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Operation: admissionv1.Update,
+			DryRun:    admission.Ptr(true),
+			UserInfo:  authenticationv1.UserInfo{Username: "u-test"},
+			Object:    runtime.RawExtension{Raw: raw},
+			OldObject: runtime.RawExtension{Raw: raw},
+		},
+	}
+	response, err = m.Admit(updateReq)
+	assert.Nil(t, err)
+	assert.True(t, response.Allowed)
+	assert.Nil(t, response.Patch)
+
+	// A dry-run Update that drops a machine pool's dynamicSchemaSpec must
+	// preview the same revert a real update performs — the revert changes
+	// only the in-flight object, so skipping it on dry-run would make the
+	// preview disagree with the eventual apply.
+	oldWithSchema := &v1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
+		Spec: v1.ClusterSpec{
+			RKEConfig: &v1.RKEConfig{
+				MachinePools: []v1.RKEMachinePool{{Name: "pool-a", DynamicSchemaSpec: "the-spec"}},
+			},
+		},
+	}
+	newWithoutSchema := &v1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
+		Spec: v1.ClusterSpec{
+			RKEConfig: &v1.RKEConfig{
+				MachinePools: []v1.RKEMachinePool{{Name: "pool-a"}},
+			},
+		},
+	}
+	oldRaw, err := json.Marshal(oldWithSchema)
+	assert.Nil(t, err)
+	newRaw, err := json.Marshal(newWithoutSchema)
+	assert.Nil(t, err)
+	dropReq := &admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Operation: admissionv1.Update,
+			DryRun:    admission.Ptr(true),
+			UserInfo:  authenticationv1.UserInfo{Username: "u-test"},
+			Object:    runtime.RawExtension{Raw: newRaw},
+			OldObject: runtime.RawExtension{Raw: oldRaw},
+		},
+	}
+	response, err = m.Admit(dropReq)
+	assert.Nil(t, err)
+	assert.True(t, response.Allowed)
+	assert.Contains(t, string(response.Patch), "the-spec",
+		"the dry-run patch must carry the dynamic-schema revert")
 }
 
 func TestDynamicSchemaDrop(t *testing.T) {

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/validator.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/validator.go
@@ -506,12 +506,26 @@ func (p *provisioningAdmitter) validatePSACT(request *admission.Request, respons
 		return nil
 	}
 
+	// The mutating webhook skips its PSACT side effects on dry-run: the
+	// admission-config secret is not written or deleted, and the cluster
+	// fields derived from it are not set or dropped. Checks against that
+	// mutator-produced state therefore skip on dry-run too (see the dryRun
+	// gates below), while the pure input checks (kubernetes version floor,
+	// template existence) still run, so invalid input is denied in the
+	// preview exactly as it would be on a real request.
+	dryRun := request.DryRun != nil && *request.DryRun
+
 	name := fmt.Sprintf(secretName, cluster.Name)
 	mountPath := fmt.Sprintf(mountPath, getRuntime(cluster.Spec.KubernetesVersion))
 	templateName := cluster.Spec.DefaultPodSecurityAdmissionConfigurationTemplateName
 
 	switch request.Operation {
 	case admissionv1.Delete:
+		if dryRun {
+			// The only check below is that the mutator deleted the
+			// admission-config secret, which it does not do on dry-run.
+			return nil
+		}
 		_, err := p.secretCache.Get(cluster.Namespace, name)
 		if err == nil {
 			return fmt.Errorf("[provisioning cluster validator] the secret %s still exists in the cluster", name)
@@ -525,6 +539,12 @@ func (p *provisioningAdmitter) validatePSACT(request *admission.Request, respons
 			return nil
 		}
 		if templateName == "" {
+			if dryRun {
+				// Every check below verifies the mutator's cleanup for a
+				// cluster without a template — secret deleted, PSA fields
+				// dropped — none of which happens on dry-run.
+				return nil
+			}
 			// validate that the secret does not exist
 			_, err := p.secretCache.Get(cluster.Namespace, name)
 			if err == nil {
@@ -572,6 +592,11 @@ func (p *provisioningAdmitter) validatePSACT(request *admission.Request, respons
 					return nil
 				}
 				return fmt.Errorf("[provisioning cluster validator] failed to get PodSecurityAdmissionConfigurationTemplate: %w", err)
+			}
+			if dryRun {
+				// The secret and the cluster fields checked below are the
+				// mutator's work, skipped on dry-run.
+				return nil
 			}
 			// validate that the secret for PSA exists
 			secret, err := p.secretCache.Get(cluster.Namespace, name)

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/validator_test.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/validator_test.go
@@ -23,6 +23,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
@@ -3245,6 +3246,88 @@ func Test_validateWebhookDeploymentCustomization(t *testing.T) {
 			}
 			got := common.ValidateWebhookDeploymentCustomization(replicaCount, tolerations, affinity, pdb, field.NewPath("test"))
 			tt.validateFunc(t, got)
+		})
+	}
+}
+
+func TestValidatePSACTDryRun(t *testing.T) {
+	t.Parallel()
+
+	// On dry-run, the pure input checks (kubernetes version floor,
+	// template existence) must still run — invalid input is denied in the
+	// preview exactly as on a real request — while the checks against the
+	// mutator's side effects (the admission-config secret and the cluster
+	// fields derived from it) must skip, since the mutator does not
+	// perform them on dry-run. The nil secret cache proves the skip: any
+	// secret lookup would panic.
+	tests := []struct {
+		name         string
+		template     string
+		k8sVersion   string
+		templateMiss bool
+		wantDenied   bool
+	}{
+		{
+			name:       "valid template and version: allowed, secret checks skipped",
+			template:   "restricted",
+			k8sVersion: "v1.30.5+rke2r1",
+		},
+		{
+			name:         "nonexistent template: denied on dry-run too",
+			template:     "no-such-template",
+			k8sVersion:   "v1.30.5+rke2r1",
+			templateMiss: true,
+			wantDenied:   true,
+		},
+		{
+			name:       "version below 1.23: denied on dry-run too",
+			template:   "restricted",
+			k8sVersion: "v1.22.9+rke2r1",
+			wantDenied: true,
+		},
+		{
+			name:       "template cleared: allowed, secret-absence check skipped",
+			template:   "",
+			k8sVersion: "v1.30.5+rke2r1",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			psactCache := fake.NewMockNonNamespacedCacheInterface[*v3.PodSecurityAdmissionConfigurationTemplate](ctrl)
+			if tt.templateMiss {
+				psactCache.EXPECT().Get(tt.template).Return(nil,
+					apierrors.NewNotFound(schema.GroupResource{Group: "management.cattle.io", Resource: "podsecurityadmissionconfigurationtemplates"}, tt.template)).AnyTimes()
+			} else if tt.template != "" {
+				psactCache.EXPECT().Get(tt.template).Return(&v3.PodSecurityAdmissionConfigurationTemplate{}, nil).AnyTimes()
+			}
+			a := provisioningAdmitter{psactCache: psactCache}
+			resp := admissionv1.AdmissionResponse{}
+			cluster := &v1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Namespace: "fleet-default"},
+				Spec: v1.ClusterSpec{
+					RKEConfig:         &v1.RKEConfig{},
+					KubernetesVersion: tt.k8sVersion,
+					DefaultPodSecurityAdmissionConfigurationTemplateName: tt.template,
+				},
+			}
+			req := &admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					DryRun:    admission.Ptr(true),
+				},
+			}
+
+			err := a.validatePSACT(req, &resp, cluster)
+			assert.NoError(t, err)
+			if tt.wantDenied {
+				assert.NotNil(t, resp.Result, "invalid input must be denied on dry-run")
+			} else {
+				assert.Nil(t, resp.Result)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/56286 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from other PRs, link them here and describe why they are needed for your solution section. -->

## Problem
<!-- Describe the root cause of the issue you are resolving. 
This may include what behavior is observed and why it is not desirable. If this is a new feature, describe why we need it and how it will be used. -->

The mutating webhook for provisioning Clusters returned early on every dry-run request, before setting the creatorId annotation.
The validating webhook requires that annotation on dry-run creates, so every server-side dry-run create was denied while the identical real create succeeded.
For PSACT-configured clusters the validating webhook also checks the admission-config secret the mutator writes, which fails the same way on dry-run since the write never happens.

## Solution
<!-- Describe what you changed to fix the issue. 
Relate your changes to the original bug/feature and explain why this addresses the issue. -->

The mutator's early return is replaced with a guard around only the PSACT secret handling, the one stage with a real side effect.
On dry-run, the object parse, the creatorId annotation, the dynamic-schema revert, and the JSON patch generation now run as they do on a real request, so the preview patch matches the eventual apply.
The validating webhook skips only its checks against that mutator-produced state (the secret and the cluster fields derived from it) on dry-run; its pure input checks — the kubernetes version floor and the template's existence — still run, so invalid input is denied in the preview exactly as it would be on a real request.
The patch changes only the in-flight request object, which a dry-run never persists, so the webhook's SideEffects: NoneOnDryRun registration remains accurate.

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [x] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [x] Docs