### PR TITLE
[v0.11] Avoid leading-zero numeric prerelease in dev version string

### DIFF
--- a/scripts/version
+++ b/scripts/version
@@ -11,7 +11,7 @@ GIT_TAG=${GIT_TAG:-$(git tag -l --contains HEAD | head -n 1)}
 if [[ -z "$DIRTY" && -n "$GIT_TAG" ]]; then
     VERSION=$GIT_TAG
 else
-    VERSION="0.0.0-${COMMIT}${DIRTY}"
+    VERSION="0.0.0-g${COMMIT}${DIRTY}"
 fi
 
 # ARCH is now expected to be in the environment, set by the Makefile


### PR DESCRIPTION
(cherry picked from commit 571e03d38dfc22c32ba18ef1beed18163e5ccb18)

