### PR TITLE
[main] Fix invalid semver for untagged dev builds

### DIFF
--- a/scripts/version
+++ b/scripts/version
@@ -11,7 +11,7 @@ GIT_TAG=${GIT_TAG:-$(git tag -l --contains HEAD | head -n 1)}
 if [[ -z "$DIRTY" && -n "$GIT_TAG" ]]; then
     VERSION=$GIT_TAG
 else
-    VERSION="0.0.0-${COMMIT}${DIRTY}"
+    VERSION="0.0.0-g${COMMIT}${DIRTY}"
 fi
 
 # ARCH is now expected to be in the environment, set by the Makefile


### PR DESCRIPTION
## Summary
- `scripts/version` builds the dev/untagged version string as `0.0.0-<short-commit>`. When the short commit hash is all-digits with a leading zero (e.g. `0894256`), that prerelease identifier is invalid per semver (numeric identifiers can't have leading zeros), which fails Helm chart validation in `make package-helm`.
- Prefix the commit hash with `g` (matches `git describe` convention) so the identifier is always alphanumeric, sidestepping the numeric leading-zero rule.

Seen failing in CI for #1824: `Error: validation: chart.metadata.version "0.0.0-0894256" is invalid`.

## Test plan
- [x] CI passes package-helm / build steps