### PR TITLE
Update rancher/hardened-build-base Docker tag to v1.26.7b2

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,7 +1,7 @@
 # ===============
 # Build Stage
 # ===============
-FROM --platform=$BUILDPLATFORM rancher/hardened-build-base:v1.26.5b2@sha256:e9ea50cbc319e0034a73aa550e64e18e8cb4a6738afe9c3ad9fa090871878c5e AS build
+FROM --platform=$BUILDPLATFORM rancher/hardened-build-base:v1.26.7b2@sha256:236e03ea562308e143d2ef9d4060f7b7da785f895aabdb4ba48bdcf871c2c243 AS build
 
 # Set up build cache
 ENV GOMODCACHE=/root/.cache/go/modcache


### PR DESCRIPTION
Bumps the build-stage base image from `v1.26.5b2` (Go 1.26.5) to `v1.26.7b2` (Go 1.26.7) to pick up the latest Go patch release.

Verified by pulling `rancher/hardened-build-base:v1.26.7b2` and running `go version` inside the image: `go version go1.26.7 linux/amd64`.

`go.mod` remains at `go 1.26.5` (min-version directive, no change needed).