### PR TITLE
[release/v0.10] Bump hardened-build-base to v1.26.7b2 to fix Go stdlib CVEs

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,7 +1,7 @@
 # ===============
 # Build Stage
 # ===============
-FROM --platform=$BUILDPLATFORM rancher/hardened-build-base:v1.26.5b1@sha256:4eeb324b5359ed1447a9ed2e0730cadf098d49e97cac5ab1e278685b67c5a602 AS build
+FROM --platform=$BUILDPLATFORM rancher/hardened-build-base:v1.26.7b2@sha256:236e03ea562308e143d2ef9d4060f7b7da785f895aabdb4ba48bdcf871c2c243 AS build
 
 # Set up build cache
 ENV GOMODCACHE=/root/.cache/go/modcache


### PR DESCRIPTION
## What

Bumps the build base image in `package/Dockerfile` from `rancher/hardened-build-base:v1.26.5b1` (Go 1.26.5) to `v1.26.7b2` (Go 1.26.7).

## Why

The CVE scan for `rancher/rancher-webhook:v0.10.11-rc.1` (rancherlabs/image-scanning#12040) reports the following Go **stdlib** vulnerabilities in `usr/bin/webhook`, all fixed in Go 1.26.6+:

| Vulnerability ID | Installed | Fixed | Severity |
| - | - | - | - |
| CVE-2026-33818 | 1.26.5 | 1.25.13, 1.26.6, 1.27.0-rc.3 | HIGH |
| CVE-2026-39821 | 1.26.5 | 1.25.13, 1.26.6, 1.27.0-rc.3 | HIGH |
| CVE-2026-56853 | 1.26.5 | 1.25.13, 1.26.6, 1.27.0-rc.3 | HIGH |
| CVE-2026-56860 | 1.26.5 | 1.25.13, 1.26.6, 1.27.0-rc.3 | MEDIUM |
| CVE-2026-56862 | 1.26.5 | 1.25.13, 1.26.6, 1.27.0-rc.3 | HIGH |

Rebuilding the binary with a patched Go toolchain remediates these. `v1.26.7b2` is already the build base used on `release/v0.11`, so this keeps the branches consistent.

## Testing

CI build/test in the pipeline.

Fixes rancherlabs/image-scanning#12040