### PR TITLE
[main] provisioning cluster: remove carriage returns from agentEnvVars values

### DIFF
--- a/pkg/resources/provisioning.cattle.io/v1/cluster/Cluster.md
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/Cluster.md
@@ -154,6 +154,10 @@ kube-apiserver argument that mount it; when the field is cleared, the secret is 
 dropped. On server-side dry-run requests the secret is neither written nor deleted, and the derived fields are not
 set or dropped — the corresponding validation of that state is skipped on dry-run as well (see Validation Checks).
 
+#### Agent Environment Variable Normalization
+
+Trailing carriage return (`\r`) and newline (`\n`) characters are stripped from the `Value` of each entry in `spec.agentEnvVars`.
+
 ### On Update
 
 #### Dynamic Schema Drop
@@ -165,3 +169,8 @@ for each `machinePool`, to its' previous value. If the values are not identical,
 
 The revert also applies to server-side dry-run updates, so a dry-run preview matches what a real update would
 persist.
+
+
+#### Agent Environment Variable Normalization
+
+Trailing carriage return (`\r`) and newline (`\n`) characters are stripped from the `Value` of each entry in `spec.agentEnvVars`.

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/mutator.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/mutator.go
@@ -152,6 +152,11 @@ func (m *ProvisioningClusterMutator) Admit(request *admission.Request) (*admissi
 		}
 	}
 
