### PR TITLE
[v0.11] Make User principalIds immutable

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -769,7 +769,11 @@ Verifies that the modified or deleted user is not linked to the `local` auth pro
 
 Users can update the following fields if they had not been set. But after getting initial values, the fields cannot be changed:
 
-- UserName
+- `userName`
+
+The following fields are immutable:
+
+- `principalIDs` (managed internally by Rancher).
 
 A user can't deactivate or delete himself.
 

--- a/pkg/resources/management.cattle.io/v3/setting/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/setting/validator_test.go
@@ -1564,19 +1564,16 @@ func (s *SettingSuite) TestValidateAuthUserSessionTTLIdleMinutesOnCreate() {
 }
 
 func (s *SettingSuite) validateAuthUserSessionTTLIdleMinutes(op v1.Operation, t *testing.T) {
-	ctrl := gomock.NewController(t)
-	settingCache := fake.NewMockNonNamespacedCacheInterface[*v3.Setting](ctrl)
-
 	tests := []struct {
 		name      string
 		value     string
-		mockSetup func()
+		mockSetup func(settingCache *fake.MockNonNamespacedCacheInterface[*v3.Setting])
 		allowed   bool
 	}{
 		{
 			name:  "valid value",
 			value: "10",
-			mockSetup: func() {
+			mockSetup: func(settingCache *fake.MockNonNamespacedCacheInterface[*v3.Setting]) {
 				settingCache.EXPECT().Get(gomock.Any()).DoAndReturn(func(_ string) (*v3.Setting, error) {
 					return &v3.Setting{
 						Value:   "",
@@ -1589,7 +1586,7 @@ func (s *SettingSuite) validateAuthUserSessionTTLIdleMinutes(op v1.Operation, t 
 		{
 			name:  "value is too high",
 			value: "10000",
-			mockSetup: func() {
+			mockSetup: func(settingCache *fake.MockNonNamespacedCacheInterface[*v3.Setting]) {
 				settingCache.EXPECT().Get(gomock.Any()).DoAndReturn(func(_ string) (*v3.Setting, error) {
 					return &v3.Setting{
 						Value:   "",
@@ -1602,31 +1599,31 @@ func (s *SettingSuite) validateAuthUserSessionTTLIdleMinutes(op v1.Operation, t 
 		{
 			name:      "value is too low",
 			value:     "-10",
-			mockSetup: func() {},
+			mockSetup: func(*fake.MockNonNamespacedCacheInterface[*v3.Setting]) {},
 			allowed:   false,
 		},
 		{
 			name:      "value cannot be 0",
 			value:     "0",
-			mockSetup: func() {},
+			mockSetup: func(*fake.MockNonNamespacedCacheInterface[*v3.Setting]) {},
 			allowed:   false,
 		},
 		{
 			name:      "value cannot be 0.5",
 			value:     "0.5",
-			mockSetup: func() {},
+			mockSetup: func(*fake.MockNonNamespacedCacheInterface[*v3.Setting]) {},
 			allowed:   false,
 		},
 		{
 			name:      "value cannot be a char",
 			value:     "A",
-			mockSetup: func() {},
+			mockSetup: func(*fake.MockNonNamespacedCacheInterface[*v3.Setting]) {},
 			allowed:   false,
 		},
 		{
 			name:  "invalid value due to auth-session-user-ttl-minutes",
 			value: "12",
-			mockSetup: func() {
+			mockSetup: func(settingCache *fake.MockNonNamespacedCacheInterface[*v3.Setting]) {
 				settingCache.EXPECT().Get(gomock.Any()).DoAndReturn(func(_ string) (*v3.Setting, error) {
 					return &v3.Setting{
 						Value:   "10",
@@ -1639,7 +1636,7 @@ func (s *SettingSuite) validateAuthUserSessionTTLIdleMinutes(op v1.Operation, t 
 		{
 			name:  "valid because auth-user-session-ttl-minutes equal 0 means token lives forever",
 			value: "1",
-			mockSetup: func() {
+			mockSetup: func(settingCache *fake.MockNonNamespacedCacheInterface[*v3.Setting]) {
 				settingCache.EXPECT().Get(gomock.Any()).DoAndReturn(func(_ string) (*v3.Setting, error) {
 					return &v3.Setting{
 						Value:   "0",
@@ -1654,7 +1651,9 @@ func (s *SettingSuite) validateAuthUserSessionTTLIdleMinutes(op v1.Operation, t 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			tt.mockSetup()
+			ctrl := gomock.NewController(t)
+			settingCache := fake.NewMockNonNamespacedCacheInterface[*v3.Setting](ctrl)
+			tt.mockSetup(settingCache)
 
 			validator := setting.NewValidator(nil, settingCache)
 			s.testAdmit(t, validator, &v3.Setting{

--- a/pkg/resources/management.cattle.io/v3/users/User.md
+++ b/pkg/resources/management.cattle.io/v3/users/User.md
@@ -18,6 +18,10 @@ Verifies that the modified or deleted user is not linked to the `local` auth pro
 
 Users can update the following fields if they had not been set. But after getting initial values, the fields cannot be changed:
 
-- UserName
+- `userName`
+
+The following fields are immutable:
+
+- `principalIDs` (managed internally by Rancher).
 
 A user can't deactivate or delete himself.

--- a/pkg/resources/management.cattle.io/v3/users/validator.go
+++ b/pkg/resources/management.cattle.io/v3/users/validator.go
@@ -3,6 +3,7 @@ package users
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
@@ -314,6 +315,9 @@ func validateUpdateFields(oldUser, newUser *v3.User, fieldPath *field.Path) erro
 	const reason = "field is immutable"
 	if oldUser.Username != "" && oldUser.Username != newUser.Username {
 		return field.Invalid(fieldPath.Child("username"), newUser.Username, reason)
+	}
+	if !slices.Equal(oldUser.PrincipalIDs, newUser.PrincipalIDs) {
+		return field.Invalid(fieldPath.Child("principalIds"), newUser.PrincipalIDs, reason)
 	}
 	return nil
 }

--- a/pkg/resources/management.cattle.io/v3/users/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/users/validator_test.go
@@ -743,9 +743,75 @@ func Test_Admit(t *testing.T) {
 			allowed:            true,
 			skipLocalUserCheck: true,
 		},
-		// verify that `checkLocalUser` is in the code paths for create,
-		// update and delete requests.  the full set of checks done by
-		// `checkLocalUser` is tested separately, see `Test_CheckLocalUser`.
+		{
+			name: "changing principalIds not allowed for non-system user",
+			oldUser: &v3.User{
+				ObjectMeta:   metav1.ObjectMeta{Name: defaultUserName},
+				Username:     defaultUserName,
+				PrincipalIDs: []string{"local://u-abc"},
+			},
+			newUser: &v3.User{
+				ObjectMeta:   metav1.ObjectMeta{Name: defaultUserName},
+				Username:     defaultUserName,
+				PrincipalIDs: []string{"local://u-abc", "openldap_user://CN=Admin,DC=corp"},
+			},
+			requestUserName: requesterUserName,
+			allowed:         false,
+		},
+		{
+			name: "changing principalIds not allowed even for manage-users holder",
+			oldUser: &v3.User{
+				ObjectMeta:   metav1.ObjectMeta{Name: defaultUserName},
+				Username:     defaultUserName,
+				PrincipalIDs: []string{"local://u-abc"},
+			},
+			newUser: &v3.User{
+				ObjectMeta:   metav1.ObjectMeta{Name: defaultUserName},
+				Username:     defaultUserName,
+				PrincipalIDs: []string{"local://u-abc", "oidc_user://alice@example.com"},
+			},
+			requestUserName:    managerUserName,
+			allowed:            false,
+			skipLocalUserCheck: true,
+		},
+		{
+			name: "removing principalIds not allowed",
+			oldUser: &v3.User{
+				ObjectMeta:   metav1.ObjectMeta{Name: defaultUserName},
+				Username:     defaultUserName,
+				PrincipalIDs: []string{"local://u-abc", "github_user://12345"},
+			},
+			newUser: &v3.User{
+				ObjectMeta:   metav1.ObjectMeta{Name: defaultUserName},
+				Username:     defaultUserName,
+				PrincipalIDs: []string{"local://u-abc"},
+			},
+			requestUserName: requesterUserName,
+			allowed:         false,
+		},
+		{
+			name: "unchanged principalIds allowed for any user",
+			oldUser: &v3.User{
+				ObjectMeta:   metav1.ObjectMeta{Name: defaultUserName},
+				Username:     defaultUserName,
+				PrincipalIDs: []string{"local://u-abc"},
+			},
+			newUser: &v3.User{
+				ObjectMeta:   metav1.ObjectMeta{Name: defaultUserName},
+				Username:     defaultUserName,
+				PrincipalIDs: []string{"local://u-abc"},
+			},
+			requestUserName: requesterUserName,
+			resolverRulesFor: func(s string) ([]rbacv1.PolicyRule, error) {
+				switch s {
+				case requesterUserName, defaultUserName:
+					return getPods, nil
+				default:
+					return nil, fmt.Errorf("unexpected error")
+				}
+			},
+			allowed: true,
+		},
 		{
 			name: "create rejects new local user (no principal ids) for hidden local auth provider",
 			newUser: &v3.User{


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from other PRs, link them here and describe why they are needed for your solution section. -->
## Problem
<!-- Describe the root cause of the issue you are resolving. 
This may include what behavior is observed and why it is not desirable. If this is a new feature, describe why we need it and how it will be used. -->

## Solution
<!-- Describe what you changed to fix the issue. 
Relate your changes to the original bug/feature and explain why this addresses the issue. -->

Updates to User PrincipalIDs are now rejected, matching the existing immutability check for Username. The check applies regardless of the manage-users verb.

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [ ] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [ ] Docs