### PR TITLE
[v0.10] Avoid leading-zero numeric prerelease in dev version string

### DIFF
--- a/scripts/version
+++ b/scripts/version
@@ -11,7 +11,7 @@ GIT_TAG=${GIT_TAG:-$(git tag -l --contains HEAD | head -n 1)}
 if [[ -z "$DIRTY" && -n "$GIT_TAG" ]]; then
     VERSION=$GIT_TAG
 else
-    VERSION="0.0.0-${COMMIT}${DIRTY}"
+    VERSION="0.0.0-g${COMMIT}${DIRTY}"
 fi
 
 # ARCH is now expected to be in the environment, set by the Makefile


### PR DESCRIPTION
(cherry picked from commit 571e03d38dfc22c32ba18ef1beed18163e5ccb18)

## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from other PRs, link them here and describe why they are needed for your solution section. -->
## Problem
<!-- Describe the root cause of the issue you are resolving. 
This may include what behavior is observed and why it is not desirable. If this is a new feature, describe why we need it and how it will be used. -->

## Solution
<!-- Describe what you changed to fix the issue. 
Relate your changes to the original bug/feature and explain why this addresses the issue. -->

## CheckList
  <!-- 
  Test: 
   PRs should be accompanied by tests, even if there isn't a single test yet.  
   Unit tests are preferred over the addition of integration tests.
   If this PR does not require additional tests, state the reason below for reviewers.
  -->
- [ ] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [ ] Docs