### PR TITLE
[release/v0.8] Bump hardened-build-base to v1.26.7b2 to fix Go stdlib CVEs

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,7 +1,7 @@
 # ===============
 # Build Stage
 # ===============
-FROM --platform=$BUILDPLATFORM rancher/hardened-build-base:v1.26.5b1@sha256:4eeb324b5359ed1447a9ed2e0730cadf098d49e97cac5ab1e278685b67c5a602 AS build
+FROM --platform=$BUILDPLATFORM rancher/hardened-build-base:v1.26.7b2@sha256:236e03ea562308e143d2ef9d4060f7b7da785f895aabdb4ba48bdcf871c2c243 AS build
 
 # Set up build cache
 ENV GOMODCACHE=/root/.cache/go/modcache


### PR DESCRIPTION
## What
Bumps `package/Dockerfile` build base from `rancher/hardened-build-base:v1.26.5` (Go 1.26.5) to `v1.26.7b2` (Go 1.26.7).

## Why
The CVE scan for `rancher/rancher-webhook:v0.8.9` (rancherlabs/image-scanning#11756) reports these Go **stdlib** vulnerabilities in `usr/bin/webhook`, all fixed in Go 1.26.6+:

| CVE | Severity | Fixed in |
| - | - | - |
| CVE-2026-33818 | HIGH | 1.26.6 |
| CVE-2026-39821 | HIGH | 1.26.6 |
| CVE-2026-56853 | HIGH | 1.26.6 |
| CVE-2026-56862 | HIGH | 1.26.6 |
| CVE-2026-56860 | MEDIUM | 1.26.6 |

Rebuilding with a patched Go toolchain remediates these. `v1.26.7b2` is the same build base already used on `release/v0.11`.

Fixes rancherlabs/image-scanning#11756