### PR TITLE
[main] Speed up CI and fix flaky setting validator test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
         archBox:
         - { arch: amd64, vmArch: x64 }
         - { arch: arm64, vmArch: arm64 }
-    runs-on: runs-on,runner=1cpu-linux-${{ matrix.archBox.vmArch }},run-id=${{ github.run_id }}
+    runs-on: runs-on,runner=2cpu-linux-${{ matrix.archBox.vmArch }},run-id=${{ github.run_id }}
     steps:
       - name : Checkout repository
         # https://github.com/actions/checkout/releases/tag/v4.1.1
@@ -89,3 +89,13 @@ jobs:
           echo "Dumping webhook configurations:"
           kubectl get mutatingwebhookconfiguration rancher.cattle.io -o yaml || true
           kubectl get validatingwebhookconfiguration rancher.cattle.io -o yaml || true
+          echo "Dumping pods:"
+          kubectl get pods -A -o wide || true
+          echo "Dumping rancher logs:"
+          kubectl logs -n cattle-system -l app=rancher --all-containers=true --tail=-1 --timestamps=true || true
+          echo "Dumping catalog apps:"
+          kubectl get apps.catalog.cattle.io -A || true
+          echo "Dumping cluster repos:"
+          kubectl get clusterrepo -o yaml || true
+          echo "Dumping recent events:"
+          kubectl get events -A --sort-by=.lastTimestamp | tail -50 || true

--- a/.github/workflows/scripts/integration-test-ci
+++ b/.github/workflows/scripts/integration-test-ci
@@ -24,7 +24,9 @@ echo "Rancher deployed"
 webhook_deployment_created() {
     kubectl get deployments -n cattle-system | grep rancher-webhook
 }
+SECONDS=0
 try --max 48 --delay 5 --waitmsg "Waiting for a rancher-webhook deployment to be created" --failmsg "Deployment creation failed" webhook_deployment_created
+echo "rancher-webhook deployment created after ${SECONDS}s"
 
 try --waitmsg "Waiting for rancher/webhook to be deployed" --failmsg "No rancher/webhook here" kubectl rollout status --watch=true --timeout=10s -n cattle-system deploy/rancher-webhook
 echo "Rancher deployed"