+	if request.Operation == admissionv1.Create ||
+		request.Operation == admissionv1.Update {
+		normalizeAgentEnvVars(cluster)
+	}
+
 	response.Allowed = true
 	if err = patch.CreatePatch(clusterJSON, cluster, response); err != nil {
 		return nil, fmt.Errorf("failed to create patch: %w", err)
@@ -441,5 +446,13 @@ func cleanupHash(file *rkev1.RKEProvisioningFiles) {
 		for j := range source.ConfigMap.Items {
 			file.FileSources[i].ConfigMap.Items[j].Hash = ""
 		}
+	}
+}
+
+// normalizeAgentEnvVars normalizes agent environment variable values by removing
+// trailing carriage return and newline characters from the provisioning cluster.
+func normalizeAgentEnvVars(cluster *v1.Cluster) {
+	for idx := range cluster.Spec.AgentEnvVars {
+		cluster.Spec.AgentEnvVars[idx].Value = strings.TrimRight(cluster.Spec.AgentEnvVars[idx].Value, "\r\n")
 	}
 }

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/mutator_test.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/mutator_test.go
@@ -757,6 +757,44 @@ func TestAdmitDryRun(t *testing.T) {
 	assert.True(t, response.Allowed)
 	assert.Contains(t, string(response.Patch), "the-spec",
 		"the dry-run patch must carry the dynamic-schema revert")
+
+	// A dry-run Create must normalize trailing carriage returns and newlines
+	// in agent environment variable values.
+	clusterWithEnvVars := &v1.Cluster{
+		Spec: v1.ClusterSpec{
+			AgentEnvVars: []rkev1.EnvVar{
+				{
+					Name:  "HTTPS_PROXY",
+					Value: "https://${domain}.com:8080\r\n",
+				},
+				{
+					Name:  "NO_PROXY",
+					Value: "10.0.0.0/8,172.16.0.0/16\n",
+				},
+			},
+		},
+	}
+
+	envVarsRaw, err := json.Marshal(clusterWithEnvVars)
+	assert.Nil(t, err)
+
+	normalizeReq := &admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Operation: admissionv1.Create,
+			DryRun:    admission.Ptr(true),
+			UserInfo:  authenticationv1.UserInfo{Username: "u-test"},
+			Object:    runtime.RawExtension{Raw: envVarsRaw},
+		},
+	}
+
+	response, err = m.Admit(normalizeReq)
+	assert.Nil(t, err)
+	assert.True(t, response.Allowed)
+
+	assert.Contains(t, string(response.Patch), "https://${domain}.com:8080")
+	assert.Contains(t, string(response.Patch), "10.0.0.0/8,172.16.0.0/16")
+	assert.NotContains(t, string(response.Patch), "\\r")
+	assert.NotContains(t, string(response.Patch), "\\n")
 }
 
 func TestDynamicSchemaDrop(t *testing.T) {
@@ -1028,4 +1066,37 @@ func TestDynamicSchemaDrop(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_normalizeAgentEnvVars(t *testing.T) {
+	cluster := &v1.Cluster{
+		Spec: v1.ClusterSpec{
+			AgentEnvVars: []rkev1.EnvVar{
+				{Name: "CRLF", Value: "https://${domain}.com:8080\r\n"},
+				{Name: "CR_ONLY", Value: "https://${domain}.com:8080\r"},
+				{Name: "LF_ONLY", Value: "https://${domain}.com:8080\n"},
+				{Name: "MULTIPLE_TRAILING", Value: "https://${domain}.com:8080\r\n\r\n\n\r"},
+				{Name: "MIDDLE_BREAKS_PRESERVED", Value: "foo\nbar\r\nbaz\n"},
+				{Name: "NO_TRAILING_BREAK", Value: "https://${domain}.com:8080"},
+				{Name: "EMPTY", Value: ""},
+			},
+		},
+	}
+
+	expected := &v1.Cluster{
+		Spec: v1.ClusterSpec{
+			AgentEnvVars: []rkev1.EnvVar{
+				{Name: "CRLF", Value: "https://${domain}.com:8080"},
+				{Name: "CR_ONLY", Value: "https://${domain}.com:8080"},
+				{Name: "LF_ONLY", Value: "https://${domain}.com:8080"},
+				{Name: "MULTIPLE_TRAILING", Value: "https://${domain}.com:8080"},
+				{Name: "MIDDLE_BREAKS_PRESERVED", Value: "foo\nbar\r\nbaz"},
+				{Name: "NO_TRAILING_BREAK", Value: "https://${domain}.com:8080"},
+				{Name: "EMPTY", Value: ""},
+			},
+		},
+	}
+
+	normalizeAgentEnvVars(cluster)
+	assert.Equal(t, expected, cluster)
 }

--- a/pkg/resources/provisioning.cattle.io/v1/cluster/mutator_test.go
+++ b/pkg/resources/provisioning.cattle.io/v1/cluster/mutator_test.go
@@ -795,6 +795,57 @@ func TestAdmitDryRun(t *testing.T) {
 	assert.Contains(t, string(response.Patch), "10.0.0.0/8,172.16.0.0/16")
 	assert.NotContains(t, string(response.Patch), "\\r")
 	assert.NotContains(t, string(response.Patch), "\\n")
+
+	// A dry-run Update must normalize trailing carriage returns and newlines
+	// in agent environment variable values.
+	oldClusterWithEnvVars := &v1.Cluster{
+		Spec: v1.ClusterSpec{
+			AgentEnvVars: []rkev1.EnvVar{
+				{
+					Name:  "HTTPS_PROXY",
+					Value: "https://old-proxy.example.com:8080",
+				},
+			},
+		},
+	}
+	oldEnvVarsRaw, err := json.Marshal(oldClusterWithEnvVars)
+	assert.Nil(t, err)
+
+	newClusterWithEnvVars := &v1.Cluster{
+		Spec: v1.ClusterSpec{
+			AgentEnvVars: []rkev1.EnvVar{
+				{
+					Name:  "HTTPS_PROXY",
+					Value: "https://${domain}.com:8080\r\n",
+				},
+				{
+					Name:  "NO_PROXY",
+					Value: "10.0.0.0/8,172.16.0.0/16\n",
+				},
+			},
+		},
+	}
+	newEnvVarsRaw, err := json.Marshal(newClusterWithEnvVars)
+	assert.Nil(t, err)
+
+	normalizeUpdateReq := &admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Operation: admissionv1.Update,
+			DryRun:    admission.Ptr(true),
+			UserInfo:  authenticationv1.UserInfo{Username: "u-test"},
+			Object:    runtime.RawExtension{Raw: newEnvVarsRaw},
+			OldObject: runtime.RawExtension{Raw: oldEnvVarsRaw},
+		},
+	}
+
+	response, err = m.Admit(normalizeUpdateReq)
+	assert.Nil(t, err)
+	assert.True(t, response.Allowed)
+
+	assert.Contains(t, string(response.Patch), "https://${domain}.com:8080")
+	assert.Contains(t, string(response.Patch), "10.0.0.0/8,172.16.0.0/16")
+	assert.NotContains(t, string(response.Patch), "\\r")
+	assert.NotContains(t, string(response.Patch), "\\n")
 }
 
 func TestDynamicSchemaDrop(t *testing.T) {


### PR DESCRIPTION


## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from other PRs, link them here and describe why they are needed for your solution section. -->
https://github.com/rancher/rancher/issues/50213

## Problem
<!-- Describe the root cause of the issue you are resolving. 
This may include what behavior is observed and why it is not desirable. If this is a new feature, describe why we need it and how it will be used. -->
When configuring a provisioning cluster's agent environment variables from a file on UI, values containing DOS/Windows line endings (\r\n) retain the trailing carriage return.
These carriage returns are propagated to the generated node registration command, resulting in malformed environment variable values
## Solution
<!-- Describe what you changed to fix the issue. 
Relate your changes to the original bug/feature and explain why this addresses the issue. -->
Update the provisioning cluster mutating webhook to normalize agentEnvVars values during Create and Update operations.

The normalization removes trailing carriage return (\r) and newline (\n) characters while preserving any newline characters within the value.
## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [x] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [ ] Docs