### PR TITLE
Add validation for crt ttl settings

### DIFF
--- a/pkg/resources/management.cattle.io/v3/setting/Setting.md
+++ b/pkg/resources/management.cattle.io/v3/setting/Setting.md
@@ -12,6 +12,8 @@ When settings are created or updated, the following common checks take place:
 - The `auth-user-session-idle-ttl-minutes` must be a positive integer and can't be greater than `auth-user-session-ttl-minutes`.
 - The `auth-user-info-max-age-seconds` must be a valid duration value.
 - The `auth-user-info-resync-cron` must be a valid cron expression.
+- If set, `crt-default-ttl-minutes` must be a valid integer no less than `30` and greater than `crt-default-grace-period-minutes` if that value is set.
+- If set, `crt-default-grace-period-minutes` must be a valid integer no less than `10` and less than `crt-default-ttl-minutes` if that value is set.
 
 ### Update
 

--- a/pkg/resources/management.cattle.io/v3/setting/validator.go
+++ b/pkg/resources/management.cattle.io/v3/setting/validator.go
@@ -33,6 +33,8 @@ const (
 	AuthUserSessionTTLMinutes             = "auth-user-session-ttl-minutes"
 	CattleClusterAgentPodDisruptionBudget = "cluster-agent-default-pod-disruption-budget"
 	CattleClusterAgentPriorityClass       = "cluster-agent-default-priority-class"
+	CRTDefaultTTL                         = "crt-default-ttl-minutes"
+	CRTDefaultGracePeriod                 = "crt-default-grace-period-minutes"
 	DeleteInactiveUserAfter               = "delete-inactive-user-after"
 	DisableInactiveUserAfter              = "disable-inactive-user-after"
 	FleetAgentPodDisruptionBudget         = "fleet-agent-default-pod-disruption-budget"
@@ -45,6 +47,11 @@ const (
 // This is introduced to minimize the risk of deleting users accidentally by setting a relatively low value.
 // The admin can still set a lower value if needed by bypassing the webhook.
 const MinDeleteInactiveUserAfter = 24 * 14 * time.Hour // 14 days.
+
+const (
+	minCRTTTLMinutes         = 30 // 30 minutes
+	minCRTGracePeriodMinutes = 10 // 10 minutes
+)
 
 var gvr = schema.GroupVersionResource{
 	Group:    "management.cattle.io",
@@ -172,6 +179,10 @@ func (a *admitter) admitCommonCreateUpdate(_, newSetting *v3.Setting) (*admissio
 		err = a.validateAuthUserInfoMaxAgeSeconds(newSetting)
 	case AuthUserInfoResyncCron:
 		err = a.validateAuthUserInfoResyncCron(newSetting)
+	case CRTDefaultTTL:
+		err = a.validateCRTDefaultTTL(newSetting)
+	case CRTDefaultGracePeriod:
+		err = a.validateCRTDefaultGracePeriod(newSetting)
 	default:
 	}
 
@@ -398,6 +409,79 @@ func (a *admitter) validateUserLastLoginDefault(s *v3.Setting) error {
 	}
 
 	return nil
+}
+
+// validateCRTDefaultTTL validates the crt-default-ttl-minutes setting
+// to make sure it's a valid integer no less than minCRTTTLMinutes and
+// greater than the value of crt-default-grace-period-minutes setting.
+func (a *admitter) validateCRTDefaultTTL(s *v3.Setting) error {
+	if s.Value == "" {
+		return nil
+	}
+
+	ttl, err := strconv.Atoi(s.Value)
+	if err != nil {
+		return field.TypeInvalid(valuePath, s.Value, err.Error())
+	}
+	if ttl < minCRTTTLMinutes {
+		return field.Forbidden(valuePath, fmt.Sprintf("must be >= %d", minCRTTTLMinutes))
+	}
+
+	gp, err := a.getCRTIntSetting(CRTDefaultGracePeriod)
+	if err != nil {
+		logrus.Warnf("[settingValidator] Failed to get %s: %v", CRTDefaultGracePeriod, err)
+		return nil // Deliberately allow to proceed.
+	}
+
+	if ttl <= gp {
+		return field.Forbidden(valuePath, fmt.Sprintf("%s (%d) must be greater than %s (%d)", CRTDefaultTTL, ttl, CRTDefaultGracePeriod, gp))
+	}
+
+	return nil
+}
+
+// validateCRTDefaultGracePeriod validates the crt-default-grace-period-minutes setting
+// to make sure it's a valid integer no less than minCRTGracePeriodMinutes and
+// less than the value of crt-default-ttl-minutes setting.
+func (a *admitter) validateCRTDefaultGracePeriod(s *v3.Setting) error {
+	if s.Value == "" {
+		return nil
+	}
+
+	gp, err := strconv.Atoi(s.Value)
+	if err != nil {
+		return field.TypeInvalid(valuePath, s.Value, err.Error())
+	}
+	if gp < minCRTGracePeriodMinutes {
+		return field.Forbidden(valuePath, fmt.Sprintf("must be >= %d", minCRTGracePeriodMinutes))
+	}
+
+	ttl, err := a.getCRTIntSetting(CRTDefaultTTL)
+	if err != nil {
+		logrus.Warnf("[settingValidator] Failed to get %s: %v", CRTDefaultTTL, err)
+		return nil // Deliberately allow to proceed.
+	}
+
+	if ttl <= gp {
+		return field.Forbidden(valuePath, fmt.Sprintf("%s (%d) must be less than %s (%d)", CRTDefaultGracePeriod, gp, CRTDefaultTTL, ttl))
+	}
+
+	return nil
+}
+
+// getCRTIntSetting fetches the effective value of the given setting from the cache and parses it as an integer.
+func (a *admitter) getCRTIntSetting(name string) (int, error) {
+	setting, err := a.settingCache.Get(name)
+	if err != nil {
+		return 0, err
+	}
+
+	value := effectiveValue(setting)
+	if value == "" {
+		return 0, nil
+	}
+
+	return strconv.Atoi(value)
 }
 
 // validateDuration parses the value as durations and makes sure it's not negative.

--- a/pkg/resources/management.cattle.io/v3/setting/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/setting/validator_test.go
@@ -467,6 +467,166 @@ func (s *SettingSuite) validateAuthUserInfoResyncCron(op v1.Operation) {
 	}
 }
 
+func (s *SettingSuite) TestValidateCRTDefaultTTLOnUpdate() {
+	s.validateCRTDefaultTTL(v1.Update)
+}
+
+func (s *SettingSuite) TestValidateCRTDefaultTTLOnCreate() {
+	s.validateCRTDefaultTTL(v1.Create)
+}
+
+func (s *SettingSuite) validateCRTDefaultTTL(op v1.Operation) {
+	tests := []struct {
+		desc           string
+		value          string
+		gracePeriod    string
+		gracePeriodErr error
+		allowed        bool
+	}{
+		{
+			desc:        "valid ttl",
+			value:       "43200",
+			gracePeriod: "180",
+			allowed:     true,
+		},
+		{
+			desc:  "not an integer",
+			value: "foo",
+		},
+		{
+			desc:  "less than minimum",
+			value: "29",
+		},
+		{
+			desc:        "not greater than grace period",
+			value:       "180",
+			gracePeriod: "180",
+		},
+		{
+			desc:        "less than grace period",
+			value:       "100",
+			gracePeriod: "180",
+		},
+		{
+			desc:           "error getting grace period",
+			value:          "43200",
+			gracePeriodErr: errors.New("some error"),
+			allowed:        true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		s.T().Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			settingCache := fake.NewMockNonNamespacedCacheInterface[*v3.Setting](ctrl)
+			settingCache.EXPECT().Get(setting.CRTDefaultGracePeriod).DoAndReturn(func(string) (*v3.Setting, error) {
+				if test.gracePeriodErr != nil {
+					return nil, test.gracePeriodErr
+				}
+				return &v3.Setting{
+					ObjectMeta: metav1.ObjectMeta{Name: setting.CRTDefaultGracePeriod},
+					Value:      test.gracePeriod,
+				}, nil
+			}).AnyTimes()
+
+			validator := setting.NewValidator(nil, settingCache)
+			s.testAdmit(t, validator, &v3.Setting{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: setting.CRTDefaultTTL,
+				},
+			}, &v3.Setting{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: setting.CRTDefaultTTL,
+				},
+				Value: test.value,
+			}, op, test.allowed)
+		})
+	}
+}
+
+func (s *SettingSuite) TestValidateCRTDefaultGracePeriodOnUpdate() {
+	s.validateCRTDefaultGracePeriod(v1.Update)
+}
+
+func (s *SettingSuite) TestValidateCRTDefaultGracePeriodOnCreate() {
+	s.validateCRTDefaultGracePeriod(v1.Create)
+}
+
+func (s *SettingSuite) validateCRTDefaultGracePeriod(op v1.Operation) {
+	tests := []struct {
+		desc    string
+		value   string
+		ttl     string
+		ttlErr  error
+		allowed bool
+	}{
+		{
+			desc:    "valid grace period",
+			value:   "180",
+			ttl:     "43200",
+			allowed: true,
+		},
+		{
+			desc:  "not an integer",
+			value: "foo",
+		},
+		{
+			desc:  "less than minimum",
+			value: "9",
+		},
+		{
+			desc:  "not less than ttl",
+			value: "43200",
+			ttl:   "43200",
+		},
+		{
+			desc:  "greater than ttl",
+			value: "43200",
+			ttl:   "180",
+		},
+		{
+			desc:    "error getting ttl",
+			value:   "180",
+			ttlErr:  errors.New("some error"),
+			allowed: true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		s.T().Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			settingCache := fake.NewMockNonNamespacedCacheInterface[*v3.Setting](ctrl)
+			settingCache.EXPECT().Get(setting.CRTDefaultTTL).DoAndReturn(func(string) (*v3.Setting, error) {
+				if test.ttlErr != nil {
+					return nil, test.ttlErr
+				}
+				return &v3.Setting{
+					ObjectMeta: metav1.ObjectMeta{Name: setting.CRTDefaultTTL},
+					Value:      test.ttl,
+				}, nil
+			}).AnyTimes()
+
+			validator := setting.NewValidator(nil, settingCache)
+			s.testAdmit(t, validator, &v3.Setting{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: setting.CRTDefaultGracePeriod,
+				},
+			}, &v3.Setting{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: setting.CRTDefaultGracePeriod,
+				},
+				Value: test.value,
+			}, op, test.allowed)
+		})
+	}
+}
+
 func (s *SettingSuite) validateUserLastLoginDefault(op v1.Operation) {
 	tests := []struct {
 		desc    string


### PR DESCRIPTION
Moving validation from norman setting store to enforce it consistently https://github.com/rancher/rancher/pull/56085/changes/43bc401deddcfc0557a8f83a7275f6b0076d3e50 


Issue: https://github.com/rancher/rancher/issues/56071 