--- a/pkg/resources/management.cattle.io/v3/setting/validator_test.go
+++ b/pkg/resources/management.cattle.io/v3/setting/validator_test.go
@@ -1564,19 +1564,16 @@ func (s *SettingSuite) TestValidateAuthUserSessionTTLIdleMinutesOnCreate() {
 }
 
 func (s *SettingSuite) validateAuthUserSessionTTLIdleMinutes(op v1.Operation, t *testing.T) {
-	ctrl := gomock.NewController(t)
-	settingCache := fake.NewMockNonNamespacedCacheInterface[*v3.Setting](ctrl)
-
 	tests := []struct {
 		name      string
 		value     string
-		mockSetup func()
+		mockSetup func(settingCache *fake.MockNonNamespacedCacheInterface[*v3.Setting])
 		allowed   bool
 	}{
 		{
 			name:  "valid value",
 			value: "10",
-			mockSetup: func() {
+			mockSetup: func(settingCache *fake.MockNonNamespacedCacheInterface[*v3.Setting]) {
 				settingCache.EXPECT().Get(gomock.Any()).DoAndReturn(func(_ string) (*v3.Setting, error) {
 					return &v3.Setting{
 						Value:   "",
@@ -1589,7 +1586,7 @@ func (s *SettingSuite) validateAuthUserSessionTTLIdleMinutes(op v1.Operation, t 
 		{
 			name:  "value is too high",
 			value: "10000",
-			mockSetup: func() {
+			mockSetup: func(settingCache *fake.MockNonNamespacedCacheInterface[*v3.Setting]) {
 				settingCache.EXPECT().Get(gomock.Any()).DoAndReturn(func(_ string) (*v3.Setting, error) {
 					return &v3.Setting{
 						Value:   "",
@@ -1602,31 +1599,31 @@ func (s *SettingSuite) validateAuthUserSessionTTLIdleMinutes(op v1.Operation, t 
 		{
 			name:      "value is too low",
 			value:     "-10",
-			mockSetup: func() {},
+			mockSetup: func(_ *fake.MockNonNamespacedCacheInterface[*v3.Setting]) {},
 			allowed:   false,
 		},
 		{
 			name:      "value cannot be 0",
 			value:     "0",
-			mockSetup: func() {},
+			mockSetup: func(_ *fake.MockNonNamespacedCacheInterface[*v3.Setting]) {},
 			allowed:   false,
 		},
 		{
 			name:      "value cannot be 0.5",
 			value:     "0.5",
-			mockSetup: func() {},
+			mockSetup: func(_ *fake.MockNonNamespacedCacheInterface[*v3.Setting]) {},
 			allowed:   false,
 		},
 		{
 			name:      "value cannot be a char",
 			value:     "A",
-			mockSetup: func() {},
+			mockSetup: func(_ *fake.MockNonNamespacedCacheInterface[*v3.Setting]) {},
 			allowed:   false,
 		},
 		{
 			name:  "invalid value due to auth-session-user-ttl-minutes",
 			value: "12",
-			mockSetup: func() {
+			mockSetup: func(settingCache *fake.MockNonNamespacedCacheInterface[*v3.Setting]) {
 				settingCache.EXPECT().Get(gomock.Any()).DoAndReturn(func(_ string) (*v3.Setting, error) {
 					return &v3.Setting{
 						Value:   "10",
@@ -1639,7 +1636,7 @@ func (s *SettingSuite) validateAuthUserSessionTTLIdleMinutes(op v1.Operation, t 
 		{
 			name:  "valid because auth-user-session-ttl-minutes equal 0 means token lives forever",
 			value: "1",
-			mockSetup: func() {
+			mockSetup: func(settingCache *fake.MockNonNamespacedCacheInterface[*v3.Setting]) {
 				settingCache.EXPECT().Get(gomock.Any()).DoAndReturn(func(_ string) (*v3.Setting, error) {
 					return &v3.Setting{
 						Value:   "0",
@@ -1654,7 +1651,10 @@ func (s *SettingSuite) validateAuthUserSessionTTLIdleMinutes(op v1.Operation, t 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			tt.mockSetup()
+
+			ctrl := gomock.NewController(t)
+			settingCache := fake.NewMockNonNamespacedCacheInterface[*v3.Setting](ctrl)
+			tt.mockSetup(settingCache)
 
 			validator := setting.NewValidator(nil, settingCache)
 			s.testAdmit(t, validator, &v3.Setting{


### PR DESCRIPTION
## Problem

CI on `main` has failed every run since Aug 15, on both arches, always at the same place:

```
Waiting for a rancher-webhook deployment to be created on try 47/48
Deployment creation failed
```

That wait is `try --max 48 --delay 5` in `.github/workflows/scripts/integration-test-ci` — a hard 240s ceiling on how long Rancher gets to create the `rancher-webhook` deployment.

The last successful `main` run (Aug 14) needed **47 of 48 tries**. There was no margin left; `main` has simply crossed the line. Release branches still pass because they run against `v2.15-head`/`v2.14-head` rather than `main`/`head`.

The underlying cause is the runner size. `runner=1cpu-linux-*` resolves to an `m7a.medium` — 1 vCPU / 4GB — running k3s, cert-manager, Rancher and the webhook. Step timings from a failing run:

| step | duration |
|---|---|
| Build, Test, and Package | 6m23s |
| setup cluster | 38s |
| start rancher | 5m16s |
| Run integration tests | 4m41s (died in the 240s wait) |

## Changes

### CI

- **2cpu runners.** The main lever; everything downstream of cluster setup is CPU-starved today.
- **Log how long the webhook deployment wait actually took.** `--max 48` is left alone deliberately — the ceiling only costs anything on a failing run, and keeping it tight means a future slowdown fails loudly instead of silently eating headroom. The new log line makes the trend visible on green runs too.
- **Dump Rancher logs, catalog apps, ClusterRepos, pods and events on failure.** Today only webhook logs are dumped, so when the webhook deployment is never created there is nothing to look at.

### Flaky test fix

Moving off 1cpu runners exposed a pre-existing data race in `validateAuthUserSessionTTLIdleMinutes`, which failed one of the stability runs:

```
--- FAIL: TestUserRetentionSettingsValidation/TestValidateAuthUserSessionTTLIdleMinutesOnUpdate/valid_because_auth-user-session-ttl-minutes_equal_0_means_token_lives_forever
    validator_test.go:1078: Not equal: expected: false / actual: true
```

The test built a single `gomock` controller and setting cache for the whole table, then ran every case under `t.Parallel()`. Each case registers a `Get(gomock.Any()).Times(1)` expectation returning a *different* setting, so parallel subtests consume each other's expectations and the validator sees the wrong value. It was effectively serialized on a 1cpu runner, which is why it only surfaced now.

Fixed by building the controller and cache per subtest, matching what the rest of this file already does.

## Testing

12 CI runs across 1cpu, 4cpu and 2cpu. One failure, and it was the flaky unit test above, not the timeout — every job since that fix is green.

On the 2cpu config being merged here:

| | before (1cpu) | after (2cpu) |
|---|---|---|
| webhook deployment created | >240s (timeout) | 93-185s |
| job total | ~17m, fail | ~11-14m, pass |

The webhook deployment wait on 2cpu, 6 samples: 93s, 93s, 103s, 104s, 109s, 185s. The 185s worst case uses 30 of the 48 tries, against effectively all 48 before. Worth knowing that the outlier is contention noise rather than arch-bound — on 2cpu the slow sample was amd64, on 4cpu it was arm64. If this does start flaking again, raising `--max` is the fix rather than another root-cause hunt.

For the test fix, the pre-fix code fails **6 of 15** local runs of `TestUserRetentionSettingsValidation`. Post-fix it is clean over 30 runs and under `-race`.
