### PR TITLE
[release/v0.7] Fix CVEs in rancher-webhook v0.7.10 (build-base + grpc)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -152,7 +152,7 @@ require (
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
-	google.golang.org/grpc v1.83.1 // indirect
+	google.golang.org/grpc v1.83.2 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -395,8 +395,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.83.1 h1:HIO0+BEtBP6soyqvqC8sNUjZ7bTs+0hFQuFF+RAy++Y=
-google.golang.org/grpc v1.83.1/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
+google.golang.org/grpc v1.83.2 h1:EManeRomTObA0BU7I8vXgg/78uE5MJ9M8B39EX2WscU=
+google.golang.org/grpc v1.83.2/go.mod h1:YPI1hK3kDked6iHvgX3tR0y+nX/qpMFKhPgFsokw1S8=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,7 +1,7 @@
 # ===============
 # Build Stage
 # ===============
-FROM --platform=$BUILDPLATFORM rancher/hardened-build-base:v1.26.5b1@sha256:4eeb324b5359ed1447a9ed2e0730cadf098d49e97cac5ab1e278685b67c5a602 AS build
+FROM --platform=$BUILDPLATFORM rancher/hardened-build-base:v1.26.7b2@sha256:236e03ea562308e143d2ef9d4060f7b7da785f895aabdb4ba48bdcf871c2c243 AS build
 
 # Set up build cache
 ENV GOMODCACHE=/root/.cache/go/modcache


### PR DESCRIPTION
## What
- Bump `package/Dockerfile` build base `rancher/hardened-build-base` from `v1.26.5b1` (Go 1.26.5) to `v1.26.7b2` (Go 1.26.7).
- Bump `google.golang.org/grpc` from `v1.83.1` to `v1.83.2`.

## Why
CVE scan for `rancher/rancher-webhook:v0.7.10` (rancherlabs/image-scanning#11104):

| CVE | Package | Severity | Fix |
| - | - | - | - |
| CVE-2026-33818 | stdlib | HIGH | Go 1.26.6+ |
| CVE-2026-39821 | stdlib | HIGH | Go 1.26.6+ |
| CVE-2026-56853 | stdlib | HIGH | Go 1.26.6+ |
| CVE-2026-56862 | stdlib | HIGH | Go 1.26.6+ |
| CVE-2026-56860 | stdlib | MEDIUM | Go 1.26.6+ |
| CVE-2026-84445 | google.golang.org/grpc | HIGH | grpc 1.83.2+ |

The stdlib CVEs are remediated by rebuilding with a patched Go toolchain (`v1.26.7b2`, same as `release/v0.11`). CVE-2026-84445 requires grpc `1.83.2` (branch was on `1.83.1`). The other reported items (`golang.org/x/text` ≥0.39.0 via v0.41.0, and grpc CVE-2026-84303/84304 fixed in 1.83.1) are already satisfied on this branch. `go mod tidy` run; `go build ./...` passes.

Fixes rancherlabs/image-scanning#11104